### PR TITLE
ci: formalize public/internal workflow convention with automated lint

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,130 @@
+# .github — Public/Internal Workflow Contract
+
+This document defines which workflows and composite actions in this repository
+are part of the **public API** (callable by consumer repos) and which are
+**internal** (used only within octopus-base itself).
+
+---
+
+## Public reusable workflows
+
+**Location:** `.github/workflows/common-*.yml`
+
+All files matching `common-*.yml` are public reusable workflows.  They expose
+`on: workflow_call:` and are meant to be called by consumer repositories via:
+
+```yaml
+uses: octopusden/octopus-base/.github/workflows/common-<name>.yml@<ref>
+```
+
+**Current public workflows:**
+
+| File | Purpose |
+|---|---|
+| `common-check-and-register-release.yml` | Check and register a release |
+| `common-docker-build-deploy.yml` | Docker image build and deploy |
+| `common-java-gradle-build.yml` | Java/Gradle build |
+| `common-java-gradle-quality-gates.yml` | Java/Gradle quality gates |
+| `common-java-gradle-release.yml` | Java/Gradle release |
+| `common-java-gradle-security-reports.yml` | Java/Gradle security reports |
+| `common-java-maven-build.yml` | Java/Maven build |
+| `common-java-maven-release.yml` | Java/Maven release |
+| `common-py-2-3-build-deploy.yml` | Python 2/3 build and deploy |
+| `common-py-build-deploy.yml` | Python build and deploy |
+| `common-py3-pysvn-build-deploy.yml` | Python 3 / pysvn build and deploy |
+| `common-register-release.yml` | Register a release |
+
+### Rules for public reusable workflows
+
+- MUST contain `workflow_call` in their `on:` triggers.
+- MUST NOT reference `.github/actions/internal/` paths (reserved for internal
+  use only).
+- MUST NOT call internal workflows (i.e., workflows without `workflow_call`).
+
+---
+
+## Internal workflows
+
+**Location:** `.github/workflows/` — any file that does **not** match
+`common-*.yml`
+
+These workflows are triggered by events within octopus-base only (push, pull
+request, schedule, etc.) and are **not** intended to be reused by consumers.
+
+**Current internal workflows:**
+
+| File | Purpose |
+|---|---|
+| `check-octopus-test-consumer.yml` | CI checks run against the octopus-test-consumer repo |
+| `release-octopus-base.yml` | Releases octopus-base itself |
+| `verify-octopus-test-consumer.yml` | Verifies the octopus-test-consumer integration (see note below) |
+
+### Internal workflows that expose `workflow_call`
+
+Some internal workflows declare `on: workflow_call:` for **local composition**
+only — they are called by other workflows in this repository but are still
+internal and MUST NOT be called by external consumer repositories.
+
+| File | Called by | Reason for `workflow_call` |
+|---|---|---|
+| `verify-octopus-test-consumer.yml` | `check-octopus-test-consumer.yml` | Allows the check workflow to reuse the verification logic as a named job |
+
+**Key distinction:**
+
+- `common-*.yml` — **public API**: stable contract, versioned, callable by any
+  consumer repository.
+- Non-`common-*` workflows with `workflow_call` — **internal composition**:
+  `workflow_call` is an implementation detail for local orchestration only.
+  Calling them from outside octopus-base is unsupported and may break without
+  notice.
+
+---
+
+## Public composite actions
+
+**Location:** `.github/actions/<name>/action.yml`
+
+Composite actions placed directly under `.github/actions/` are public and may
+be referenced by consumer repos:
+
+```yaml
+uses: octopusden/octopus-base/.github/actions/<name>@<ref>
+```
+
+**Current public composite actions:**
+
+| Directory | Purpose |
+|---|---|
+| `get-version/` | Resolve the project version from Gradle or Maven |
+
+Upcoming: `merge-gate/` (planned for Step 2.3).
+
+---
+
+## Internal composite actions
+
+**Location:** `.github/actions/internal/<name>/action.yml`
+
+The `internal/` sub-namespace is reserved for composite actions that are
+implementation details of public workflows and MUST NOT be called directly by
+consumers.  None exist today; the namespace is reserved to keep the public
+surface clean.
+
+---
+
+## Adding a new reusable workflow
+
+1. Create `.github/workflows/common-<name>.yml`.
+2. Ensure `on:` includes `workflow_call:` (with all required/optional inputs
+   and secrets declared).
+3. Do not reference `.github/actions/internal/` from this file.
+4. Update the table in this README.
+5. The automated lint (`validate-workflow-naming.sh`) will enforce rules 2–3
+   in CI.
+
+## Adding a new composite action
+
+- **Public:** create `.github/actions/<name>/action.yml` and add it to the
+  table above.
+- **Internal:** create `.github/actions/internal/<name>/action.yml`.  Add a
+  comment in the file header stating it is internal-only.

