### PR TITLE
Fix path for calling own action

### DIFF
--- a/.github/workflows/common-java-maven-release.yml
+++ b/.github/workflows/common-java-maven-release.yml
@@ -48,7 +48,7 @@ jobs:
           level: ${{ inputs.increment-version-level }}
 
       - name: Get new version
-        uses: octopusden/octopus-base/.github/actions/get-version
+        uses: ./.github/actions/get-version
         id: new-version
         with:
           tag-value: ${{ steps.new-tag-version.outputs.new_version }}


### PR DESCRIPTION
According to https://docs.github.com/en/actions/using-workflows/reusing-workflows#calling-a-reusable-workflow