### PR TITLE
Add Task for Publishing Build Artifact to Sonatype Staging

### DIFF
--- a/.github/workflows/common-java-gradle-build.yml
+++ b/.github/workflows/common-java-gradle-build.yml
@@ -18,6 +18,10 @@ on:
         required: false
         type: boolean
         default: true
+      publish-to-staging:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -60,7 +64,17 @@ jobs:
 
       - name: Gradle build and publish to local
         if: inputs.docker-image == ''
-        run: ./gradlew build publishToMavenLocal ${{ env.SKIP_TESTS }} -PbuildVersion=${{ env.BUILD_VERSION }} -Pversion=${{ env.BUILD_VERSION }} --info -s
+        run: ./gradlew build ${{ env.SKIP_TESTS }} -PbuildVersion=${{ env.BUILD_VERSION }} -Pversion=${{ env.BUILD_VERSION }} --info -s
+
+      # publish to nexus staging
+      - name: Publish to Sonatype Nexus Staging
+        if: inputs.publish-to-staging
+        run: ./gradlew -Pnexus=true publishToSonatype -PbuildVersion=${{ env.BUILD_VERSION }} -Pversion=${{ env.BUILD_VERSION }} --info -s
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Gradle build docker image
         if: inputs.docker-image

--- a/.github/workflows/common-java-gradle-build.yml
+++ b/.github/workflows/common-java-gradle-build.yml
@@ -24,13 +24,13 @@ on:
         default: false
     secrets:
       OSSRH_USERNAME:
-        required: true
+        required: false
       OSSRH_TOKEN:
-        required: true
+        required: false
       GPG_PASSPHRASE:
-        required: true
+        required: false
       GPG_PRIVATE_KEY:
-        required: true
+        required: false
 
 jobs:
   build:

--- a/.github/workflows/common-java-gradle-build.yml
+++ b/.github/workflows/common-java-gradle-build.yml
@@ -58,9 +58,9 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1
 
-      - name: Gradle build
+      - name: Gradle build and publish to local
         if: inputs.docker-image == ''
-        run: ./gradlew build ${{ env.SKIP_TESTS }} -PbuildVersion=${{ env.BUILD_VERSION }} -Pversion=${{ env.BUILD_VERSION }} --info -s
+        run: ./gradlew build publishToMavenLocal ${{ env.SKIP_TESTS }} -PbuildVersion=${{ env.BUILD_VERSION }} -Pversion=${{ env.BUILD_VERSION }} --info -s
 
       - name: Gradle build docker image
         if: inputs.docker-image

--- a/.github/workflows/common-java-gradle-build.yml
+++ b/.github/workflows/common-java-gradle-build.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1
 
-      - name: Gradle build and publish to local
+      - name: Gradle build
         if: inputs.docker-image == ''
         run: ./gradlew build ${{ env.SKIP_TESTS }} -PbuildVersion=${{ env.BUILD_VERSION }} -Pversion=${{ env.BUILD_VERSION }} --info -s
 

--- a/.github/workflows/common-java-gradle-build.yml
+++ b/.github/workflows/common-java-gradle-build.yml
@@ -22,6 +22,15 @@ on:
         required: false
         type: boolean
         default: false
+    secrets:
+      OSSRH_USERNAME:
+        required: true
+      OSSRH_TOKEN:
+        required: true
+      GPG_PASSPHRASE:
+        required: true
+      GPG_PRIVATE_KEY:
+        required: true
 
 jobs:
   build:


### PR DESCRIPTION
- Added a task for publishing build artifacts to Sonatype Staging in `common-java-gradle-build.yml`.
- Controlled via the input parameter `publish-to-staging` (default: `false`).
- This enables downstream jobs to use the published artifact from the workflow template job.