### PR TITLE
64 add general docker build and deploy action

### DIFF
--- a/common-docker-build-deploy.yml
+++ b/common-docker-build-deploy.yml
@@ -1,0 +1,64 @@
+name: Docker Image Build And Push
+on:
+  workflow_call:
+    inputs:
+      context:
+        description: Relative path for docker build context
+        required: false
+        type: string
+        default: .
+      file:
+        description: Relative path to Dockerfile to use for build
+        required: false
+        type: string
+        default: Dockerfile
+      platforms:
+        description: Comma-separated list of platforms to build image for
+        required: false
+        type: string
+        default: linux/amd64
+      build-args:
+        description: Additional buid-args for an image build
+        required: false
+        type: string
+        default: |
+          DOCKER_REGISTRY_HOST=ghcr.io
+      registry:
+        description: Registry to login and push to
+        required: false
+        type: string
+        default: ghcr.io
+      tags:
+        required: false
+        type: string
+        default: ''
+
+jobs:
+  build-push-docker-image:
+    name: Build and push docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login To Registry
+        if: inputs.tags
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ inputs.registry }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Docker Image
+        uses: docker/build-push-action@v3
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.file }}
+          platforms: ${{ inputs.platforms }}
+          push: ${{ inputs.tags != '' }}
+          build-args: ${{ inputs.build-args }}
+          tags: ${{ inputs.tags }}
+

--- a/docs/Octopus Developer Guide.md
+++ b/docs/Octopus Developer Guide.md
@@ -98,7 +98,7 @@ where:
 - *DOCKER_REGISTRY_HOST*: the registry to deploy image to. Currently `ghcr.io`.
 - *REPOSITORY_OWNER*: the owner of the source repository, that is: **octopusden** always.
 - *REPOSITORY_NAME*: the short repository name the image is build from.
-- *BRANCH_OR_RELEASE_TAG*: the branch image is build from for development versions and release tag for releases:
+- *BRANCH_OR_RELEASE_TAG*: the branch image is build from for development versions (short name, without `/refs/...` prefixes), or version tag for releases:
     - **Have to be free from extra garbage and spaces**. This means:
         - Use `X.Y.Z` fromat for release tags, where *X, Y* and *Z* are integers. **Do NOT** use extra prefixes like `v.`, `ver.` and so on.
         - **Do NOT** use space characters in branch names.

--- a/docs/Octopus Developer Guide.md
+++ b/docs/Octopus Developer Guide.md
@@ -75,3 +75,27 @@ Package name should start with `org.octopusden.octopus.` prefix.
 - **Module**: `oc_sql_helpers`
 - **Package**: `oc-sql-helpers`
 - **Repository**: `octopus-oc-corelibs-sql-helpers`
+
+## Additional rules for Docker images repository and tag name
+
+Docker image may be a side-build for *Python* or *Java* package (if it is an executable module), or a general image-only build.
+
+For *Java* and *Python* side-builds the repository and package names are described above.
+
+For *general image-only* builds the repository name should follow the same rules as for *Python* code except that `oc-` suffix is to be replaced with `di-` one (means `Docker Image`).
+
+It is also recommended to develop a signle image family from single repository. This means all tag part before *version separator* `:` should remain the same within images build from that repository and last part have to be different only.
+
+Image tagging should follow the template:
+
+`${DOCKER_REGISTRY_HOST}/${REPOSITORY_OWNER}/${REPOSITORY_NAME}:${BRANCH_OR_RELEASE_TAG}`
+
+where:
+- *DOCKER_REGISTRY_HOST*: the registry to deploy image to. Currently `ghcr.io`.
+- *REPOSITORY_OWNER*: the owner of the source repository, that is: **octopusden** always.
+- *REPOSITORY_NAME*: the short repository name the image is build from.
+- *BRANCH_OR_RELEASE_TAG*: the branch image is build from for development versions and release tag for releases:
+    - **Have to be free from extra garbage and spaces**. This means:
+        - Use `X.Y.Z` fromat for release tags, where *X, Y* and *Z* are integers. **Do NOT** use extra prefixes like `v.`, `ver.` and so on.
+        - **Do NOT** use space characters in branch names.
+    - The most recent release have also to be pushed with `latest` tag.

--- a/docs/Octopus Developer Guide.md
+++ b/docs/Octopus Developer Guide.md
@@ -46,8 +46,8 @@ Examples: `13-fix-npe-on-start`, `12-support-security-champ`, `fix-typo`
 
 ## Pull Request names
 
-If there is a related issue, specify its id in the PR description, e.g. '#123'. 
-Use GitHub keywords to automatically close the related issue, for example 'fixes #123' or 'closes #123'. See https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
+If there is a related issue, specify its id in the PR description, e.g. `#123`. 
+Use GitHub keywords to automatically close the related issue, for example `fixes #123` or `closes #123`. See https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
 
 ## Group Id, Artifact Id
 

