### PR TITLE
fix: add sources/javadoc JARs and Maven Central publication validator

### DIFF
--- a/docs/Octopus JVM Style Guidelines.md
+++ b/docs/Octopus JVM Style Guidelines.md
@@ -175,6 +175,78 @@ Each repo adds two workflow files that call reusable workflows from octopus-base
 
 See `docs/Octopus GitHub Actions Guide.md` for workflow details and inputs.
 
+## Maven Central Publication Validation
+
+For repos that publish to Maven Central via `maven-publish`, the convention plugin automatically registers a `validatePublications` task when both `maven-publish` and `org.octopusden.octopus-quality` are applied. The task is wired into `check` — so it runs on every PR build and catches Central-incompatible publications before publish time.
+
+### What is validated
+
+**POM metadata** (parsed from generated POM XML, direct `<project>` children only):
+
+| Field | Required |
+|-------|:--------:|
+| `<name>` | yes |
+| `<description>` | yes |
+| `<url>` | yes |
+| `<licenses>` | yes (at least one `<license>`) |
+| `<developers>` | yes (at least one `<developer>`) |
+| `<scm>` | yes |
+
+**Artifacts** (for non-pom publications):
+
+| Artifact | Required |
+|----------|:--------:|
+| `-sources.jar` | yes |
+| `-javadoc.jar` | yes |
+
+**pom-only publications** (java-platform, BOM, version-catalog) are exempt from artifact checks — only POM metadata is validated.
+
+### Consumer example
+
+```kotlin
+plugins {
+    kotlin("jvm")
+    `maven-publish`
+    id("org.octopusden.octopus-quality")
+}
+
+java {
+    withSourcesJar()
+    withJavadocJar()
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("mavenJava") {
+            from(components["java"])
+            pom {
+                name.set(project.name)
+                description.set("Octopus module: ${project.name}")
+                url.set("https://github.com/octopusden/${rootProject.name}")
+                licenses {
+                    license {
+                        name.set("The Apache License, Version 2.0")
+                        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                    }
+                }
+                scm {
+                    url.set("https://github.com/octopusden/${rootProject.name}")
+                    connection.set("scm:git://github.com/octopusden/${rootProject.name}.git")
+                }
+                developers {
+                    developer {
+                        id.set("octopus")
+                        name.set("octopus")
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+With this setup, `./gradlew check` includes `validatePublications` automatically. If any required field is missing or sources/javadoc JARs are absent, the build fails with a clear error message listing exactly what is wrong.
+
 ## Baseline Strategy
 
 - Baseline/suppressions are allowed only for existing violations.

--- a/gradle-quality-plugin/build.gradle.kts
+++ b/gradle-quality-plugin/build.gradle.kts
@@ -140,25 +140,63 @@ signing {
 // but applied to the plugin build itself (which doesn't use the convention plugin).
 tasks.register("validatePublications") {
     group = "verification"
-    description = "Validates plugin publications meet Maven Central requirements"
+    description = "Validates plugin publications meet Maven Central requirements (artifacts + POM)"
     dependsOn(tasks.withType<org.gradle.api.publish.maven.tasks.GenerateMavenPom>())
     doLast {
+        val metadataClassifiers = setOf("sources", "javadoc")
         publishing.publications.withType<MavenPublication>().forEach { pub ->
-            // Skip Gradle plugin marker publications (pom-only, no artifacts expected)
-            val hasRealArtifact =
-                pub.artifacts.any {
-                    it.classifier !in setOf("sources", "javadoc")
-                }
-            if (!hasRealArtifact) return@forEach
+            val hasRealArtifact = pub.artifacts.any { it.classifier !in metadataClassifiers }
+            if (!hasRealArtifact) return@forEach // skip pom-only marker publications
 
             val errors = mutableListOf<String>()
-            val hasSourcesJar = pub.artifacts.any { it.classifier == "sources" && it.extension == "jar" }
-            val hasJavadocJar = pub.artifacts.any { it.classifier == "javadoc" && it.extension == "jar" }
-            if (!hasSourcesJar) errors.add("${pub.name}: -sources.jar missing")
-            if (!hasJavadocJar) errors.add("${pub.name}: -javadoc.jar missing")
+
+            // Artifact checks
+            if (!pub.artifacts.any { it.classifier == "sources" && it.extension == "jar" }) {
+                errors.add("${pub.name}: -sources.jar missing")
+            }
+            if (!pub.artifacts.any { it.classifier == "javadoc" && it.extension == "jar" }) {
+                errors.add("${pub.name}: -javadoc.jar missing")
+            }
+
+            // POM metadata checks (parse generated POM XML)
+            val pubNameCap = pub.name.replaceFirstChar { it.uppercase() }
+            val pomTask =
+                tasks.findByName("generatePomFileFor${pubNameCap}Publication")
+                    as? org.gradle.api.publish.maven.tasks.GenerateMavenPom
+            val pomFile = pomTask?.destination
+            if (pomFile != null && pomFile.exists()) {
+                val dbf =
+                    javax.xml.parsers.DocumentBuilderFactory
+                        .newInstance()
+                dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+                val root = dbf.newDocumentBuilder().parse(pomFile).documentElement
+                val direct =
+                    (0 until root.childNodes.length)
+                        .map { root.childNodes.item(it) }
+                        .filter { it.nodeType == org.w3c.dom.Node.ELEMENT_NODE }
+
+                fun text(tag: String) =
+                    direct
+                        .firstOrNull { it.nodeName == tag }
+                        ?.textContent
+                        ?.trim()
+                        ?.ifBlank { null }
+
+                fun hasKids(tag: String) =
+                    direct.firstOrNull { it.nodeName == tag }?.let { node ->
+                        (0 until node.childNodes.length).any { node.childNodes.item(it).nodeType == org.w3c.dom.Node.ELEMENT_NODE }
+                    } ?: false
+                if (text("name").isNullOrBlank()) errors.add("${pub.name}: POM <name> missing")
+                if (text("description").isNullOrBlank()) errors.add("${pub.name}: POM <description> missing")
+                if (text("url").isNullOrBlank()) errors.add("${pub.name}: POM <url> missing")
+                if (!hasKids("licenses")) errors.add("${pub.name}: POM <licenses> missing")
+                if (!hasKids("developers")) errors.add("${pub.name}: POM <developers> missing")
+                if (!hasKids("scm")) errors.add("${pub.name}: POM <scm> missing")
+            }
+
             if (errors.isNotEmpty()) throw GradleException("Publication validation failed:\n${errors.joinToString("\n")}")
         }
-        logger.lifecycle("validatePublications: plugin publications passed Maven Central artifact checks")
+        logger.lifecycle("validatePublications: plugin publications passed Maven Central checks")
     }
 }
 tasks.named("check") { dependsOn("validatePublications") }

--- a/gradle-quality-plugin/build.gradle.kts
+++ b/gradle-quality-plugin/build.gradle.kts
@@ -160,11 +160,16 @@ tasks.register("validatePublications") {
 
             // POM metadata checks (parse generated POM XML)
             val pubNameCap = pub.name.replaceFirstChar { it.uppercase() }
+            val pomTaskName = "generatePomFileFor${pubNameCap}Publication"
             val pomTask =
-                tasks.findByName("generatePomFileFor${pubNameCap}Publication")
+                tasks.findByName(pomTaskName)
                     as? org.gradle.api.publish.maven.tasks.GenerateMavenPom
-            val pomFile = pomTask?.destination
-            if (pomFile != null && pomFile.exists()) {
+            if (pomTask == null) {
+                errors.add("${pub.name}: GenerateMavenPom task '$pomTaskName' not found")
+            } else if (!pomTask.destination.exists()) {
+                errors.add("${pub.name}: generated POM not found at ${pomTask.destination.path}")
+            } else {
+                val pomFile = pomTask.destination
                 val dbf =
                     javax.xml.parsers.DocumentBuilderFactory
                         .newInstance()

--- a/gradle-quality-plugin/build.gradle.kts
+++ b/gradle-quality-plugin/build.gradle.kts
@@ -54,6 +54,11 @@ tasks.withType<Test> {
     useJUnitPlatform()
 }
 
+java {
+    withJavadocJar()
+    withSourcesJar()
+}
+
 kotlin {
     // JDK 11 = minimum CI runtime across all target repos.
     // Gradle 8.x requires JDK 11+, quality tools (Checkstyle 10.x) require JDK 11+.

--- a/gradle-quality-plugin/build.gradle.kts
+++ b/gradle-quality-plugin/build.gradle.kts
@@ -174,6 +174,8 @@ tasks.register("validatePublications") {
                     javax.xml.parsers.DocumentBuilderFactory
                         .newInstance()
                 dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+                dbf.setFeature("http://xml.org/sax/features/external-general-entities", false)
+                dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false)
                 val root = dbf.newDocumentBuilder().parse(pomFile).documentElement
                 val direct =
                     (0 until root.childNodes.length)

--- a/gradle-quality-plugin/build.gradle.kts
+++ b/gradle-quality-plugin/build.gradle.kts
@@ -134,3 +134,31 @@ signing {
     sign(publishing.publications)
     isRequired = gradle.startParameter.taskNames.any { it == "publishToSonatype" || it.endsWith(":publishToSonatype") }
 }
+
+// Self-validate: ensure plugin's own publications meet Maven Central requirements.
+// This is the same check that PublicationValidator provides to consumer repos,
+// but applied to the plugin build itself (which doesn't use the convention plugin).
+tasks.register("validatePublications") {
+    group = "verification"
+    description = "Validates plugin publications meet Maven Central requirements"
+    dependsOn(tasks.withType<org.gradle.api.publish.maven.tasks.GenerateMavenPom>())
+    doLast {
+        publishing.publications.withType<MavenPublication>().forEach { pub ->
+            // Skip Gradle plugin marker publications (pom-only, no artifacts expected)
+            val hasRealArtifact =
+                pub.artifacts.any {
+                    it.classifier !in setOf("sources", "javadoc")
+                }
+            if (!hasRealArtifact) return@forEach
+
+            val errors = mutableListOf<String>()
+            val hasSourcesJar = pub.artifacts.any { it.classifier == "sources" && it.extension == "jar" }
+            val hasJavadocJar = pub.artifacts.any { it.classifier == "javadoc" && it.extension == "jar" }
+            if (!hasSourcesJar) errors.add("${pub.name}: -sources.jar missing")
+            if (!hasJavadocJar) errors.add("${pub.name}: -javadoc.jar missing")
+            if (errors.isNotEmpty()) throw GradleException("Publication validation failed:\n${errors.joinToString("\n")}")
+        }
+        logger.lifecycle("validatePublications: plugin publications passed Maven Central artifact checks")
+    }
+}
+tasks.named("check") { dependsOn("validatePublications") }

--- a/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/OctopusQualityPlugin.kt
+++ b/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/OctopusQualityPlugin.kt
@@ -2,6 +2,7 @@ package org.octopusden.octopus.quality
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.octopusden.octopus.quality.internal.PublicationValidator
 import org.octopusden.octopus.quality.internal.SubprojectConfigurer
 import org.octopusden.octopus.quality.internal.TaskRegistrar
 
@@ -72,6 +73,14 @@ class OctopusQualityPlugin : Plugin<Project> {
         // all subproject afterEvaluate blocks have completed before wiring task dependencies.
         project.gradle.projectsEvaluated {
             TaskRegistrar.register(project, extension)
+        }
+
+        // Validate Maven Central publication readiness (sources, javadoc, POM fields)
+        // for every project that applies maven-publish. Wired into `check`.
+        if (project.subprojects.isEmpty()) {
+            PublicationValidator.register(project)
+        } else {
+            project.allprojects.forEach { PublicationValidator.register(it) }
         }
     }
 }

--- a/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/OctopusQualityPlugin.kt
+++ b/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/OctopusQualityPlugin.kt
@@ -77,10 +77,6 @@ class OctopusQualityPlugin : Plugin<Project> {
 
         // Validate Maven Central publication readiness (sources, javadoc, POM fields)
         // for every project that applies maven-publish. Wired into `check`.
-        if (project.subprojects.isEmpty()) {
-            PublicationValidator.register(project)
-        } else {
-            project.allprojects.forEach { PublicationValidator.register(it) }
-        }
+        project.allprojects.forEach { PublicationValidator.register(it) }
     }
 }

--- a/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/PublicationValidator.kt
+++ b/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/PublicationValidator.kt
@@ -114,20 +114,22 @@ internal object PublicationValidator {
                 .parse(pomFile)
         val root = doc.documentElement
 
-        fun textOf(tag: String): String? {
-            val nodes = root.getElementsByTagName(tag)
-            if (nodes.length == 0) return null
-            return nodes
-                .item(0)
-                .textContent
-                ?.trim()
-                ?.ifBlank { null }
-        }
+        // Only look at direct children of <project>, not nested descendants.
+        // This prevents <license><name> from satisfying the top-level <name> check.
+        val directChildren =
+            (0 until root.childNodes.length)
+                .map { root.childNodes.item(it) }
+                .filter { it.nodeType == org.w3c.dom.Node.ELEMENT_NODE }
+
+        fun directChild(tag: String): org.w3c.dom.Node? = directChildren.firstOrNull { it.nodeName == tag }
+
+        fun textOf(tag: String): String? = directChild(tag)?.textContent?.trim()?.ifBlank { null }
 
         fun hasChildElements(tag: String): Boolean {
-            val nodes = root.getElementsByTagName(tag)
-            if (nodes.length == 0) return false
-            return nodes.item(0).childNodes.length > 1
+            val node = directChild(tag) ?: return false
+            return (0 until node.childNodes.length).any {
+                node.childNodes.item(it).nodeType == org.w3c.dom.Node.ELEMENT_NODE
+            }
         }
 
         if (textOf("name").isNullOrBlank()) {
@@ -164,12 +166,21 @@ internal object PublicationValidator {
         }
     }
 
+    /**
+     * Detect pom-only publications: java-platform, BOM, version-catalog.
+     * A publication is pom-only if:
+     * - packaging is explicitly "pom", OR
+     * - it has no non-metadata artifacts (no jar, war, ear, etc.)
+     *
+     * Metadata-only classifiers (sources, javadoc) don't count as "real" artifacts.
+     */
     private fun isPomOnly(pub: MavenPublication): Boolean {
         if (pub.pom.packaging == "pom") return true
-        val hasJar =
-            pub.artifacts.any {
-                it.classifier == null && it.extension == "jar"
+        val metadataClassifiers = setOf("sources", "javadoc")
+        val hasRealArtifact =
+            pub.artifacts.any { artifact ->
+                artifact.classifier !in metadataClassifiers
             }
-        return !hasJar
+        return !hasRealArtifact
     }
 }

--- a/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/PublicationValidator.kt
+++ b/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/PublicationValidator.kt
@@ -157,12 +157,20 @@ internal object PublicationValidator {
         prefix: String,
         errors: MutableList<String>,
     ) {
-        val classifiers = pub.artifacts.map { it.classifier }.toSet()
-        if ("sources" !in classifiers) {
-            errors.add("$prefix: sources JAR missing (Maven Central requires it)")
+        // Maven Central requires -sources.jar and -javadoc.jar specifically (not .zip etc.)
+        val hasSourcesJar =
+            pub.artifacts.any {
+                it.classifier == "sources" && it.extension == "jar"
+            }
+        val hasJavadocJar =
+            pub.artifacts.any {
+                it.classifier == "javadoc" && it.extension == "jar"
+            }
+        if (!hasSourcesJar) {
+            errors.add("$prefix: sources JAR missing (Maven Central requires -sources.jar)")
         }
-        if ("javadoc" !in classifiers) {
-            errors.add("$prefix: javadoc JAR missing (Maven Central requires it)")
+        if (!hasJavadocJar) {
+            errors.add("$prefix: javadoc JAR missing (Maven Central requires -javadoc.jar)")
         }
     }
 

--- a/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/PublicationValidator.kt
+++ b/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/PublicationValidator.kt
@@ -1,0 +1,94 @@
+package org.octopusden.octopus.quality.internal
+
+import org.gradle.api.Project
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+
+/**
+ * Registers a `validatePublications` task that checks Maven Central readiness:
+ * - POM has required fields (name, description, url)
+ * - Publication includes sources and javadoc JARs
+ *
+ * Runs as part of `check` so issues are caught on PR, not at publish time.
+ */
+internal object PublicationValidator {
+    fun register(project: Project) {
+        // Only for projects that have maven-publish applied
+        project.plugins.withId("maven-publish") {
+            project.tasks.register("validatePublications") { task ->
+                task.group = "verification"
+                task.description =
+                    "Validates that Maven publications meet Central Portal requirements"
+                task.doLast {
+                    val publishing =
+                        project.extensions.getByType(PublishingExtension::class.java)
+                    val publications =
+                        publishing.publications.withType(MavenPublication::class.java)
+
+                    if (publications.isEmpty()) {
+                        project.logger.warn(
+                            "validatePublications: no MavenPublication found in ${project.path}",
+                        )
+                        return@doLast
+                    }
+
+                    val errors = mutableListOf<String>()
+
+                    for (pub in publications) {
+                        val prefix = "${project.path}:${pub.name}"
+
+                        if (pub.pom.name.orNull
+                                .isNullOrBlank()
+                        ) {
+                            errors.add("$prefix: POM <name> is missing or blank")
+                        }
+                        if (pub.pom.description.orNull
+                                .isNullOrBlank()
+                        ) {
+                            errors.add("$prefix: POM <description> is missing or blank")
+                        }
+                        if (pub.pom.url.orNull
+                                .isNullOrBlank()
+                        ) {
+                            errors.add("$prefix: POM <url> is missing or blank")
+                        }
+
+                        val classifiers = pub.artifacts.map { it.classifier }.toSet()
+                        if ("sources" !in classifiers) {
+                            errors.add(
+                                "$prefix: sources JAR missing (Maven Central requires it)",
+                            )
+                        }
+                        if ("javadoc" !in classifiers) {
+                            errors.add(
+                                "$prefix: javadoc JAR missing (Maven Central requires it)",
+                            )
+                        }
+                    }
+
+                    if (errors.isNotEmpty()) {
+                        val message =
+                            buildString {
+                                appendLine("Maven Central publication validation failed:")
+                                errors.forEach { appendLine("  - $it") }
+                                appendLine()
+                                appendLine(
+                                    "Fix these before publishing. " +
+                                        "See https://central.sonatype.org/publish/requirements/",
+                                )
+                            }
+                        throw org.gradle.api.GradleException(message)
+                    }
+
+                    project.logger.lifecycle(
+                        "validatePublications: ${publications.size} publication(s) " +
+                            "in ${project.path} passed Maven Central checks",
+                    )
+                }
+            }
+
+            // Wire into check so it runs on every PR build
+            project.tasks.named("check") { it.dependsOn("validatePublications") }
+        }
+    }
+}

--- a/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/PublicationValidator.kt
+++ b/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/PublicationValidator.kt
@@ -5,15 +5,19 @@ import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 
 /**
- * Registers a `validatePublications` task that checks Maven Central readiness:
- * - POM has required fields (name, description, url)
+ * Registers a `validatePublications` task that checks Maven Central readiness.
+ *
+ * For non-pom publications (jar, etc.):
+ * - POM has required fields: name, description, url, licenses, scm, developers
  * - Publication includes sources and javadoc JARs
+ *
+ * For pom-only publications (java-platform, BOM, version-catalog):
+ * - Only POM metadata is validated (no sources/javadoc required)
  *
  * Runs as part of `check` so issues are caught on PR, not at publish time.
  */
 internal object PublicationValidator {
     fun register(project: Project) {
-        // Only for projects that have maven-publish applied
         project.plugins.withId("maven-publish") {
             project.tasks.register("validatePublications") { task ->
                 task.group = "verification"
@@ -37,32 +41,10 @@ internal object PublicationValidator {
                     for (pub in publications) {
                         val prefix = "${project.path}:${pub.name}"
 
-                        if (pub.pom.name.orNull
-                                .isNullOrBlank()
-                        ) {
-                            errors.add("$prefix: POM <name> is missing or blank")
-                        }
-                        if (pub.pom.description.orNull
-                                .isNullOrBlank()
-                        ) {
-                            errors.add("$prefix: POM <description> is missing or blank")
-                        }
-                        if (pub.pom.url.orNull
-                                .isNullOrBlank()
-                        ) {
-                            errors.add("$prefix: POM <url> is missing or blank")
-                        }
+                        validatePomMetadata(pub, prefix, errors)
 
-                        val classifiers = pub.artifacts.map { it.classifier }.toSet()
-                        if ("sources" !in classifiers) {
-                            errors.add(
-                                "$prefix: sources JAR missing (Maven Central requires it)",
-                            )
-                        }
-                        if ("javadoc" !in classifiers) {
-                            errors.add(
-                                "$prefix: javadoc JAR missing (Maven Central requires it)",
-                            )
+                        if (!isPomOnly(pub)) {
+                            validateArtifacts(pub, prefix, errors)
                         }
                     }
 
@@ -87,8 +69,69 @@ internal object PublicationValidator {
                 }
             }
 
-            // Wire into check so it runs on every PR build
             project.tasks.named("check") { it.dependsOn("validatePublications") }
         }
+    }
+
+    private fun validatePomMetadata(
+        pub: MavenPublication,
+        prefix: String,
+        errors: MutableList<String>,
+    ) {
+        if (pub.pom.name.orNull
+                .isNullOrBlank()
+        ) {
+            errors.add("$prefix: POM <name> is missing or blank")
+        }
+        if (pub.pom.description.orNull
+                .isNullOrBlank()
+        ) {
+            errors.add("$prefix: POM <description> is missing or blank")
+        }
+        if (pub.pom.url.orNull
+                .isNullOrBlank()
+        ) {
+            errors.add("$prefix: POM <url> is missing or blank")
+        }
+
+        // licenses, scm, developers are configured via closures — check via the
+        // generated POM XML would require task ordering. Instead we check the
+        // action lists are non-empty (they're populated when the DSL closure runs).
+        // A pragmatic compromise: if pom.licenses {} was never called, the internal
+        // action list is empty. We access this via the public API nodes.
+        // Note: Gradle MavenPomLicenseSpec doesn't expose a count, so we validate
+        // by checking if the standard POM sections were configured at all.
+        // The pom.licenses/scm/developers blocks only have closure-based API,
+        // not queryable state. We validate what we can via Provider API.
+    }
+
+    private fun validateArtifacts(
+        pub: MavenPublication,
+        prefix: String,
+        errors: MutableList<String>,
+    ) {
+        val classifiers = pub.artifacts.map { it.classifier }.toSet()
+        if ("sources" !in classifiers) {
+            errors.add("$prefix: sources JAR missing (Maven Central requires it)")
+        }
+        if ("javadoc" !in classifiers) {
+            errors.add("$prefix: javadoc JAR missing (Maven Central requires it)")
+        }
+    }
+
+    /**
+     * Detect pom-only publications: java-platform, BOM, version-catalog.
+     * These don't produce a JAR and don't need sources/javadoc.
+     */
+    private fun isPomOnly(pub: MavenPublication): Boolean {
+        // If packaging is explicitly "pom", it's pom-only
+        if (pub.pom.packaging == "pom") return true
+
+        // If there are no artifacts at all (no main JAR), treat as pom-only
+        val hasJar =
+            pub.artifacts.any {
+                it.classifier == null && it.extension == "jar"
+            }
+        return !hasJar
     }
 }

--- a/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/PublicationValidator.kt
+++ b/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/PublicationValidator.kt
@@ -96,22 +96,27 @@ internal object PublicationValidator {
         prefix: String,
         errors: MutableList<String>,
     ) {
+        // Resolve POM file from the actual GenerateMavenPom task output (not hardcoded path)
+        val pubNameCap = pub.name.replaceFirstChar { it.uppercase() }
+        val pomTaskName = "generatePomFileFor${pubNameCap}Publication"
+        val pomTask = project.tasks.findByName(pomTaskName) as? GenerateMavenPom
         val pomFile =
-            project.layout.buildDirectory
-                .file("publications/${pub.name}/pom-default.xml")
-                .get()
-                .asFile
+            pomTask?.destination ?: run {
+                errors.add("$prefix: GenerateMavenPom task '$pomTaskName' not found")
+                return
+            }
 
         if (!pomFile.exists()) {
             errors.add("$prefix: generated POM not found at ${pomFile.path}")
             return
         }
 
-        val doc =
-            DocumentBuilderFactory
-                .newInstance()
-                .newDocumentBuilder()
-                .parse(pomFile)
+        val dbf = DocumentBuilderFactory.newInstance()
+        // Harden against XXE / entity expansion
+        dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+        dbf.setFeature("http://xml.org/sax/features/external-general-entities", false)
+        dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false)
+        val doc = dbf.newDocumentBuilder().parse(pomFile)
         val root = doc.documentElement
 
         // Only look at direct children of <project>, not nested descendants.

--- a/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/PublicationValidator.kt
+++ b/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/PublicationValidator.kt
@@ -3,9 +3,12 @@ package org.octopusden.octopus.quality.internal
 import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.publish.maven.tasks.GenerateMavenPom
+import javax.xml.parsers.DocumentBuilderFactory
 
 /**
- * Registers a `validatePublications` task that checks Maven Central readiness.
+ * Registers a `validatePublications` task that checks Maven Central readiness
+ * by parsing the generated POM XML files.
  *
  * For non-pom publications (jar, etc.):
  * - POM has required fields: name, description, url, licenses, scm, developers
@@ -14,95 +17,137 @@ import org.gradle.api.publish.maven.MavenPublication
  * For pom-only publications (java-platform, BOM, version-catalog):
  * - Only POM metadata is validated (no sources/javadoc required)
  *
- * Runs as part of `check` so issues are caught on PR, not at publish time.
+ * Wired into `check` (when available) so issues are caught on PR, not at publish time.
  */
 internal object PublicationValidator {
     fun register(project: Project) {
         project.plugins.withId("maven-publish") {
-            project.tasks.register("validatePublications") { task ->
-                task.group = "verification"
-                task.description =
-                    "Validates that Maven publications meet Central Portal requirements"
-                task.doLast {
-                    val publishing =
-                        project.extensions.getByType(PublishingExtension::class.java)
-                    val publications =
-                        publishing.publications.withType(MavenPublication::class.java)
+            val validateTask =
+                project.tasks.register("validatePublications") { task ->
+                    task.group = "verification"
+                    task.description =
+                        "Validates that Maven publications meet Central Portal requirements"
 
-                    if (publications.isEmpty()) {
-                        project.logger.warn(
-                            "validatePublications: no MavenPublication found in ${project.path}",
-                        )
-                        return@doLast
-                    }
-
-                    val errors = mutableListOf<String>()
-
-                    for (pub in publications) {
-                        val prefix = "${project.path}:${pub.name}"
-
-                        validatePomMetadata(pub, prefix, errors)
-
-                        if (!isPomOnly(pub)) {
-                            validateArtifacts(pub, prefix, errors)
-                        }
-                    }
-
-                    if (errors.isNotEmpty()) {
-                        val message =
-                            buildString {
-                                appendLine("Maven Central publication validation failed:")
-                                errors.forEach { appendLine("  - $it") }
-                                appendLine()
-                                appendLine(
-                                    "Fix these before publishing. " +
-                                        "See https://central.sonatype.org/publish/requirements/",
-                                )
-                            }
-                        throw org.gradle.api.GradleException(message)
-                    }
-
-                    project.logger.lifecycle(
-                        "validatePublications: ${publications.size} publication(s) " +
-                            "in ${project.path} passed Maven Central checks",
+                    // Depend on POM generation so we can parse the XML
+                    task.dependsOn(
+                        project.tasks.withType(GenerateMavenPom::class.java),
                     )
-                }
-            }
 
-            project.tasks.named("check") { it.dependsOn("validatePublications") }
+                    task.doLast {
+                        val publishing =
+                            project.extensions.getByType(PublishingExtension::class.java)
+                        val publications =
+                            publishing.publications.withType(MavenPublication::class.java)
+
+                        if (publications.isEmpty()) {
+                            project.logger.warn(
+                                "validatePublications: no MavenPublication found in ${project.path}",
+                            )
+                            return@doLast
+                        }
+
+                        val errors = mutableListOf<String>()
+
+                        for (pub in publications) {
+                            val prefix = "${project.path}:${pub.name}"
+                            val pomOnly = isPomOnly(pub)
+
+                            validatePomFromXml(project, pub, prefix, errors)
+
+                            if (!pomOnly) {
+                                validateArtifacts(pub, prefix, errors)
+                            }
+                        }
+
+                        if (errors.isNotEmpty()) {
+                            val message =
+                                buildString {
+                                    appendLine("Maven Central publication validation failed:")
+                                    errors.forEach { appendLine("  - $it") }
+                                    appendLine()
+                                    appendLine(
+                                        "Fix these before publishing. " +
+                                            "See https://central.sonatype.org/publish/requirements/",
+                                    )
+                                }
+                            throw org.gradle.api.GradleException(message)
+                        }
+
+                        project.logger.lifecycle(
+                            "validatePublications: ${publications.size} publication(s) " +
+                                "in ${project.path} passed Maven Central checks",
+                        )
+                    }
+                }
+
+            // Wire into check lazily — safe regardless of plugin application order
+            project.tasks.matching { it.name == "check" }.configureEach {
+                it.dependsOn(validateTask)
+            }
         }
     }
 
-    private fun validatePomMetadata(
+    /**
+     * Parse the generated POM XML and validate required Maven Central fields.
+     */
+    private fun validatePomFromXml(
+        project: Project,
         pub: MavenPublication,
         prefix: String,
         errors: MutableList<String>,
     ) {
-        if (pub.pom.name.orNull
-                .isNullOrBlank()
-        ) {
-            errors.add("$prefix: POM <name> is missing or blank")
-        }
-        if (pub.pom.description.orNull
-                .isNullOrBlank()
-        ) {
-            errors.add("$prefix: POM <description> is missing or blank")
-        }
-        if (pub.pom.url.orNull
-                .isNullOrBlank()
-        ) {
-            errors.add("$prefix: POM <url> is missing or blank")
+        val pomFile =
+            project.layout.buildDirectory
+                .file("publications/${pub.name}/pom-default.xml")
+                .get()
+                .asFile
+
+        if (!pomFile.exists()) {
+            errors.add("$prefix: generated POM not found at ${pomFile.path}")
+            return
         }
 
-        // licenses, scm, developers are configured via closures — check via the
-        // generated POM XML would require task ordering. Instead we check the
-        // action lists are non-empty (they're populated when the DSL closure runs).
-        // A pragmatic compromise: if pom.licenses {} was never called, the internal
-        // action list is empty. We access this via the public API nodes.
-        // Note: Gradle MavenPomLicenseSpec doesn't expose a count, so we validate
-        // by checking if the standard POM sections were configured at all.
-        // The pom.licenses/scm/developers blocks only have closure-based API,
-        // not queryable state. We validate what we can via Provider API.
+        val doc =
+            DocumentBuilderFactory
+                .newInstance()
+                .newDocumentBuilder()
+                .parse(pomFile)
+        val root = doc.documentElement
+
+        fun textOf(tag: String): String? {
+            val nodes = root.getElementsByTagName(tag)
+            if (nodes.length == 0) return null
+            return nodes
+                .item(0)
+                .textContent
+                ?.trim()
+                ?.ifBlank { null }
+        }
+
+        fun hasChildElements(tag: String): Boolean {
+            val nodes = root.getElementsByTagName(tag)
+            if (nodes.length == 0) return false
+            return nodes.item(0).childNodes.length > 1
+        }
+
+        if (textOf("name").isNullOrBlank()) {
+            errors.add("$prefix: POM <name> is missing or blank")
+        }
+        if (textOf("description").isNullOrBlank()) {
+            errors.add("$prefix: POM <description> is missing or blank")
+        }
+        if (textOf("url").isNullOrBlank()) {
+            errors.add("$prefix: POM <url> is missing or blank")
+        }
+        if (!hasChildElements("licenses")) {
+            errors.add("$prefix: POM <licenses> section is missing or empty")
+        }
+        if (!hasChildElements("developers")) {
+            errors.add("$prefix: POM <developers> section is missing or empty")
+        }
+        if (!hasChildElements("scm")) {
+            errors.add("$prefix: POM <scm> section is missing or empty")
+        }
     }
 
     private fun validateArtifacts(
@@ -119,15 +164,8 @@ internal object PublicationValidator {
         }
     }
 
-    /**
-     * Detect pom-only publications: java-platform, BOM, version-catalog.
-     * These don't produce a JAR and don't need sources/javadoc.
-     */
     private fun isPomOnly(pub: MavenPublication): Boolean {
-        // If packaging is explicitly "pom", it's pom-only
         if (pub.pom.packaging == "pom") return true
-
-        // If there are no artifacts at all (no main JAR), treat as pom-only
         val hasJar =
             pub.artifacts.any {
                 it.classifier == null && it.extension == "jar"

--- a/gradle-quality-plugin/src/test/kotlin/org/octopusden/octopus/quality/OctopusQualityPluginFunctionalTest.kt
+++ b/gradle-quality-plugin/src/test/kotlin/org/octopusden/octopus/quality/OctopusQualityPluginFunctionalTest.kt
@@ -12,6 +12,32 @@ class OctopusQualityPluginFunctionalTest {
     @TempDir
     lateinit var projectDir: File
 
+    /** Full POM that passes Maven Central requirements — used by validator tests. */
+    private val fullPom =
+        """
+        pom {
+            name.set("test")
+            description.set("test library")
+            url.set("https://example.com")
+            licenses {
+                license {
+                    name.set("The Apache License, Version 2.0")
+                    url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                }
+            }
+            scm {
+                url.set("https://github.com/octopusden/test")
+                connection.set("scm:git://github.com/octopusden/test.git")
+            }
+            developers {
+                developer {
+                    id.set("test")
+                    name.set("test")
+                }
+            }
+        }
+        """.trimIndent()
+
     private fun settingsFile(content: String) {
         File(projectDir, "settings.gradle.kts").writeText(content)
     }
@@ -235,34 +261,6 @@ class OctopusQualityPluginFunctionalTest {
     }
 
     // ---------------------------------------------------------------
-    // Helper: full POM that passes Central requirements
-    // ---------------------------------------------------------------
-    private val fullPom =
-        """
-        pom {
-            name.set("test")
-            description.set("test library")
-            url.set("https://example.com")
-            licenses {
-                license {
-                    name.set("The Apache License, Version 2.0")
-                    url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
-                }
-            }
-            scm {
-                url.set("https://github.com/octopusden/test")
-                connection.set("scm:git://github.com/octopusden/test.git")
-            }
-            developers {
-                developer {
-                    id.set("test")
-                    name.set("test")
-                }
-            }
-        }
-        """.trimIndent()
-
-    // ---------------------------------------------------------------
     // 6. Publication validator: valid jar publication passes
     // ---------------------------------------------------------------
     @Test
@@ -444,5 +442,55 @@ class OctopusQualityPluginFunctionalTest {
         val result = runner("validatePublications").build()
         assertEquals(TaskOutcome.SUCCESS, result.task(":validatePublications")?.outcome)
         assertTrue(result.output.contains("passed Maven Central checks"))
+    }
+
+    // ---------------------------------------------------------------
+    // 11. Nested <name> in licenses does not satisfy top-level <name>
+    // ---------------------------------------------------------------
+    @Test
+    fun `validatePublications rejects POM with nested name but no top-level name`() {
+        settingsFile(kotlinSettings("test-pub-nested-name"))
+        buildFile(
+            """
+            plugins {
+                kotlin("jvm") version "1.9.25"
+                `maven-publish`
+                id("org.octopusden.octopus-quality")
+            }
+            repositories { mavenCentral() }
+            group = "org.example"
+            version = "1.0.0"
+            java { withSourcesJar(); withJavadocJar() }
+            publishing {
+                publications {
+                    create<MavenPublication>("mavenJava") {
+                        from(components["java"])
+                        pom {
+                            // NO top-level name/description set
+                            url.set("https://example.com")
+                            licenses {
+                                license {
+                                    // This <name> is nested inside <license>, not top-level
+                                    name.set("Apache-2.0")
+                                    url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                                }
+                            }
+                            scm { url.set("https://github.com/octopusden/test") }
+                            developers { developer { id.set("test"); name.set("test") } }
+                        }
+                    }
+                }
+            }
+            octopusQuality { coverage { enabled.set(false) } }
+            """.trimIndent(),
+        )
+        writeKotlinFile("src/main/kotlin/com/example/Hello.kt", "package com.example\nfun hello() = 1\n")
+
+        val result = runner("validatePublications").buildAndFail()
+        // Must fail on BOTH top-level name and description
+        assertTrue(result.output.contains("POM <name> is missing"))
+        assertTrue(result.output.contains("POM <description> is missing"))
+        // url is set, so should NOT be in errors
+        assertTrue(!result.output.contains("POM <url> is missing"))
     }
 }

--- a/gradle-quality-plugin/src/test/kotlin/org/octopusden/octopus/quality/OctopusQualityPluginFunctionalTest.kt
+++ b/gradle-quality-plugin/src/test/kotlin/org/octopusden/octopus/quality/OctopusQualityPluginFunctionalTest.kt
@@ -235,6 +235,34 @@ class OctopusQualityPluginFunctionalTest {
     }
 
     // ---------------------------------------------------------------
+    // Helper: full POM that passes Central requirements
+    // ---------------------------------------------------------------
+    private val fullPom =
+        """
+        pom {
+            name.set("test")
+            description.set("test library")
+            url.set("https://example.com")
+            licenses {
+                license {
+                    name.set("The Apache License, Version 2.0")
+                    url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                }
+            }
+            scm {
+                url.set("https://github.com/octopusden/test")
+                connection.set("scm:git://github.com/octopusden/test.git")
+            }
+            developers {
+                developer {
+                    id.set("test")
+                    name.set("test")
+                }
+            }
+        }
+        """.trimIndent()
+
+    // ---------------------------------------------------------------
     // 6. Publication validator: valid jar publication passes
     // ---------------------------------------------------------------
     @Test
@@ -255,11 +283,7 @@ class OctopusQualityPluginFunctionalTest {
                 publications {
                     create<MavenPublication>("mavenJava") {
                         from(components["java"])
-                        pom {
-                            name.set("test")
-                            description.set("test library")
-                            url.set("https://example.com")
-                        }
+                        $fullPom
                     }
                 }
             }
@@ -294,11 +318,7 @@ class OctopusQualityPluginFunctionalTest {
                 publications {
                     create<MavenPublication>("mavenJava") {
                         from(components["java"])
-                        pom {
-                            name.set("test")
-                            description.set("test")
-                            url.set("https://example.com")
-                        }
+                        $fullPom
                     }
                 }
             }
@@ -332,11 +352,7 @@ class OctopusQualityPluginFunctionalTest {
                 publications {
                     create<MavenPublication>("mavenJava") {
                         from(components["java"])
-                        pom {
-                            name.set("test")
-                            description.set("test")
-                            url.set("https://example.com")
-                        }
+                        $fullPom
                     }
                 }
             }
@@ -370,7 +386,7 @@ class OctopusQualityPluginFunctionalTest {
                 publications {
                     create<MavenPublication>("mavenJava") {
                         from(components["java"])
-                        // no pom name/description/url
+                        // no pom metadata at all
                     }
                 }
             }
@@ -383,6 +399,9 @@ class OctopusQualityPluginFunctionalTest {
         assertTrue(result.output.contains("POM <name> is missing"))
         assertTrue(result.output.contains("POM <description> is missing"))
         assertTrue(result.output.contains("POM <url> is missing"))
+        assertTrue(result.output.contains("POM <licenses> section is missing"))
+        assertTrue(result.output.contains("POM <developers> section is missing"))
+        assertTrue(result.output.contains("POM <scm> section is missing"))
     }
 
     // ---------------------------------------------------------------
@@ -406,6 +425,14 @@ class OctopusQualityPluginFunctionalTest {
                             name.set("test-bom")
                             description.set("test BOM")
                             url.set("https://example.com")
+                            licenses {
+                                license {
+                                    name.set("Apache-2.0")
+                                    url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                                }
+                            }
+                            scm { url.set("https://github.com/octopusden/test") }
+                            developers { developer { id.set("test"); name.set("test") } }
                         }
                     }
                 }

--- a/gradle-quality-plugin/src/test/kotlin/org/octopusden/octopus/quality/OctopusQualityPluginFunctionalTest.kt
+++ b/gradle-quality-plugin/src/test/kotlin/org/octopusden/octopus/quality/OctopusQualityPluginFunctionalTest.kt
@@ -233,4 +233,189 @@ class OctopusQualityPluginFunctionalTest {
         assertTrue(result.output.contains(":test-utils:detekt"))
         assertTrue(result.output.contains(":app:detekt"))
     }
+
+    // ---------------------------------------------------------------
+    // 6. Publication validator: valid jar publication passes
+    // ---------------------------------------------------------------
+    @Test
+    fun `validatePublications passes for complete jar publication`() {
+        settingsFile(kotlinSettings("test-pub-valid"))
+        buildFile(
+            """
+            plugins {
+                kotlin("jvm") version "1.9.25"
+                `maven-publish`
+                id("org.octopusden.octopus-quality")
+            }
+            repositories { mavenCentral() }
+            group = "org.example"
+            version = "1.0.0"
+            java { withSourcesJar(); withJavadocJar() }
+            publishing {
+                publications {
+                    create<MavenPublication>("mavenJava") {
+                        from(components["java"])
+                        pom {
+                            name.set("test")
+                            description.set("test library")
+                            url.set("https://example.com")
+                        }
+                    }
+                }
+            }
+            octopusQuality { coverage { enabled.set(false) } }
+            """.trimIndent(),
+        )
+        writeKotlinFile("src/main/kotlin/com/example/Hello.kt", "package com.example\nfun hello() = 1\n")
+
+        val result = runner("validatePublications").build()
+        assertEquals(TaskOutcome.SUCCESS, result.task(":validatePublications")?.outcome)
+        assertTrue(result.output.contains("passed Maven Central checks"))
+    }
+
+    // ---------------------------------------------------------------
+    // 7. Publication validator: missing sources JAR fails
+    // ---------------------------------------------------------------
+    @Test
+    fun `validatePublications fails when sources JAR is missing`() {
+        settingsFile(kotlinSettings("test-pub-no-sources"))
+        buildFile(
+            """
+            plugins {
+                kotlin("jvm") version "1.9.25"
+                `maven-publish`
+                id("org.octopusden.octopus-quality")
+            }
+            repositories { mavenCentral() }
+            group = "org.example"
+            version = "1.0.0"
+            java { withJavadocJar() }
+            publishing {
+                publications {
+                    create<MavenPublication>("mavenJava") {
+                        from(components["java"])
+                        pom {
+                            name.set("test")
+                            description.set("test")
+                            url.set("https://example.com")
+                        }
+                    }
+                }
+            }
+            octopusQuality { coverage { enabled.set(false) } }
+            """.trimIndent(),
+        )
+        writeKotlinFile("src/main/kotlin/com/example/Hello.kt", "package com.example\nfun hello() = 1\n")
+
+        val result = runner("validatePublications").buildAndFail()
+        assertTrue(result.output.contains("sources JAR missing"))
+    }
+
+    // ---------------------------------------------------------------
+    // 8. Publication validator: missing javadoc JAR fails
+    // ---------------------------------------------------------------
+    @Test
+    fun `validatePublications fails when javadoc JAR is missing`() {
+        settingsFile(kotlinSettings("test-pub-no-javadoc"))
+        buildFile(
+            """
+            plugins {
+                kotlin("jvm") version "1.9.25"
+                `maven-publish`
+                id("org.octopusden.octopus-quality")
+            }
+            repositories { mavenCentral() }
+            group = "org.example"
+            version = "1.0.0"
+            java { withSourcesJar() }
+            publishing {
+                publications {
+                    create<MavenPublication>("mavenJava") {
+                        from(components["java"])
+                        pom {
+                            name.set("test")
+                            description.set("test")
+                            url.set("https://example.com")
+                        }
+                    }
+                }
+            }
+            octopusQuality { coverage { enabled.set(false) } }
+            """.trimIndent(),
+        )
+        writeKotlinFile("src/main/kotlin/com/example/Hello.kt", "package com.example\nfun hello() = 1\n")
+
+        val result = runner("validatePublications").buildAndFail()
+        assertTrue(result.output.contains("javadoc JAR missing"))
+    }
+
+    // ---------------------------------------------------------------
+    // 9. Publication validator: missing POM fields fail
+    // ---------------------------------------------------------------
+    @Test
+    fun `validatePublications fails when POM fields are missing`() {
+        settingsFile(kotlinSettings("test-pub-no-pom"))
+        buildFile(
+            """
+            plugins {
+                kotlin("jvm") version "1.9.25"
+                `maven-publish`
+                id("org.octopusden.octopus-quality")
+            }
+            repositories { mavenCentral() }
+            group = "org.example"
+            version = "1.0.0"
+            java { withSourcesJar(); withJavadocJar() }
+            publishing {
+                publications {
+                    create<MavenPublication>("mavenJava") {
+                        from(components["java"])
+                        // no pom name/description/url
+                    }
+                }
+            }
+            octopusQuality { coverage { enabled.set(false) } }
+            """.trimIndent(),
+        )
+        writeKotlinFile("src/main/kotlin/com/example/Hello.kt", "package com.example\nfun hello() = 1\n")
+
+        val result = runner("validatePublications").buildAndFail()
+        assertTrue(result.output.contains("POM <name> is missing"))
+        assertTrue(result.output.contains("POM <description> is missing"))
+        assertTrue(result.output.contains("POM <url> is missing"))
+    }
+
+    // ---------------------------------------------------------------
+    // 10. Publication validator: pom-only publication passes without sources/javadoc
+    // ---------------------------------------------------------------
+    @Test
+    fun `validatePublications passes for pom-only publication`() {
+        settingsFile(kotlinSettings("test-pub-pom-only"))
+        buildFile(
+            """
+            plugins {
+                `java-platform`
+                `maven-publish`
+                id("org.octopusden.octopus-quality")
+            }
+            publishing {
+                publications {
+                    create<MavenPublication>("bom") {
+                        from(components["javaPlatform"])
+                        pom {
+                            name.set("test-bom")
+                            description.set("test BOM")
+                            url.set("https://example.com")
+                        }
+                    }
+                }
+            }
+            octopusQuality { coverage { enabled.set(false) } }
+            """.trimIndent(),
+        )
+
+        val result = runner("validatePublications").build()
+        assertEquals(TaskOutcome.SUCCESS, result.task(":validatePublications")?.outcome)
+        assertTrue(result.output.contains("passed Maven Central checks"))
+    }
 }


### PR DESCRIPTION
## Summary

Fixes release failure (Sonatype staging close 400: missing sources/javadoc) and adds a reusable Maven Central publication validator to the convention plugin.

## Changes

### 1. Plugin build fix
`java.withJavadocJar()` and `java.withSourcesJar()` added to `gradle-quality-plugin/build.gradle.kts`.

### 2. Reusable PublicationValidator
`validatePublications` task auto-registered on any project with `maven-publish` + `org.octopusden.octopus-quality`. Wired into `check`.

**POM metadata** (parsed from generated POM XML, direct `<project>` children only):
- `name`, `description`, `url`, `licenses`, `developers`, `scm`

**Artifacts** (non-pom publications only):
- `-sources.jar` (classifier + extension check)
- `-javadoc.jar` (classifier + extension check)

**pom-only publications** (java-platform, BOM, version-catalog) exempt from artifact checks.

**Security**: XML parser hardened against XXE (disallow-doctype-decl, external entities disabled).

### 3. Plugin self-validation
`build.gradle.kts` has its own `validatePublications` task (wired into `check`) with the same POM + artifact checks — catches regressions like removed `withSourcesJar()` in Merge Gate.

### 4. Documentation
New "Maven Central Publication Validation" section in `docs/Octopus JVM Style Guidelines.md`:
- What is validated (tables)
- Consumer example with full POM
- pom-only exemption

## Tests

11 Gradle TestKit functional tests:

| # | Test | Expects |
|---|------|---------|
| 1-5 | Quality gates (existing) | Various PASS |
| 6 | Valid jar publication (full POM + sources + javadoc) | PASS |
| 7 | Missing sources JAR | FAIL |
| 8 | Missing javadoc JAR | FAIL |
| 9 | Missing POM fields (all 6) | FAIL |
| 10 | pom-only (java-platform) | PASS |
| 11 | Nested `<name>` in `<license>` (not top-level) | FAIL |

## Follow-up
- octopusden/octopus-test#43 — consumer integration test for validatePublications

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic validation of Maven Central publication requirements, checking POM metadata fields (name, description, URL, licenses, developers, SCM) and required artifact JARs (sources and javadoc).
  * Validation integrates into the build check phase.

* **Documentation**
  * Added Maven Central Publication Validation guidelines to style documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->