### PR TITLE
ci: add shared merge-gate composite action for consumer repos

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -96,8 +96,7 @@ uses: octopusden/octopus-base/.github/actions/<name>@<ref>
 | Directory | Purpose |
 |---|---|
 | `get-version/` | Resolve the project version from Gradle or Maven |
-
-Upcoming: `merge-gate/` (planned for Step 2.3).
+| `merge-gate/` | Aggregate upstream job results; fails unless every job reports "success" |
 
 ---
 

--- a/.github/actions/merge-gate/action.yml
+++ b/.github/actions/merge-gate/action.yml
@@ -1,0 +1,33 @@
+name: Merge Gate
+description: >
+  Aggregates job results from the merge-gate workflow.
+  Fails unless every upstream job reports "success".
+
+inputs:
+  needs:
+    description: 'JSON object from ${{ toJson(needs) }}'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Validate gate results
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        results='${{ inputs.needs }}'
+        failed="$(jq -r 'to_entries[] | select(.value.result != "success") | "\(.key): \(.value.result)"' <<<"${results}")"
+
+        {
+          echo "### Merge gate results"
+          jq -r 'to_entries[] | "- \(.key): \(.value.result)"' <<<"${results}"
+        } >> "${GITHUB_STEP_SUMMARY}"
+
+        if [[ -n "${failed}" ]]; then
+          echo "::error::Merge gate failed"
+          echo "${failed}"
+          exit 1
+        fi
+
+        echo "Merge gate passed."

--- a/.github/workflows/test-merge-gate-action.yml
+++ b/.github/workflows/test-merge-gate-action.yml
@@ -1,0 +1,56 @@
+name: Test merge-gate action (manual smoke test)
+
+on:
+  workflow_dispatch:
+
+jobs:
+
+  job-success:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Succeed
+        run: exit 0
+
+  job-failure:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Fail
+        run: exit 1
+
+  job-skipped:
+    runs-on: ubuntu-latest
+    if: false
+    steps:
+      - name: Never runs
+        run: exit 0
+
+  gate-all-success:
+    needs: [job-success]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run merge gate (expect PASS)
+        uses: ./.github/actions/merge-gate
+        with:
+          needs: ${{ toJson(needs) }}
+
+  gate-mixed:
+    needs: [job-success, job-failure, job-skipped]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run merge gate (expect FAIL)
+        id: gate
+        uses: ./.github/actions/merge-gate
+        with:
+          needs: ${{ toJson(needs) }}
+        continue-on-error: true
+      - name: Assert gate failed
+        run: |
+          if [[ "${{ steps.gate.outcome }}" != "failure" ]]; then
+            echo "::error::Expected gate-mixed to fail, but outcome was: ${{ steps.gate.outcome }}"
+            exit 1
+          fi
+          echo "gate-mixed correctly failed as expected."


### PR DESCRIPTION
## Summary
- Add `.github/actions/merge-gate/action.yml` — composite action aggregating `needs.*.result`, fails unless all `"success"`
- Add `test-merge-gate-action.yml` synthetic test (workflow_dispatch only) exercising success, failure, and skipped cases
- Update `.github/README.md` to list `merge-gate/` as a public composite action

**Step 2.3** of the [quality gates rollout plan](https://github.com/octopusden/octopus-base/issues/113).
Stacked on #121 (Step 2.2).

## Test plan
- [ ] After merge, trigger `test-merge-gate-action.yml` via workflow_dispatch
- [ ] `gate-all-success` job passes; `gate-mixed` job correctly detects failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)