--- a/docs/Octopus Developer Guide.md
+++ b/docs/Octopus Developer Guide.md
@@ -52,7 +52,7 @@ Use GitHub keywords to automatically close the related issue, for example `fixes
 ## Group Id, Artifact Id
 
 - **groupId** should start with `org.octopusden.octopus.` prefix.
-  - For example: groupId = `org.octopusden.octopus.employee`, groupId = `org.octopusden.octopus.vcsfacade`.
+  - For example: *groupId* = `org.octopusden.octopus.employee`, *groupId* = `org.octopusden.octopus.vcsfacade`.
 - **artifactId** may optionally include `octopus` prefix if it is meaningful.
   - For example: *artifactId* = `octopus-parent`, *artifactId* = `cloud-commons`.
 

--- a/docs/Octopus Developer Guide.md
+++ b/docs/Octopus Developer Guide.md
@@ -28,10 +28,10 @@
 
 - lowercase
 - hyphen as a delimiter
-- 'octopus-' prefix
+- `octopus-` prefix
 
-Template: 'octopus-abc-def'
-Examples: 'octopus-parent', 'octopus-versions-api'
+Template: `octopus-abc-def`
+Examples: `octopus-parent`, `octopus-versions-api`
 
 ## Project names
 
@@ -42,7 +42,7 @@ Project name is the same as a repository name
 - issueid-brief-description: if there is an issue for the change
 - brief-description: if there is no issue 
 
-Examples: 13-fix-npe-on-start, 12-support-security-champ, fix-typo
+Examples: `13-fix-npe-on-start`, `12-support-security-champ`, `fix-typo`
 
 ## Pull Request names
 
@@ -51,10 +51,10 @@ Use GitHub keywords to automatically close the related issue, for example 'fixes
 
 ## Group Id, Artifact Id
 
-- groupId should start with `org.octopusden.octopus.` prefix.
+- **groupId** should start with `org.octopusden.octopus.` prefix.
   - For example: groupId = `org.octopusden.octopus.employee`, groupId = `org.octopusden.octopus.vcsfacade`.
-- artifactId may optionally include `octopus` prefix if it is meaningful.
-  - For example: artifactId = `octopus-parent`, artifactId = `cloud-commons`.
+- **artifactId** may optionally include `octopus` prefix if it is meaningful.
+  - For example: *artifactId* = `octopus-parent`, *artifactId* = `cloud-commons`.
 
 ## Package names
 

--- a/docs/Octopus Developer Guide.md
+++ b/docs/Octopus Developer Guide.md
@@ -102,4 +102,4 @@ where:
     - **Have to be free from extra garbage and spaces**. This means:
         - Use `X.Y.Z` fromat for release tags, where *X, Y* and *Z* are integers. **Do NOT** use extra prefixes like `v.`, `ver.` and so on.
         - **Do NOT** use space characters in branch names.
-    - The most recent release have also to be pushed with `latest` tag suffix in this position.
+    - The most recent release have to be pushed with `latest` tag suffix in this position also.

--- a/docs/Octopus Developer Guide.md
+++ b/docs/Octopus Developer Guide.md
@@ -27,7 +27,7 @@
 ## Repository names
 
 - lowercase
-- hyphen as a delimiter
+- hyphen `-` as a delimiter
 - `octopus-` prefix
 
 Template: `octopus-abc-def`

--- a/docs/Octopus Developer Guide.md
+++ b/docs/Octopus Developer Guide.md
@@ -18,6 +18,10 @@
 - The way recommended to run high-level code: `python -m <module_name>`.
 - The way recommended to run unit-tests: `python -m unittest discover -v`.
 
+## Additional policies for general Docker image-only code
+
+- Please use `ENTRYPOINT` directive for runnable images to start a container instead of `CMD` one.
+
 # Naming Conventions
 
 ## Repository names
@@ -98,4 +102,4 @@ where:
     - **Have to be free from extra garbage and spaces**. This means:
         - Use `X.Y.Z` fromat for release tags, where *X, Y* and *Z* are integers. **Do NOT** use extra prefixes like `v.`, `ver.` and so on.
         - **Do NOT** use space characters in branch names.
-    - The most recent release have also to be pushed with `latest` tag.
+    - The most recent release have also to be pushed with `latest` tag suffix in this position.


### PR DESCRIPTION
- Added `common-docker-build-and-deploy` action - for general image builds from `Dockerfile`.
- `Developer Guide` appended with:
    - recommendations upon generalised Docker-image-only development and builds
    - image tags naming rules