### PR TITLE
ci: add ruleset infrastructure with sync workflow (evaluate mode)

### DIFF
--- a/.github/rulesets/jvm-strict.json
+++ b/.github/rulesets/jvm-strict.json
@@ -1,0 +1,50 @@
+{
+  "name": "jvm-strict",
+  "target": "branch",
+  "enforcement": "evaluate",
+  "do_not_enforce_on_create": true,
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "bypass_actors": [],
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": true,
+        "required_approving_review_count": 2,
+        "required_review_thread_resolution": true,
+        "allowed_merge_methods": ["merge", "squash", "rebase"]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "required_status_checks": [
+          {
+            "context": "gate/merge",
+            "integration_id": null
+          },
+          {
+            "context": "GitGuardian Security Checks",
+            "integration_id": null
+          }
+        ]
+      }
+    },
+    {
+      "type": "required_linear_history"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "deletion"
+    }
+  ]
+}

--- a/.github/rulesets/jvm-strict.targets.txt
+++ b/.github/rulesets/jvm-strict.targets.txt
@@ -1,0 +1,1 @@
+octopusden/octopus-base

--- a/.github/workflows/sync-rulesets.yml
+++ b/.github/workflows/sync-rulesets.yml
@@ -1,0 +1,96 @@
+name: Sync Repository Rulesets
+
+on:
+  # NOTE: push trigger is deliberately disabled for initial rollout.
+  # The first sync must be operator-triggered via workflow_dispatch to control timing.
+  # After validating evaluate-mode behavior, uncomment the push trigger:
+  #
+  # push:
+  #   branches: [main]
+  #   paths:
+  #     - '.github/rulesets/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    name: sync-rulesets
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Sync rulesets to targets
+        env:
+          GH_TOKEN: ${{ secrets.RULESETS_ADMIN_TOKEN }}
+        shell: bash
+        run: |
+          set -uo pipefail
+
+          # Pre-flight: verify token
+          if ! gh api user --jq '.login' >/dev/null 2>&1; then
+            echo "::error::RULESETS_ADMIN_TOKEN is invalid or expired"
+            exit 1
+          fi
+          echo "Authenticated as: $(gh api user --jq '.login')"
+
+          ruleset_file=".github/rulesets/jvm-strict.json"
+          targets_file=".github/rulesets/jvm-strict.targets.txt"
+          ruleset_name="jvm-strict"
+          failed=0
+          total=0
+          skipped=0
+
+          while IFS= read -r repo; do
+            # Skip empty lines and comments
+            [[ -z "${repo}" || "${repo}" == \#* ]] && continue
+            total=$((total + 1))
+
+            echo "--- Processing: ${repo}"
+
+            # Check if archived
+            archived="$(gh api "repos/${repo}" --jq '.archived' 2>/dev/null)" || true
+            if [[ "${archived}" == "true" ]]; then
+              echo "  SKIP: ${repo} is archived"
+              skipped=$((skipped + 1))
+              sleep 1
+              continue
+            fi
+
+            # Check for existing ruleset
+            existing_id="$(gh api "repos/${repo}/rulesets" --jq ".[] | select(.name == \"${ruleset_name}\") | .id" 2>/dev/null)" || true
+
+            if [[ -n "${existing_id}" ]]; then
+              echo "  Updating existing ruleset (id: ${existing_id})"
+              if output="$(gh api "repos/${repo}/rulesets/${existing_id}" \
+                --method PUT \
+                --input "${ruleset_file}" 2>&1)"; then
+                echo "  OK: updated"
+              else
+                echo "  FAIL: update failed for ${repo}: ${output}"
+                failed=$((failed + 1))
+              fi
+            else
+              echo "  Creating new ruleset"
+              if output="$(gh api "repos/${repo}/rulesets" \
+                --method POST \
+                --input "${ruleset_file}" 2>&1)"; then
+                echo "  OK: created"
+              else
+                echo "  FAIL: create failed for ${repo}: ${output}"
+                failed=$((failed + 1))
+              fi
+            fi
+
+            sleep 1
+          done < "${targets_file}"
+
+          echo ""
+          echo "=== Summary ==="
+          echo "Total: ${total}, Skipped: ${skipped}, Failed: ${failed}"
+
+          if [[ "${failed}" -gt 0 ]]; then
+            echo "::error::${failed} repo(s) failed ruleset sync"
+            exit 1
+          fi

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -1,0 +1,95 @@
+# Branch Protection via Repository Rulesets
+
+This document describes how the `jvm-strict` GitHub repository ruleset is managed, what it enforces, and how to opt repos in or out.
+
+## What `jvm-strict` Enforces
+
+The ruleset targets the **default branch** of each enrolled repository and enforces the following rules:
+
+| Rule | Detail |
+|---|---|
+| **Pull request reviews** | 2 approving reviews required before merge |
+| **Code-owner review** | At least one approval must come from a code owner |
+| **Stale review dismissal** | Approvals are dismissed when new commits are pushed |
+| **Thread resolution** | All review comment threads must be resolved before merge |
+| **Required status checks** | `gate/merge` and `GitGuardian Security Checks` must pass |
+| **Linear history** | Merge commits that rewrite history are blocked |
+| **No force-push** | `non_fast_forward` rule prevents rewriting history |
+| **No branch deletion** | The default branch cannot be deleted |
+
+## Evaluate vs Active Mode
+
+The ruleset is initially deployed in **evaluate (shadow) mode** (`"enforcement": "evaluate"`). In this mode:
+
+- Rules are evaluated but **not enforced** — PRs and pushes are not blocked.
+- Violations are visible in the GitHub UI under _Insights → Rule insights_ for each repository.
+- This allows teams to observe compliance before hard enforcement begins.
+
+When the rollout is ready to enforce, update the `enforcement` field in `jvm-strict.json` to `"active"` and merge to `main`, then manually trigger the `sync-rulesets` workflow. The sync will propagate the change to all enrolled repos.
+
+## Opting a Repo In
+
+1. Open a PR against `octopus-base` `main` branch.
+2. Add one line to `.github/rulesets/jvm-strict.targets.txt`:
+   ```
+   octopusden/<repo-name>
+   ```
+3. Get the PR approved and merged.
+4. Trigger the `sync-rulesets` workflow manually via **Actions → Sync Repository Rulesets → Run workflow**. The push trigger is disabled during initial rollout; after the rollout stabilizes, it will be enabled for automatic sync on merge.
+
+The token used (`RULESETS_ADMIN_TOKEN`) must have admin access to the target repository.
+
+## Opting a Repo Out
+
+Opting out is a two-step process:
+
+**Step 1 — Stop future syncs.** Remove the repo line from `jvm-strict.targets.txt` via a PR. Once merged, the workflow will no longer touch that repo.
+
+**Step 2 — Remove the existing ruleset.** Find the ruleset ID and delete it:
+
+```bash
+# List rulesets to find the ID
+gh api repos/octopusden/<repo-name>/rulesets --jq '.[] | select(.name == "jvm-strict") | {id, name}'
+
+# Delete by ID
+gh api repos/octopusden/<repo-name>/rulesets/<id> --method DELETE
+```
+
+Skipping Step 2 leaves the ruleset in place on the repo even though the sync no longer manages it.
+
+## Emergency Rollback
+
+If the ruleset causes unexpected issues across all repos, perform a full rollback:
+
+### Option A — Switch back to evaluate mode (preferred)
+
+1. Edit `jvm-strict.json`: change `"enforcement": "active"` → `"enforcement": "evaluate"`.
+2. Merge to `main`, then manually trigger the `sync-rulesets` workflow via **Actions → Sync Repository Rulesets → Run workflow**. The sync will propagate the change to all enrolled repos.
+
+### Option B — Remove the ruleset from all repos
+
+Run the following script locally with a token that has admin access:
+
+```bash
+export GH_TOKEN="<your-admin-token>"
+while IFS= read -r repo; do
+  [[ -z "${repo}" || "${repo}" == \#* ]] && continue
+  id="$(gh api "repos/${repo}/rulesets" --jq '.[] | select(.name == "jvm-strict") | .id' 2>/dev/null)" || true
+  if [[ -n "${id}" ]]; then
+    echo "Deleting ruleset ${id} from ${repo}"
+    gh api "repos/${repo}/rulesets/${id}" --method DELETE
+  fi
+  sleep 1
+done < .github/rulesets/jvm-strict.targets.txt
+```
+
+After the emergency is resolved, restore the ruleset by re-merging `jvm-strict.json` (or updating enforcement mode) so the sync workflow recreates it.
+
+## Sync Workflow Details
+
+The `sync-rulesets.yml` workflow (`Sync Repository Rulesets`) currently runs on:
+- Manual trigger via `workflow_dispatch` only
+
+> **Note:** The push trigger (on changes to `.github/rulesets/**`) is commented out during initial rollout to ensure the first sync is operator-controlled. After validating evaluate-mode behavior, uncomment the push trigger in `sync-rulesets.yml` to enable automatic sync on merge.
+
+It requires the `RULESETS_ADMIN_TOKEN` repository secret. Archived repositories are automatically skipped. Failures per repo are accumulated and reported at the end; the job exits non-zero if any repo fails, so CI is red but all repos are attempted.


### PR DESCRIPTION
## Summary
- Add `.github/rulesets/jvm-strict.json` — evaluate mode, 2 approvals, `gate/merge` + `GitGuardian` required checks, `do_not_enforce_on_create: true`
- Add `.github/rulesets/jvm-strict.targets.txt` with `octopusden/octopus-base` as initial target
- Add `.github/workflows/sync-rulesets.yml` — fault-tolerant sync (workflow_dispatch only for initial rollout; push trigger commented out)
- Add `docs/branch-protection.md` — onboarding, opt-in/opt-out, rollback procedure

**Step 2.4** of the [quality gates rollout plan](https://github.com/octopusden/octopus-base/issues/113).
Stacked on #120 (Step 2.1).

## Operator actions required
- [ ] Create fine-grained PAT with `Administration: write`, store as `RULESETS_ADMIN_TOKEN` secret
- [ ] After merge, manually trigger `sync-rulesets.yml` via workflow_dispatch
- [ ] Observe evaluate-mode behavior on test PRs before proceeding to Step 2.5

## Test plan
- [ ] `gh api repos/octopusden/octopus-base/rulesets` shows `jvm-strict` with `enforcement: "evaluate"` after manual sync
- [ ] Test PR shows "would block" in Rule Insights but merge button stays enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)