--- a/.github/scripts/validate-workflow-naming.sh
+++ b/.github/scripts/validate-workflow-naming.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# validate-workflow-naming.sh — Lint public reusable workflow naming convention.
+#
+# Rules enforced:
+#   1. Every common-*.yml in .github/workflows/ MUST contain a workflow_call trigger.
+#   2. Every common-*.yml MUST NOT reference .github/actions/internal/ paths.
+#   3. Every common-*.yml MUST NOT call a non-common local workflow via uses: ./.github/workflows/<non-common>.yml.
+#   4. (Advisory) Non-common-*.yml workflows that expose workflow_call MUST be in the
+#      known-exceptions whitelist below; unrecognised occurrences emit a WARNING but
+#      do not fail the build, so a human can decide whether to whitelist or fix them.
+#
+# Usage: validate-workflow-naming.sh [repo-dir]
+
+set -euo pipefail
+
+if [[ $# -gt 1 ]]; then
+  echo "Usage: $0 [repo-dir]"
+  exit 1
+fi
+
+repo_dir="${1:-$PWD}"
+workflows_dir="$repo_dir/.github/workflows"
+
+if [[ ! -d "$workflows_dir" ]]; then
+  echo "Workflow directory '$workflows_dir' does not exist"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Rule 4 whitelist — non-common-*.yml workflows that are permitted to expose
+# workflow_call for internal composition only (called locally within this
+# repo, never by external consumers).  Add filenames (basename only) here
+# when a new internal-composition workflow is introduced.
+# ---------------------------------------------------------------------------
+readonly INTERNAL_WORKFLOW_CALL_WHITELIST=(
+  "verify-octopus-test-consumer.yml"  # called by check-octopus-test-consumer.yml
+)
+
+# Helper: return 0 if $1 is in the whitelist, 1 otherwise.
+is_whitelisted() {
+  local name="$1"
+  local entry
+  for entry in "${INTERNAL_WORKFLOW_CALL_WHITELIST[@]}"; do
+    [[ "$entry" == "$name" ]] && return 0
+  done
+  return 1
+}
+
+failed=0
+
+while IFS= read -r -d '' file; do
+  # Rule 1: common-*.yml must have a workflow_call trigger.
+  if ! grep -q 'workflow_call' "$file"; then
+    echo "FAIL [no workflow_call] $file"
+    failed=$((failed + 1))
+  fi
+
+  # Rule 2: common-*.yml must not reference actions/internal/.
+  if grep -q 'actions/internal/' "$file"; then
+    echo "FAIL [references actions/internal/] $file"
+    grep -n 'actions/internal/' "$file" | while IFS= read -r match; do
+      echo "  $match"
+    done
+    failed=$((failed + 1))
+  fi
+
+  # Rule 3: common-*.yml must not call a non-common local workflow.
+  while IFS= read -r match; do
+    # Extract the workflow path from the uses: value
+    ref="${match#*uses:}"
+    ref="${ref// /}"
+    ref="${ref##*/}"  # keep only the filename
+    if [[ "$ref" != common-* ]]; then
+      echo "FAIL [calls non-common workflow: $ref] $file"
+      failed=$((failed + 1))
+    fi
+  done < <(grep -E 'uses:[[:space:]]+\./.github/workflows/' "$file" || true)
+done < <(find "$workflows_dir" -maxdepth 1 -type f -name 'common-*.yml' -print0 | sort -z)
+
+if [[ "$failed" -ne 0 ]]; then
+  echo "Workflow naming convention validation failed: ${failed} violation(s)."
+  exit 1
+fi
+
+echo "All common-*.yml files pass naming convention checks."
+
+# ---------------------------------------------------------------------------
+# Rule 4 (advisory): warn about non-common-*.yml workflows that expose
+# workflow_call but are not in the whitelist.
+# ---------------------------------------------------------------------------
+warnings=0
+while IFS= read -r -d '' file; do
+  basename_file="$(basename "$file")"
+  if grep -q 'workflow_call' "$file"; then
+    if ! is_whitelisted "$basename_file"; then
+      echo "WARNING [non-common workflow exposes workflow_call — add to whitelist if intentional] $file"
+      warnings=$((warnings + 1))
+    fi
+  fi
+done < <(find "$workflows_dir" -maxdepth 1 -type f -name '*.yml' ! -name 'common-*.yml' -print0 | sort -z)
+
+if [[ "$warnings" -ne 0 ]]; then
+  echo "Rule 4 advisory: ${warnings} non-common workflow(s) expose workflow_call outside the whitelist. Review and update INTERNAL_WORKFLOW_CALL_WHITELIST if intentional."
+fi

--- a/.github/workflows/check-octopus-test-consumer.yml
+++ b/.github/workflows/check-octopus-test-consumer.yml
@@ -99,6 +99,9 @@ jobs:
           while IFS= read -r script; do
             bash -n "$script"
           done < <(find .github/scripts -type f -name '*.sh' | sort)
+      - name: Validate workflow naming convention
+        shell: bash
+        run: bash .github/scripts/validate-workflow-naming.sh .
 
   security:
     name: security


### PR DESCRIPTION
## Summary
- Add `.github/README.md` documenting the public (`common-*`) vs internal workflow contract
- Add `validate-workflow-naming.sh` enforcing 3 rules + advisory Rule 4 (whitelist for internal `workflow_call`)
- Wire lint into the `workflow-lint` job in `check-octopus-test-consumer.yml`

**Step 2.2** of the [quality gates rollout plan](https://github.com/octopusden/octopus-base/issues/113).

## Test plan
- [ ] `workflow-lint` job passes on this PR (no false positives)
- [ ] Deliberately violating PR (e.g. remove `workflow_call` from a `common-*.yml`) fails the lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)