### PR TITLE
Add inputs.release-mvn-parameters for Maven release

### DIFF
--- a/.github/workflows/common-java-maven-release.yml
+++ b/.github/workflows/common-java-maven-release.yml
@@ -30,6 +30,9 @@ on:
         required: false
         type: boolean
         default: false
+      release-mvn-parameters:
+        type: string
+        default: ''
     secrets:
       OSSRH_USERNAME:
         required: true
@@ -141,7 +144,7 @@ jobs:
           gpg-passphrase: GPG_PASSPHRASE # env variable for gpg signing in deploy
 
       - name: Publish to Sonatype Nexus
-        run: mvn --batch-mode deploy -P gpg
+        run: mvn --batch-mode deploy -P gpg ${{ inputs.release-mvn-parameters }}
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}


### PR DESCRIPTION
Add `release-mvn-parameters` input to allow passing custom Maven flags (e.g., `-DskipTests`, `-Dinvoker.skip=true`) 
during deployment. 
This is required because some projects (e.g., octopus-artifactory-npm-maven-plugin) have tests bound to verify/integration-test phases that still execute during `mvn deploy` even when the hybrid flow intends to skip testing.
