### PR TITLE
Release registration in octopus-release-log

### DIFF
--- a/.github/workflows/common-check-and-register-release.yml
+++ b/.github/workflows/common-check-and-register-release.yml
@@ -34,22 +34,14 @@ jobs:
         id: check-artifact
         run: |
           VERSION_FROM_TAG="${{ steps.tag_version.outputs.tag }}"         # v2.3.4
-          echo "VERSION WITH TAG: $VERSION_FROM_TAG"
-          VERSION_WO_PREFIX=${VERSION_FROM_TAG#v}
-          echo "VERSION WITHOUT PREFIX: $VERSION_WO_PREFIX"
-          echo "RELEASE_VERSION=$VERSION_WO_PREFIX" >> "$GITHUB_OUTPUT"    # 2.3.4
-          echo "RELEASE VERSION: $RELEASE_VERSION"
+          VER=${VERSION_FROM_TAG#v}                                       # 2.3.4
+          echo "RELEASE_VERSION=$VER" >> "$GITHUB_OUTPUT"
 
-          if [ "$RELEASE_VERSION" == '' ]; then
-            echo "RELEASE_VERSION was not set"
-            exit 1
-          fi
-          
           PATTERN="${{ inputs.artifact-pattern }}"
-          ART_PATH="${PATTERN//_VER_/$RELEASE_VERSION}"
+          ART_PATH="${PATTERN//_VER_/$VER}"
           
           ART_URL="${BASE_URL}/${ART_PATH}"
-          echo "Current version is $RELEASE_VERSION"
+          echo "Current version is $VER"
           echo "Artifact url to check $ART_URL"
 
           success=false

--- a/.github/workflows/common-check-and-register-release.yml
+++ b/.github/workflows/common-check-and-register-release.yml
@@ -7,16 +7,14 @@ on:
         required: true
         type: string
 
-env:
-  RELEASE_VERSION: ''
-  
 jobs:
   check-http-artifact:
     runs-on: ubuntu-latest
     environment: Prod
     env:
-      ATTEMPTS: 30
+      ATTEMPTS: 1 # 30
       BASE_URL: "https://repo1.maven.org/maven2/org/octopusden"
+      RELEASE_VERSION: ''
 
     steps:
 
@@ -40,18 +38,18 @@ jobs:
           VERSION_WO_PREFIX=${VERSION_FROM_TAG#v}
           echo "VERSION WITHOUT PREFIX: $VERSION_WO_PREFIX"
           echo "RELEASE_VERSION=$VERSION_WO_PREFIX" >> $GITHUB_ENV    # 2.3.4
-          echo "RELEASE VERSION: $RELEASE_VERSION"
+          echo "RELEASE VERSION: ${{ env.RELEASE_VERSION }}"
 
-          if [ "$RELEASE_VERSION" == '' ]; then
+          if [ "${{ env.RELEASE_VERSION }}" == '' ]; then
             echo "RELEASE_VERSION was not set"
             exit 1
           fi
           
           PATTERN="${{ inputs.artifact-pattern }}"
-          ART_PATH="${PATTERN//_VER_/$RELEASE_VERSION}"
+          ART_PATH="${PATTERN//_VER_/${{ env.RELEASE_VERSION }}}"
           
           ART_URL="${BASE_URL}/${ART_PATH}"
-          echo "Current version is $RELEASE_VERSION"
+          echo "Current version is ${{ env.RELEASE_VERSION }}"
           echo "Artifact url to check $ART_URL"
 
           success=false
@@ -79,5 +77,5 @@ jobs:
     name: Register release
     with:
       octopus-repository: ${{ github.repository }}
-      release-version: $RELEASE_VERSION
+      release-version: ${{ env.RELEASE_VERSION }}
     secrets: inherit

--- a/.github/workflows/common-check-and-register-release.yml
+++ b/.github/workflows/common-check-and-register-release.yml
@@ -70,5 +70,5 @@ jobs:
     name: Register release
     with:
       octopus-repository: ${{ github.repository }}
-      release-version:  ${{ inputs.build-version }}
+      release-version:  ${{ env.RELEASE_VERSION }}
     secrets: inherit

--- a/.github/workflows/common-check-and-register-release.yml
+++ b/.github/workflows/common-check-and-register-release.yml
@@ -37,6 +37,11 @@ jobs:
         run: |
           VERSION_FROM_TAG="${{ steps.tag_version.outputs.tag }}"        # v2.3.4
           echo "RELEASE_VERSION=${VERSION_FROM_TAG#v}" >> $GITHUB_ENV    # 2.3.4
+
+          if [ $RELEASE_VERSION = '' ]; then
+            echo "RELEASE_VERSION was not set"
+            exit 1
+          fi
            
           PATTERN="${{ inputs.artifact-pattern }}"
           ART_PATH="${PATTERN//_VER_/$RELEASE_VERSION}"

--- a/.github/workflows/common-check-and-register-release.yml
+++ b/.github/workflows/common-check-and-register-release.yml
@@ -37,7 +37,9 @@ jobs:
         run: |
           VERSION_FROM_TAG="${{ steps.tag_version.outputs.tag }}"         # v2.3.4
           echo "VERSION WITH TAG: $VERSION_FROM_TAG"
-          echo "RELEASE_VERSION=$(echo ${VERSION_FROM_TAG#v})" >> $GITHUB_ENV    # 2.3.4
+          VERSION_WO_PREFIX=${VERSION_FROM_TAG#v}
+          echo "VERSION WITHOUT PREFIX: $VERSION_WO_PREFIX"
+          echo "RELEASE_VERSION=$VERSION_WO_PREFIX" >> $GITHUB_ENV    # 2.3.4
           echo "RELEASE VERSION: $RELEASE_VERSION"
 
           if [ "$RELEASE_VERSION" == '' ]; then

--- a/.github/workflows/common-check-and-register-release.yml
+++ b/.github/workflows/common-check-and-register-release.yml
@@ -65,6 +65,7 @@ jobs:
   register-release-in-log:
     # register release in octopus-release-log
     needs: check-http-artifact
+    if: ${{ success() }}
     uses: ./.github/workflows/common-register-release.yml
     name: Register release
     with:

--- a/.github/workflows/common-check-and-register-release.yml
+++ b/.github/workflows/common-check-and-register-release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: Prod
     env:
-      ATTEMPTS: 1 # 30
+      ATTEMPTS: 30
       BASE_URL: "https://repo1.maven.org/maven2/org/octopusden"
     outputs:
       release-version: ${{ steps.check-artifact.outputs.RELEASE_VERSION }}

--- a/.github/workflows/common-check-and-register-release.yml
+++ b/.github/workflows/common-check-and-register-release.yml
@@ -33,14 +33,14 @@ jobs:
       - name: Check Sonatype Nexus publish
         id: check-artifact
         run: |
-          VERSION_FROM_TAG="${{ steps.tag_version.outputs.tag }}"      # v2.3.4
-          VER=${VERSION_FROM_TAG#v}                                    # 2.3.4
+          VERSION_FROM_TAG=${{ steps.tag_version.outputs.tag }}      # v2.3.4
+          VER=${VERSION_FROM_TAG#v}                                  # 2.3.4
           echo "RELEASE_VERSION=$VER" >> $GITHUB_OUTPUT
 
-          PATTERN="${{ inputs.artifact-pattern }}"
-          ART_PATH="${PATTERN//_VER_/$VER}"
+          PATTERN=${{ inputs.artifact-pattern }}
+          ART_PATH=${PATTERN//_VER_/$VER}
           
-          ART_URL="${BASE_URL}/${ART_PATH}"
+          ART_URL=${BASE_URL}/${ART_PATH}
           echo "Current version is $VER"
           echo "Artifact url to check $ART_URL"
 

--- a/.github/workflows/common-check-and-register-release.yml
+++ b/.github/workflows/common-check-and-register-release.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           VERSION_FROM_TAG="${{ steps.tag_version.outputs.tag }}"         # v2.3.4
           echo "VERSION WITH TAG: $VERSION_FROM_TAG"
-          echo "RELEASE_VERSION='${VERSION_FROM_TAG#v}'" >> $GITHUB_ENV    # 2.3.4
+          echo "RELEASE_VERSION=$(echo ${VERSION_FROM_TAG#v})" >> $GITHUB_ENV    # 2.3.4
           echo "RELEASE VERSION: $RELEASE_VERSION"
 
           if [ "$RELEASE_VERSION" == '' ]; then

--- a/.github/workflows/common-check-and-register-release.yml
+++ b/.github/workflows/common-check-and-register-release.yml
@@ -15,7 +15,7 @@ jobs:
       ATTEMPTS: 1 # 30
       BASE_URL: "https://repo1.maven.org/maven2/org/octopusden"
     outputs:
-      RELEASE_VERSION: ${{ steps.check-artifact.outputs.RELEASE_VERSION }}
+      release-version: ${{ steps.check-artifact.outputs.RELEASE_VERSION }}
 
     steps:
       - name: Checkout
@@ -77,5 +77,5 @@ jobs:
     name: Register release
     with:
       octopus-repository: ${{ github.repository }}
-      release-version: ${{ needs.check-http-artifact.outputs.RELEASE_VERSION }}
+      release-version: ${{ needs.check-http-artifact.outputs.release-version }}
     secrets: inherit

--- a/.github/workflows/common-check-and-register-release.yml
+++ b/.github/workflows/common-check-and-register-release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: Prod
     env:
-      ATTEMPTS: 30
+      ATTEMPTS: 45
       BASE_URL: "https://repo1.maven.org/maven2/org/octopusden"
     outputs:
       release-version: ${{ steps.check-artifact.outputs.RELEASE_VERSION }}

--- a/.github/workflows/common-check-and-register-release.yml
+++ b/.github/workflows/common-check-and-register-release.yml
@@ -35,8 +35,9 @@ jobs:
       - name: Check Sonatype Nexus publish
         id: check-artifact
         run: |
-          VERSION_FROM_TAG="${{ steps.tag_version.outputs.tag }}"        # v2.3.4
-          echo "RELEASE_VERSION=${VERSION_FROM_TAG#v}" >> $GITHUB_ENV    # 2.3.4
+          VERSION_FROM_TAG="${{ steps.tag_version.outputs.tag }}"         # v2.3.4
+          echo "VERSION WITH TAG: $VERSION_FROM_TAG"
+          echo "RELEASE_VERSION='${VERSION_FROM_TAG#v}'" >> $GITHUB_ENV    # 2.3.4
           echo "RELEASE VERSION: $RELEASE_VERSION"
 
           if [ "$RELEASE_VERSION" == '' ]; then

--- a/.github/workflows/common-check-and-register-release.yml
+++ b/.github/workflows/common-check-and-register-release.yml
@@ -39,10 +39,10 @@ jobs:
           echo "RELEASE_VERSION=${VERSION_FROM_TAG#v}" >> $GITHUB_ENV    # 2.3.4
            
           PATTERN="${{ inputs.artifact-pattern }}"
-          ART_PATH="${PATTERN//_VER_/${{ env.RELEASE_VERSION }}}"
+          ART_PATH="${PATTERN//_VER_/$RELEASE_VERSION}"
           
           ART_URL="${BASE_URL}/${ART_PATH}"
-          echo "Current version is ${{ env.RELEASE_VERSION }}"
+          echo "Current version is $RELEASE_VERSION"
           echo "Artifact url to check $ART_URL"
 
           success=false
@@ -70,5 +70,5 @@ jobs:
     name: Register release
     with:
       octopus-repository: ${{ github.repository }}
-      release-version:  ${{ env.RELEASE_VERSION }}
+      release-version: $RELEASE_VERSION
     secrets: inherit

--- a/.github/workflows/common-check-and-register-release.yml
+++ b/.github/workflows/common-check-and-register-release.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Check Sonatype Nexus publish
         id: check-artifact
         run: |
-          VERSION_FROM_TAG="${{ steps.tag_version.outputs.tag }}"         # v2.3.4
-          VER=${VERSION_FROM_TAG#v}                                       # 2.3.4
+          VERSION_FROM_TAG="${{ steps.tag_version.outputs.tag }}"      # v2.3.4
+          VER=${VERSION_FROM_TAG#v}                                    # 2.3.4
           echo "RELEASE_VERSION=$VER" >> $GITHUB_OUTPUT
 
           PATTERN="${{ inputs.artifact-pattern }}"

--- a/.github/workflows/common-check-and-register-release.yml
+++ b/.github/workflows/common-check-and-register-release.yml
@@ -39,7 +39,7 @@ jobs:
           echo "RELEASE_VERSION=${VERSION_FROM_TAG#v}" >> $GITHUB_ENV    # 2.3.4
           echo "RELEASE VERSION: $RELEASE_VERSION"
 
-          if [ $RELEASE_VERSION == '' ]; then
+          if [ "$RELEASE_VERSION" == '' ]; then
             echo "RELEASE_VERSION was not set"
             exit 1
           fi

--- a/.github/workflows/common-check-and-register-release.yml
+++ b/.github/workflows/common-check-and-register-release.yml
@@ -37,12 +37,13 @@ jobs:
         run: |
           VERSION_FROM_TAG="${{ steps.tag_version.outputs.tag }}"        # v2.3.4
           echo "RELEASE_VERSION=${VERSION_FROM_TAG#v}" >> $GITHUB_ENV    # 2.3.4
+          echo "RELEASE VERSION: $RELEASE_VERSION"
 
           if [ $RELEASE_VERSION == '' ]; then
             echo "RELEASE_VERSION was not set"
             exit 1
           fi
-           
+          
           PATTERN="${{ inputs.artifact-pattern }}"
           ART_PATH="${PATTERN//_VER_/$RELEASE_VERSION}"
           

--- a/.github/workflows/common-check-and-register-release.yml
+++ b/.github/workflows/common-check-and-register-release.yml
@@ -14,10 +14,10 @@ jobs:
     env:
       ATTEMPTS: 1 # 30
       BASE_URL: "https://repo1.maven.org/maven2/org/octopusden"
-      RELEASE_VERSION: ''
+    outputs:
+      RELEASE_VERSION: ${{ steps.check-artifact.outputs.RELEASE_VERSION }}
 
     steps:
-
       - name: Checkout
         uses: actions/checkout@v1
 
@@ -37,19 +37,19 @@ jobs:
           echo "VERSION WITH TAG: $VERSION_FROM_TAG"
           VERSION_WO_PREFIX=${VERSION_FROM_TAG#v}
           echo "VERSION WITHOUT PREFIX: $VERSION_WO_PREFIX"
-          echo "RELEASE_VERSION=$VERSION_WO_PREFIX" >> $GITHUB_ENV    # 2.3.4
-          echo "RELEASE VERSION: ${{ env.RELEASE_VERSION }}"
+          echo "RELEASE_VERSION=$VERSION_WO_PREFIX" >> "$GITHUB_OUTPUT"    # 2.3.4
+          echo "RELEASE VERSION: $RELEASE_VERSION"
 
-          if [ "${{ env.RELEASE_VERSION }}" == '' ]; then
+          if [ "$RELEASE_VERSION" == '' ]; then
             echo "RELEASE_VERSION was not set"
             exit 1
           fi
           
           PATTERN="${{ inputs.artifact-pattern }}"
-          ART_PATH="${PATTERN//_VER_/${{ env.RELEASE_VERSION }}}"
+          ART_PATH="${PATTERN//_VER_/$RELEASE_VERSION}"
           
           ART_URL="${BASE_URL}/${ART_PATH}"
-          echo "Current version is ${{ env.RELEASE_VERSION }}"
+          echo "Current version is $RELEASE_VERSION"
           echo "Artifact url to check $ART_URL"
 
           success=false
@@ -77,5 +77,5 @@ jobs:
     name: Register release
     with:
       octopus-repository: ${{ github.repository }}
-      release-version: 2.0.0 # ${{ env.RELEASE_VERSION }}
+      release-version: ${{ needs.check-http-artifact.outputs.RELEASE_VERSION }}
     secrets: inherit

--- a/.github/workflows/common-check-and-register-release.yml
+++ b/.github/workflows/common-check-and-register-release.yml
@@ -38,7 +38,7 @@ jobs:
           VERSION_FROM_TAG="${{ steps.tag_version.outputs.tag }}"        # v2.3.4
           echo "RELEASE_VERSION=${VERSION_FROM_TAG#v}" >> $GITHUB_ENV    # 2.3.4
 
-          if [ $RELEASE_VERSION = '' ]; then
+          if [ $RELEASE_VERSION == '' ]; then
             echo "RELEASE_VERSION was not set"
             exit 1
           fi

--- a/.github/workflows/common-check-and-register-release.yml
+++ b/.github/workflows/common-check-and-register-release.yml
@@ -62,3 +62,13 @@ jobs:
             fi
           done
           exit 1
+
+  register-release-in-log:
+    # register release in octopus-release-log
+    needs: check-http-artifact
+    uses: ./.github/workflows/common-register-release.yml
+    name: Register release
+    with:
+      octopus-repository: ${{ github.repository }}
+      release-version:  ${{ inputs.build-version }}
+    secrets: inherit

--- a/.github/workflows/common-check-and-register-release.yml
+++ b/.github/workflows/common-check-and-register-release.yml
@@ -52,16 +52,23 @@ jobs:
           echo "Current version is $VER"
           echo "Artifact url to check $ART_URL"
 
+          success=false
+
           for i in $(seq 1 $ATTEMPTS); do
             if curl -sSf "$ART_URL" -o artifact.jar; then
               echo "Artifact found!"
-              exit 0
+              success=true
+              break
             else
               echo "Artifact not found at $ART_URL, retrying in 2 minutes..."
               sleep 120
             fi
           done
-          exit 1
+
+          if [ "$success" = false ]; then
+            echo "All attempts failed. Exiting..."
+            exit 1
+          fi
 
   register-release-in-log:
     # register release in octopus-release-log

--- a/.github/workflows/common-check-and-register-release.yml
+++ b/.github/workflows/common-check-and-register-release.yml
@@ -6,9 +6,6 @@ on:
       artifact-pattern:
         required: true
         type: string
-      prev_conclusion: 
-        required: true
-        type: string
 
 jobs:
   check-http-artifact:
@@ -20,13 +17,6 @@ jobs:
 
     steps:
 
-      - name: Check Previous Workflow Outcome
-        run: |
-          if [ "${{ inputs.prev_conclusion }}" != "success" ]; then
-            echo "Release workflow was unsuccessful, exiting..."
-            exit 0     # ok
-          fi
-    
       - name: Checkout
         uses: actions/checkout@v1
 

--- a/.github/workflows/common-check-and-register-release.yml
+++ b/.github/workflows/common-check-and-register-release.yml
@@ -1,4 +1,4 @@
-name: Check for artifact
+name: Check for artifact and register release in log
 
 on:
   workflow_call:
@@ -7,6 +7,9 @@ on:
         required: true
         type: string
 
+env:
+  RELEASE_VERSION: ''
+  
 jobs:
   check-http-artifact:
     runs-on: ubuntu-latest
@@ -32,14 +35,14 @@ jobs:
       - name: Check Sonatype Nexus publish
         id: check-artifact
         run: |
-          VERSION_FROM_TAG="${{ steps.tag_version.outputs.tag }}"      # v2.3.4
-          VER="${VERSION_FROM_TAG#v}"                                  # 2.3.4
+          VERSION_FROM_TAG="${{ steps.tag_version.outputs.tag }}"        # v2.3.4
+          echo "RELEASE_VERSION=${VERSION_FROM_TAG#v}" >> $GITHUB_ENV    # 2.3.4
            
           PATTERN="${{ inputs.artifact-pattern }}"
-          ART_PATH="${PATTERN//_VER_/${VER}}"
+          ART_PATH="${PATTERN//_VER_/${{ env.RELEASE_VERSION }}}"
           
           ART_URL="${BASE_URL}/${ART_PATH}"
-          echo "Current version is $VER"
+          echo "Current version is ${{ env.RELEASE_VERSION }}"
           echo "Artifact url to check $ART_URL"
 
           success=false

--- a/.github/workflows/common-check-and-register-release.yml
+++ b/.github/workflows/common-check-and-register-release.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           VERSION_FROM_TAG="${{ steps.tag_version.outputs.tag }}"         # v2.3.4
           VER=${VERSION_FROM_TAG#v}                                       # 2.3.4
-          echo "RELEASE_VERSION=$VER" >> "$GITHUB_OUTPUT"
+          echo "RELEASE_VERSION=$VER" >> $GITHUB_OUTPUT
 
           PATTERN="${{ inputs.artifact-pattern }}"
           ART_PATH="${PATTERN//_VER_/$VER}"

--- a/.github/workflows/common-check-and-register-release.yml
+++ b/.github/workflows/common-check-and-register-release.yml
@@ -77,5 +77,5 @@ jobs:
     name: Register release
     with:
       octopus-repository: ${{ github.repository }}
-      release-version: ${{ env.RELEASE_VERSION }}
+      release-version: 2.0.0 # ${{ env.RELEASE_VERSION }}
     secrets: inherit

--- a/.github/workflows/common-java-gradle-release.yml
+++ b/.github/workflows/common-java-gradle-release.yml
@@ -185,6 +185,6 @@ jobs:
       uses: octopusden/octopus-base/.github/workflows/common-register-release.yml@release-reg
       name: Register release
       with:
-        octopus-repository: ${{ env.GITHUB_REPOSITORY }}
+        octopus-repository: ${{ github.repository }}
         release-version:  ${{ inputs.build-version }}
       secrets: inherit

--- a/.github/workflows/common-java-gradle-release.yml
+++ b/.github/workflows/common-java-gradle-release.yml
@@ -185,6 +185,6 @@ jobs:
       uses: octopusden/octopus-base/.github/workflows/common-register-release.yml@release-reg
       name: Register release
       with:
-        octopus-repository: $env:GITHUB_REPOSITORY
+        octopus-repository: ${{ env.GITHUB_REPOSITORY }}
         release-version:  ${{ inputs.build-version }}
       secrets: inherit

--- a/.github/workflows/common-java-gradle-release.yml
+++ b/.github/workflows/common-java-gradle-release.yml
@@ -183,7 +183,7 @@ jobs:
       # register release in octopus-release-log
       if: inputs.register-release-immediately
       needs: prepare-build-publish-release
-      uses: octopusden/octopus-base/.github/workflows/common-register-release.yml@release-reg
+      uses: ./.github/workflows/common-register-release.yml
       name: Register release
       with:
         octopus-repository: ${{ github.repository }}

--- a/.github/workflows/common-java-gradle-release.yml
+++ b/.github/workflows/common-java-gradle-release.yml
@@ -30,6 +30,11 @@ on:
         required: false
         type: string
         default: ''
+      register-release-immediately:
+        description: 'Register release in octopus-release-log immediately (true) or wait for artifact check (false)'
+        required: false
+        type: boolean
+        default: false
     secrets:
       OSSRH_USERNAME:
         required: true
@@ -173,3 +178,13 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: false
           automatic_release_tag: v${{ env.BUILD_VERSION }}
+
+  register-release-in-log:
+      # register release in octopus-release-log
+      if: inputs.register-release-immediately
+      uses: octopusden/octopus-base/.github/workflows/common-register-release.yml@release-reg
+      name: Register release
+      with:
+        octopus-repository: $env:GITHUB_REPOSITORY
+        release-version:  ${{ inputs.build-version }}
+      secrets: inherit

--- a/.github/workflows/common-java-gradle-release.yml
+++ b/.github/workflows/common-java-gradle-release.yml
@@ -182,6 +182,7 @@ jobs:
   register-release-in-log:
       # register release in octopus-release-log
       if: inputs.register-release-immediately
+      needs: prepare-build-publish-release
       uses: octopusden/octopus-base/.github/workflows/common-register-release.yml@release-reg
       name: Register release
       with:

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set module name
         id: set-module-name
         run: |
-          echo "OCTOPUS_MODULE_NAME=$(echo ${{ inputs.octopus-repository }} | cut -d'/' -f2)" >> "$GITHUB_OUTPUT"
+          echo "OCTOPUS_MODULE_NAME=$(echo ${{ inputs.octopus-repository }} | cut -d'/' -f2)" >> $GITHUB_OUTPUT
           echo "env = " ${{ env.OCTOPUS_MODULE_NAME }}
 
       - name: Launch action using REST

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -2,7 +2,7 @@
 name: Register Release
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       octopus-module-name:
         type: string

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Launch action using REST
         run: |
-          echo "OCTOPUS_MODULE_NAME=${{ inputs.octopus-repository }} | cut -d'/' -f2" >> $GITHUB_ENV
+          echo "OCTOPUS_MODULE_NAME='${{ inputs.octopus-repository }}' | cut -d'/' -f2" >> $GITHUB_ENV
           echo ${{ env.OCTOPUS_MODULE_NAME }}
           curl -L \
           -X POST \

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -16,11 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     environment: Prod
     env:
-      OCTOPUS_MODULE_NAME: ${{ inputs.octopus-repository }} | cut -d'/' -f2
+      OCTOPUS_MODULE_NAME: ''
 
     steps:
       - name: Launch action using REST
         run: |
+          echo "OCTOPUS_MODULE_NAME=${{ inputs.octopus-repository }} | cut -d'/' -f2" >> $GITHUB_ENV
           echo ${{ env.OCTOPUS_MODULE_NAME }}
           curl -L \
           -X POST \

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Launch action using REST
         run: |
-          echo "OCTOPUS_MODULE_NAME=$(echo ${{ inputs.octopus-repository }} | cut -d'/' -f2)"
+          OCTOPUS_MODULE_NAME=$(echo ${{ inputs.octopus-repository }} | cut -d'/' -f2)
           echo 'var: ' $OCTOPUS_MODULE_NAME
           echo $OCTOPUS_MODULE_NAME >> "$GITHUB_ENV"
           echo 'env: ' ${{ env.OCTOPUS_MODULE_NAME }}

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: Prod
     env:
-      OCTOPUS_MODULE_NAME: 'default'
+      OCTOPUS_MODULE_NAME: ''
 
     steps:
       - name: Set module name

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -27,5 +27,5 @@ jobs:
           -H "Authorization: Bearer ${{ secrets.OCTOPUS_GITHUB_TOKEN }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/octopusden/octopus-release-log/dispatches \
-          -d '{ "event_type": "register-release", "client_payload": {"octopus-module-name": "${{ OCTOPUS_MODULE_NAME }}", "release-version": "${{ inputs.release-version }}"} }' \
+          -d '{ "event_type": "register-release", "client_payload": {"octopus-module-name": ${OCTOPUS_MODULE_NAME, "release-version": "${{ inputs.release-version }}"} }' \
           --fail

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -22,9 +22,9 @@ jobs:
       - name: Launch action using REST
         run: |
           OCTOPUS_MODULE_NAME=$(echo ${{ inputs.octopus-repository }} | cut -d'/' -f2)
-          echo 'param $OCTOPUS_MODULE_NAME'
+          echo 'param' $OCTOPUS_MODULE_NAME
           echo $OCTOPUS_MODULE_NAME >> $GITHUB_ENV
-          echo 'env ${{ env.OCTOPUS_MODULE_NAME }}'
+          echo 'env' ${{ env.OCTOPUS_MODULE_NAME }}
           curl -L \
           -X POST \
           -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -15,16 +15,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     environment: Prod
-    env:
-      OCTOPUS_MODULE_NAME: 'default'
 
     steps:
       - name: Set module name
+        id: set-module-name
         run: |
           OCTOPUS_MODULE_NAME=$(echo ${{ inputs.octopus-repository }} | cut -d'/' -f2)
           echo "var: " $OCTOPUS_MODULE_NAME
-          echo $OCTOPUS_MODULE_NAME >> "$GITHUB_ENV"
-          echo "env: " ${{ env.OCTOPUS_MODULE_NAME }}
+          echo $OCTOPUS_MODULE_NAME >> "$GITHUB_OUTPUT"
 
       - name: Launch action using REST
         run: |
@@ -34,5 +32,5 @@ jobs:
           -H "Authorization: Bearer ${{ secrets.OCTOPUS_GITHUB_TOKEN }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/octopusden/octopus-release-log/dispatches \
-          -d '{ "event_type": "register-release", "client_payload": {"octopus-module-name": "${{ env.OCTOPUS_MODULE_NAME }}", "release-version": "${{ inputs.release-version }}"} }' \
+          -d '{ "event_type": "register-release", "client_payload": {"octopus-module-name": "${{ steps.set-module-name.outputs.OCTOPUS_MODULE_NAME }}", "release-version": "${{ inputs.release-version }}"} }' \
           --fail

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -15,14 +15,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     environment: Prod
+    env:
+      OCTOPUS_MODULE_NAME: 'default'
 
     steps:
       - name: Set module name
         id: set-module-name
         run: |
-          OCTOPUS_MODULE_NAME=$(echo ${{ inputs.octopus-repository }} | cut -d'/' -f2)
-          echo "var: " $OCTOPUS_MODULE_NAME
-          echo $OCTOPUS_MODULE_NAME >> "$GITHUB_OUTPUT"
+          echo "OCTOPUS_MODULE_NAME=$(echo ${{ inputs.octopus-repository }} | cut -d'/' -f2)" >> "$GITHUB_OUTPUT"
+          echo "env = " ${{ env.OCTOPUS_MODULE_NAME }}
 
       - name: Launch action using REST
         run: |
@@ -32,5 +33,5 @@ jobs:
           -H "Authorization: Bearer ${{ secrets.OCTOPUS_GITHUB_TOKEN }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/octopusden/octopus-release-log/dispatches \
-          -d '{ "event_type": "register-release", "client_payload": {"octopus-module-name": "${{ steps.set-module-name.outputs.OCTOPUS_MODULE_NAME }}", "release-version": "${{ inputs.release-version }}"} }' \
+          -d '{ "event_type": "register-release", "client_payload": {"octopus-module-name": "${{ env.OCTOPUS_MODULE_NAME }}", "release-version": "${{ inputs.release-version }}"} }' \
           --fail

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -4,7 +4,7 @@ name: Register Release
 on:
   workflow_call:
     inputs:
-      octopus-module-name:
+      octopus-repository:
         type: string
         required: true
       release-version:
@@ -25,5 +25,5 @@ jobs:
           -H "Authorization: Bearer ${{ secrets.OCTOPUS_GITHUB_TOKEN }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/octopusden/octopus-release-log/dispatches \
-          -d '{ "event_type": "register-release", "client_payload": {"octopus-module-name": "${{ inputs.octopus-module-name }}", "release-version": "${{ inputs.release-version }}"} }' \
+          -d '{ "event_type": "register-release", "client_payload": {"octopus-repository": "${{ inputs.octopus-repository }}", "release-version": "${{ inputs.release-version }}"} }' \
           --fail

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -34,6 +34,8 @@ jobs:
           echo "Register release ${{ inputs.octopus-module-name }}-${{ inputs.release-version }}"
           cd release-log
           git pull
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
           # git config user.name "gh-octopusden"
           # git config user.email "gh.octopusden@gmail.com"
           # git config --global core.autocrlf input

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -27,5 +27,5 @@ jobs:
           -H "Authorization: Bearer ${{ secrets.OCTOPUS_GITHUB_TOKEN }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/octopusden/octopus-release-log/dispatches \
-          -d '{ "event_type": "register-release", "client_payload": {"octopus-module-name": ${OCTOPUS_MODULE_NAME, "release-version": "${{ inputs.release-version }}"} }' \
+          -d '{ "event_type": "register-release", "client_payload": {"octopus-module-name": $OCTOPUS_MODULE_NAME, "release-version": "${{ inputs.release-version }}"} }' \
           --fail

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Launch action using REST
         run: |
-          echo OCTOPUS_MODULE_NAME='${{ inputs.octopus-repository }}' | cut -d'/' -f2 >> $GITHUB_ENV
+          echo OCTOPUS_MODULE_NAME=${{ inputs.octopus-repository }} | cut -d'/' -f2 >> $GITHUB_ENV
           echo ${{ env.OCTOPUS_MODULE_NAME }}
           curl -L \
           -X POST \

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -16,15 +16,18 @@ jobs:
     runs-on: ubuntu-latest
     environment: Prod
     env:
-      OCTOPUS_MODULE_NAME: ''
+      OCTOPUS_MODULE_NAME: 'default'
 
     steps:
-      - name: Launch action using REST
+      - name: Set module name
         run: |
           OCTOPUS_MODULE_NAME=$(echo ${{ inputs.octopus-repository }} | cut -d'/' -f2)
           echo "var: " $OCTOPUS_MODULE_NAME
           echo $OCTOPUS_MODULE_NAME >> "$GITHUB_ENV"
           echo "env: " ${{ env.OCTOPUS_MODULE_NAME }}
+
+      - name: Launch action using REST
+        run: |
           curl -L \
           -X POST \
           -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -34,9 +34,9 @@ jobs:
           echo "Register release ${{ inputs.octopus-module-name }}-${{ inputs.release-version }}"
           cd release-log
           git pull
-          git config user.name "gh-octopusden"
-          git config user.email "gh.octopusden@gmail.com"
-          git config --global core.autocrlf input
+          # git config user.name "gh-octopusden"
+          # git config user.email "gh.octopusden@gmail.com"
+          # git config --global core.autocrlf input
           # git config user.name github-actions
           # git config user.email github-actions@github.com
           ls -l

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set module name
         id: set-module-name
         run: |
-          echo "OCTOPUS_MODULE_NAME=$(echo ${{ inputs.octopus-repository }} | cut -d'/' -f2)" >> $GITHUB_OUTPUT
+          echo "OCTOPUS_MODULE_NAME=$(echo ${{ inputs.octopus-repository }} | cut -d'/' -f2)" >> $GITHUB_ENV
           echo "env = " ${{ env.OCTOPUS_MODULE_NAME }}
 
       - name: Launch action using REST

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Launch action using REST
         run: |
-          OCTOPUS_MODULE_NAME="$(echo ${{ inputs.octopus-repository }} | cut -d'/' -f2)"
+          OCTOPUS_MODULE_NAME=$(echo ${{ inputs.octopus-repository }} | cut -d'/' -f2)
           echo $OCTOPUS_MODULE_NAME
           echo $OCTOPUS_MODULE_NAME >> $GITHUB_ENV
           echo ${{ env.OCTOPUS_MODULE_NAME }}

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Launch action using REST
         run: |
           echo "OCTOPUS_MODULE_NAME=$(echo ${{ inputs.octopus-repository }} | cut -d'/' -f2)" >> "$GITHUB_ENV"
-          echo $OCTOPUS_MODULE_NAME
+          echo ${{ env.OCTOPUS_MODULE_NAME }}
           curl -L \
           -X POST \
           -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -35,7 +35,7 @@ jobs:
           cd release-log
           git pull
           git config user.name "gh-octopusden"
-          git config user.email "gh-octopusden@gmail.com"
+          git config user.email "gh.octopusden@gmail.com"
           git config --global core.autocrlf input
           # git config user.name github-actions
           # git config user.email github-actions@github.com

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -26,8 +26,7 @@ jobs:
         with:
           repository: octopusden/octopus-release-log
           path: release-log
-          persist-credentials: true
-          ssh-key: ${{ secrets.GH_OCTOPUSDEN_PRIVATE_KEY }}
+          fetch-depth: 0
 
       - name: Register release
         run: |
@@ -56,6 +55,6 @@ jobs:
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:
-          ssh: true
           repository: octopusden/octopus-release-log
+          force: true
           directory: release-log

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -21,7 +21,9 @@ jobs:
     steps:
       - name: Launch action using REST
         run: |
-          echo OCTOPUS_MODULE_NAME=${{ inputs.octopus-repository }} | cut -d'/' -f2 >> $GITHUB_ENV
+          OCTOPUS_MODULE_NAME="$(echo ${{ inputs.octopus-repository }} | cut -d'/' -f2)"
+          echo $OCTOPUS_MODULE_NAME
+          echo $OCTOPUS_MODULE_NAME >> $GITHUB_ENV
           echo ${{ env.OCTOPUS_MODULE_NAME }}
           curl -L \
           -X POST \

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Launch action using REST
         run: |
-          echo OCTOPUS_MODULE_NAME="${{ inputs.octopus-repository }}" | cut -d'/' -f2 >> $GITHUB_ENV
+          echo "OCTOPUS_MODULE_NAME=${{ inputs.octopus-repository }} | cut -d'/' -f2" >> $GITHUB_ENV
           echo ${{ env.OCTOPUS_MODULE_NAME }}
           curl -L \
           -X POST \

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -27,5 +27,5 @@ jobs:
           -H "Authorization: Bearer ${{ secrets.OCTOPUS_GITHUB_TOKEN }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/octopusden/octopus-release-log/dispatches \
-          -d '{ "event_type": "register-release", "client_payload": {"octopus-module-name": "$OCTOPUS_MODULE_NAME", "release-version": "${{ inputs.release-version }}"} }' \
+          -d '{ "event_type": "register-release", "client_payload": {"octopus-module-name": "${{ OCTOPUS_MODULE_NAME }}", "release-version": "${{ inputs.release-version }}"} }' \
           --fail

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -15,15 +15,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     environment: Prod
-    
+    env:
+      OCTOPUS_MODULE_NAME: ''
+
     steps:
       - name: Launch action using REST
         run: |
+          echo OCTOPUS_MODULE_NAME="${{ inputs.octopus-repository }}" | cut -d'/' -f2 >> $GITHUB_ENV
+          echo ${{ env.OCTOPUS_MODULE_NAME }}
           curl -L \
           -X POST \
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: Bearer ${{ secrets.OCTOPUS_GITHUB_TOKEN }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/octopusden/octopus-release-log/dispatches \
-          -d '{ "event_type": "register-release", "client_payload": {"octopus-repository": "${{ inputs.octopus-repository }}", "release-version": "${{ inputs.release-version }}"} }' \
+          -d '{ "event_type": "register-release", "client_payload": {"octopus-module-name": "${{ env.OCTOPUS_MODULE_NAME }}", "release-version": "${{ inputs.release-version }}"} }' \
           --fail

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Launch action using REST
         run: |
-          OCTOPUS_MODULE_NAME=$(echo ${{ inputs.octopus-repository }} | cut -d'/' -f2)
+          echo "OCTOPUS_MODULE_NAME=$(echo ${{ inputs.octopus-repository }} | cut -d'/' -f2)" >> "$GITHUB_ENV"
           echo $OCTOPUS_MODULE_NAME
           curl -L \
           -X POST \
@@ -27,5 +27,5 @@ jobs:
           -H "Authorization: Bearer ${{ secrets.OCTOPUS_GITHUB_TOKEN }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/octopusden/octopus-release-log/dispatches \
-          -d '{ "event_type": "register-release", "client_payload": {"octopus-module-name": $OCTOPUS_MODULE_NAME, "release-version": "${{ inputs.release-version }}"} }' \
+          -d '{ "event_type": "register-release", "client_payload": {"octopus-module-name": "$OCTOPUS_MODULE_NAME", "release-version": "${{ inputs.release-version }}"} }' \
           --fail

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -22,9 +22,9 @@ jobs:
       - name: Launch action using REST
         run: |
           OCTOPUS_MODULE_NAME=$(echo ${{ inputs.octopus-repository }} | cut -d'/' -f2)
-          echo $OCTOPUS_MODULE_NAME
+          echo 'param $OCTOPUS_MODULE_NAME'
           echo $OCTOPUS_MODULE_NAME >> $GITHUB_ENV
-          echo ${{ env.OCTOPUS_MODULE_NAME }}
+          echo 'env ${{ env.OCTOPUS_MODULE_NAME }}'
           curl -L \
           -X POST \
           -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -15,21 +15,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     environment: Prod
-    env:
-      OCTOPUS_MODULE_NAME: ''
 
     steps:
       - name: Launch action using REST
         run: |
           OCTOPUS_MODULE_NAME=$(echo ${{ inputs.octopus-repository }} | cut -d'/' -f2)
-          echo 'param' $OCTOPUS_MODULE_NAME
-          echo $OCTOPUS_MODULE_NAME >> $GITHUB_ENV
-          echo 'env' ${{ env.OCTOPUS_MODULE_NAME }}
+          echo $OCTOPUS_MODULE_NAME
           curl -L \
           -X POST \
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: Bearer ${{ secrets.OCTOPUS_GITHUB_TOKEN }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/octopusden/octopus-release-log/dispatches \
-          -d '{ "event_type": "register-release", "client_payload": {"octopus-module-name": "${{ env.OCTOPUS_MODULE_NAME }}", "release-version": "${{ inputs.release-version }}"} }' \
+          -d '{ "event_type": "register-release", "client_payload": {"octopus-module-name": "$OCTOPUS_MODULE_NAME", "release-version": "${{ inputs.release-version }}"} }' \
           --fail

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -16,12 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     environment: Prod
     env:
-      OCTOPUS_MODULE_NAME: ''
+      OCTOPUS_MODULE_NAME: ${{ inputs.octopus-repository }} | cut -d'/' -f2
 
     steps:
       - name: Launch action using REST
         run: |
-          echo "OCTOPUS_MODULE_NAME=${{ inputs.octopus-repository }} | cut -d'/' -f2" >> $GITHUB_ENV
           echo ${{ env.OCTOPUS_MODULE_NAME }}
           curl -L \
           -X POST \

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -22,9 +22,9 @@ jobs:
       - name: Launch action using REST
         run: |
           OCTOPUS_MODULE_NAME=$(echo ${{ inputs.octopus-repository }} | cut -d'/' -f2)
-          echo 'var: ' $OCTOPUS_MODULE_NAME
+          echo "var: " $OCTOPUS_MODULE_NAME
           echo $OCTOPUS_MODULE_NAME >> "$GITHUB_ENV"
-          echo 'env: ' ${{ env.OCTOPUS_MODULE_NAME }}
+          echo "env: " ${{ env.OCTOPUS_MODULE_NAME }}
           curl -L \
           -X POST \
           -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Launch action using REST
         run: |
-          echo "OCTOPUS_MODULE_NAME='${{ inputs.octopus-repository }}' | cut -d'/' -f2" >> $GITHUB_ENV
+          echo OCTOPUS_MODULE_NAME='${{ inputs.octopus-repository }}' | cut -d'/' -f2 >> $GITHUB_ENV
           echo ${{ env.OCTOPUS_MODULE_NAME }}
           curl -L \
           -X POST \

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -21,8 +21,10 @@ jobs:
     steps:
       - name: Launch action using REST
         run: |
-          echo "OCTOPUS_MODULE_NAME=$(echo ${{ inputs.octopus-repository }} | cut -d'/' -f2)" >> "$GITHUB_ENV"
-          echo ${{ env.OCTOPUS_MODULE_NAME }}
+          echo "OCTOPUS_MODULE_NAME=$(echo ${{ inputs.octopus-repository }} | cut -d'/' -f2)"
+          echo 'var: ' $OCTOPUS_MODULE_NAME
+          echo $OCTOPUS_MODULE_NAME >> "$GITHUB_ENV"
+          echo 'env: ' ${{ env.OCTOPUS_MODULE_NAME }}
           curl -L \
           -X POST \
           -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -23,7 +23,6 @@ jobs:
         id: set-module-name
         run: |
           echo "OCTOPUS_MODULE_NAME=$(echo ${{ inputs.octopus-repository }} | cut -d'/' -f2)" >> $GITHUB_ENV
-          echo "env = " ${{ env.OCTOPUS_MODULE_NAME }}
 
       - name: Launch action using REST
         run: |

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -2,59 +2,28 @@
 name: Register Release
 
 on:
-  workflow_call:
+  workflow_dispatch:
     inputs:
       octopus-module-name:
-        required: true
         type: string
+        required: true
       release-version:
-        required: true
         type: string
+        required: true
 
-permissions:
-  contents: write
-  pull-requests: write
-  
 jobs:
-  register-release-in-log:
+  build:
     runs-on: ubuntu-latest
     environment: Prod
-
+    
     steps:
-      - name: Fetch release log
-        uses: actions/checkout@v4
-        with:
-          repository: octopusden/octopus-release-log
-          path: release-log
-          fetch-depth: 0
-
-      - name: Register release
+      - name: Launch action using REST
         run: |
-          echo "Register release ${{ inputs.octopus-module-name }}-${{ inputs.release-version }}"
-          cd release-log
-          git pull
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          # git config user.name "gh-octopusden"
-          # git config user.email "gh.octopusden@gmail.com"
-          # git config --global core.autocrlf input
-          # git config user.name github-actions
-          # git config user.email github-actions@github.com
-          ls -l
-          if [[ ! -e ${{ inputs.octopus-module-name }}.txt ]]; then
-            touch ${{ inputs.octopus-module-name }}.txt
-          fi
-          echo "${{ inputs.release-version }}" | cat - ${{ inputs.octopus-module-name }}.txt > temp && mv temp ${{ inputs.octopus-module-name }}.txt
-          git diff
-          git add ${{ inputs.octopus-module-name }}.txt
-          git commit -m"${{ inputs.octopus-module-name }}-${{ inputs.release-version }}"
-          git log
-          git status
-          git config --list
-          
-      - name: Push changes
-        uses: ad-m/github-push-action@master
-        with:
-          repository: octopusden/octopus-release-log
-          force: true
-          directory: release-log
+          curl -L \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.OCTOPUS_GITHUB_TOKEN }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/octopusden/octopus-release-log/dispatches \
+          -d '{ "event_type": "register-release", "client_payload": {"octopus-module-name": "${{ inputs.octopus-module-name }}", "release-version": "${{ inputs.release-version }}"} }' \
+          --fail

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -29,5 +29,5 @@ jobs:
           -H "Authorization: Bearer ${{ secrets.OCTOPUS_GITHUB_TOKEN }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/octopusden/octopus-release-log/dispatches \
-          -d '{ "event_type": "register-release", "client_payload": {"octopus-module-name": "$OCTOPUS_MODULE_NAME", "release-version": "${{ inputs.release-version }}"} }' \
+          -d '{ "event_type": "register-release", "client_payload": {"octopus-module-name": "${{ env.OCTOPUS_MODULE_NAME }}", "release-version": "${{ inputs.release-version }}"} }' \
           --fail

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -15,6 +15,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     environment: Prod
+    env:
+      OCTOPUS_MODULE_NAME: ''
 
     steps:
       - name: Launch action using REST


### PR DESCRIPTION
All releases of Octopus modules will be registered in the release log: https://github.com/octopusden/octopus-release-log 
This repository can be used to setup trigger on new release inside your Octopus installation in order to perform additional pre-production testing and plan deployment.