### PR TITLE
ci: add sub-agent prompt templates for quality-gates rollout

### DIFF
--- a/.agents/prompts/consumer-implementer.md
+++ b/.agents/prompts/consumer-implementer.md
@@ -1,0 +1,227 @@
+# Sub-Agent Playbook: Consumer Quality-Gates Implementer
+
+## Purpose
+
+Apply the octopusden quality-gates convention to a consumer JVM repository so that
+every pull request is blocked by a mandatory `gate/merge` status check.
+
+## Parameters (filled in by the orchestrator before dispatching this agent)
+
+| Placeholder          | Example value              | Meaning                                                            |
+|----------------------|----------------------------|--------------------------------------------------------------------|
+| `{{REPO_NAME}}`      | `octopus-release-plugin`   | GitHub repository name (under the `octopusden` org)               |
+| `{{JAVA_VERSION}}`   | `17`                       | JDK version used by the repo's CI runtime                         |
+| `{{FLOW_TYPE}}`      | `public` \| `hybrid`           | Build flow type passed to `common-java-gradle-build.yml`; `public` runs tests, `hybrid` can skip them |
+| `{{FT_EXCLUSIONS}}`  | `"integrationTest", ":ft:test"` | Fully quoted Kotlin argument list of Gradle task names/paths to exclude from the gate (or empty). The orchestrator must supply the value already formatted with double-quoted strings and commas so that `excludeTasks({{FT_EXCLUSIONS}})` is valid Kotlin DSL — e.g. `"integrationTest", ":ft:test"`. |
+| `{{COVERAGE_ENABLED}}` | `true` \| `false`        | Whether to configure Kover coverage gates                         |
+| `{{LANGUAGES}}`      | `kotlin,java`              | Comma-separated set of languages detected in `src/`               |
+
+---
+
+## Step 1 — Apply the convention plugin
+
+Open `build.gradle.kts` (root project) and add the quality plugin to the `plugins {}` block:
+
+```kotlin
+plugins {
+    // …existing plugins…
+    id("org.octopusden.octopus-quality")
+}
+```
+
+If `{{COVERAGE_ENABLED}}` is `true`, also add a coverage override block after the `plugins {}` block
+(adjust the threshold values to *current measured coverage + 5 percentage points*):
+
+```kotlin
+octopusQuality {
+    coverage {
+        minimumLineCoverage.set(java.math.BigDecimal("0.10"))   // per-module minimum
+        overallMinimum.set(java.math.BigDecimal("0.72"))        // e.g. 0.72 if current coverage is 67 %
+    }
+}
+```
+
+If `{{COVERAGE_ENABLED}}` is `false`:
+
+```kotlin
+octopusQuality {
+    coverage {
+        enabled.set(false)
+    }
+}
+```
+
+If `{{FT_EXCLUSIONS}}` is non-empty, add task exclusions:
+
+```kotlin
+octopusQuality {
+    excludeTasks({{FT_EXCLUSIONS}})   // e.g. excludeTasks("integrationTest", ":ft:test")
+}
+```
+
+---
+
+## Step 2 — Plugin version declarations (Kotlin repos only)
+
+When `{{LANGUAGES}}` contains `kotlin`, open `settings.gradle.kts` and ensure the
+`pluginManagement { plugins { … } }` block declares exact versions for:
+
+```kotlin
+pluginManagement {
+    plugins {
+        // …existing entries…
+        id("io.gitlab.arturbosch.detekt")      version "<detekt-version>"
+        id("org.jlleitschuh.gradle.ktlint")    version "<ktlint-plugin-version>"
+        id("org.jetbrains.kotlinx.kover")      version "<kover-version>"
+    }
+}
+```
+
+Use the versions that are already pinned in `octopus-base/gradle-quality-plugin/gradle.properties`
+(or `libs.versions.toml` if the consumer has one). Do **not** introduce a second copy of a version
+that is already declared.
+
+---
+
+## Step 3 — Generate baselines (Kotlin repos only)
+
+When `{{LANGUAGES}}` contains `kotlin`, run:
+
+```bash
+./gradlew detektBaseline
+./gradlew ktlintGenerateBaseline
+```
+
+Commit the generated baseline files together with the rest of the changes:
+
+- `detekt-baseline.xml` (root and any sub-project locations)
+- `.editorconfig` or `ktlint-baseline.xml` artefacts produced by `ktlintGenerateBaseline`
+
+---
+
+## Step 4 — Add workflow files
+
+Create or replace the three files below.  
+**Keep the `# PUBLIC —` or `# INTERNAL —` comment on the first line of each file exactly as shown; it is required by the workflow naming linter.**
+
+### 4a. `.github/workflows/merge-gate.yml`
+
+```yaml
+# PUBLIC — every PR triggers this workflow and the gate/merge check must be green to merge.
+name: Merge Gate
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@<version>
+    with:
+      java-version: '{{JAVA_VERSION}}'
+      flow-type: '{{FLOW_TYPE}}'
+    secrets: inherit
+
+  quality:
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@<version>
+    with:
+      java-version: '{{JAVA_VERSION}}'
+    secrets: inherit
+
+  security:
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@<version>
+    with:
+      java-version: '{{JAVA_VERSION}}'
+    secrets: inherit
+
+  gate-merge:
+    name: gate/merge
+    needs: [ build, quality, security ]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: octopusden/octopus-base/.github/actions/merge-gate@<version>
+        with:
+          needs: ${{ toJson(needs) }}
+```
+
+Replace `<version>` with the current semver release tag of `octopus-base` (e.g. `v2.0.3`).
+Do **not** use `@main`.
+
+### 4b. `.github/workflows/quality.yml`
+
+```yaml
+# INTERNAL — triggered on push to main and manually; never on pull_request.
+name: Quality
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  quality:
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@<version>
+    with:
+      java-version: '{{JAVA_VERSION}}'
+    secrets: inherit
+```
+
+### 4c. `.github/workflows/security.yml`
+
+```yaml
+# INTERNAL — triggered on push to main, nightly, and manually; never on pull_request.
+name: Security
+
+on:
+  push:
+    branches: [ main ]
+  schedule:
+    - cron: '0 3 * * 1'   # every Monday at 03:00 UTC
+  workflow_dispatch:
+
+jobs:
+  security:
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@<version>
+    with:
+      java-version: '{{JAVA_VERSION}}'
+    secrets: inherit
+```
+
+---
+
+## Step 5 — Strip `pull_request:` from existing workflows
+
+If `quality.yml` or `security.yml` already exist and have a `pull_request:` trigger, remove it.
+
+```yaml
+# BEFORE
+on:
+  push:
+    branches: [ main ]
+  pull_request:           # <-- remove this block entirely
+
+# AFTER
+on:
+  push:
+    branches: [ main ]
+```
+
+---
+
+## Step 6 — Commit and open a PR
+
+Stage all changed and new files, then commit with exactly this message:
+
+```
+chore: enable quality gates
+```
+
+Open a pull-request with:
+
+- **Title:** `chore: enable quality gates for {{REPO_NAME}}`
+- **Base branch:** `main`
+- **Body:** brief description of what changed (plugin applied, workflows added, baselines committed)
+
+Do **not** merge; wait for the `pr-reviewer` agent to approve.

--- a/.agents/prompts/discovery.md
+++ b/.agents/prompts/discovery.md
@@ -1,0 +1,210 @@
+# Sub-Agent Playbook: Repository Discovery & Classification
+
+## Purpose
+
+Produce a structured classification report for a consumer JVM repository so that the
+orchestrator can fill in the template parameters required by `consumer-implementer.md`.
+
+## Parameter (filled in by the orchestrator)
+
+| Placeholder    | Example value              |
+|----------------|----------------------------|
+| `{{REPO_NAME}}`| `octopus-release-plugin`   |
+
+---
+
+## Procedure
+
+Work through each detection step below.  Collect all findings; do **not** stop early.
+
+### D1 — Build system
+
+Check the repository root (and each directory listed in `settings.gradle.kts` / `settings.gradle`):
+
+| File present            | Build system              |
+|-------------------------|---------------------------|
+| `build.gradle.kts`      | Gradle — Kotlin DSL       |
+| `build.gradle`          | Gradle — Groovy DSL       |
+| `pom.xml`               | Maven                     |
+
+If multiple files exist in the root, Kotlin DSL takes precedence over Groovy DSL.
+
+```bash
+ls build.gradle.kts build.gradle pom.xml 2>/dev/null
+```
+
+### D2 — Languages
+
+Scan `src/` recursively for source file extensions:
+
+```bash
+find . -path '*/src/*' -type f \( -name "*.kt" -o -name "*.java" -o -name "*.groovy" \) \
+  -not -path '*/build/*' -not -path '*/node_modules/*' \
+  | sed 's|.*\.||' | sort | uniq -c | sort -rn
+```
+
+Map extensions to `{{LANGUAGES}}` value:
+- `.kt` → `kotlin`
+- `.java` → `java`
+- `.groovy` → `groovy`
+
+Report all languages found; list them most-frequent first.
+
+> **Note:** `{{FLOW_TYPE}}` (`public` | `hybrid`) is determined by the orchestrator based on
+> the repo's existing build workflow, not from language detection. Do not set it here.
+
+### D3 — CI runtime JDK
+
+Inspect every file in `.github/workflows/`:
+
+```bash
+grep -r 'java-version' .github/workflows/ | grep -v '^Binary'
+```
+
+Extract the numeric version (e.g. `17`, `21`).
+If multiple distinct values appear, flag a **conflict** for human review and use the value
+from the primary build workflow (typically `build.yml` or `ci.yml`).
+
+This value becomes `{{JAVA_VERSION}}`.
+
+### D4 — Module structure
+
+Check for multi-module setup:
+
+```bash
+grep 'include(' settings.gradle.kts settings.gradle 2>/dev/null
+```
+
+List every included sub-project path.  Indicate whether the project is:
+- Single-module (no `include(` lines)
+- Multi-module (one or more `include(` lines)
+
+### D5 — Frontend
+
+Check for `package.json` in any sub-project directory:
+
+```bash
+find . -name 'package.json' -not -path '*/node_modules/*'
+```
+
+Report: **yes** (path) or **no**.
+
+### D6 — Functional / integration tests
+
+Check for signals that the repo runs FT or integration tests:
+
+```bash
+# Docker Compose files
+find . -name 'docker-compose*.yml' -not -path '*/.git/*'
+
+# Gradle task names
+grep -rwE 'integrationTest|functionalTest|FunctionalTest|IntegrationTest' \
+  build.gradle.kts build.gradle */build.gradle.kts */build.gradle 2>/dev/null | head -30
+grep -wE 'ft' \
+  build.gradle.kts build.gradle */build.gradle.kts */build.gradle 2>/dev/null | head -30
+
+# Sub-projects named ft or integration-test
+grep -E '"ft"|"integration"' settings.gradle.kts settings.gradle 2>/dev/null
+```
+
+Record:
+- Whether Docker Compose is present (path if yes)
+- Gradle task names detected
+- Sub-project names that suggest FT scope
+
+This informs the `{{FT_EXCLUSIONS}}` placeholder (leave empty if none found).
+
+### D7 — Existing workflows inventory
+
+List all workflow files and their triggers:
+
+```bash
+for f in .github/workflows/*.yml .github/workflows/*.yaml; do
+  [ -f "$f" ] || continue
+  echo "=== $f ==="
+  grep -A 10 '^on:' "$f" | head -15
+done
+```
+
+For each file, record:
+- File name
+- Triggers present (`push`, `pull_request`, `schedule`, `workflow_dispatch`, `workflow_call`)
+
+Flag any workflow that already has `pull_request:` in addition to `push:` (these are candidates
+for trigger-stripping in Step 5 of `consumer-implementer.md`).
+
+### D8 — Coverage baseline
+
+If the repo uses Kover (Kotlin) or JaCoCo (Java/Groovy), attempt to read the current
+coverage figure:
+
+```bash
+# Kover report (if already generated)
+find . -name 'report.xml' -path '*/kover/*' | head -1
+
+# JaCoCo report
+find . -name 'jacoco.xml' -o -name 'jacocoTestReport.xml' | head -5
+```
+
+Parse the `<counter type="LINE">` (JaCoCo) or `<report>` (Kover) element to extract
+a percentage.  If no report exists locally, set `{{COVERAGE_ENABLED}}` based on whether
+a coverage plugin is already declared in `build.gradle.kts`.
+
+---
+
+## Output Format
+
+Produce a structured report in **both** JSON (machine-readable) and markdown (human-readable).
+
+### JSON block
+
+```json
+{
+  "repo": "{{REPO_NAME}}",
+  "build_system": "gradle-kotlin-dsl",
+  "languages": ["kotlin", "java"],
+  "java_version": "17",
+  "module_structure": "multi-module",
+  "subprojects": ["core", "plugin", "ft"],
+  "frontend": false,
+  "ft_signals": {
+    "docker_compose": ["ft/docker-compose.yml"],
+    "gradle_tasks": ["integrationTest", "ft"],
+    "ft_subprojects": ["ft"]
+  },
+  "ft_exclusions": "",
+  "coverage_enabled": true,
+  "coverage_baseline_pct": 67,
+  "existing_workflows": [
+    {"file": "build.yml",    "triggers": ["push", "pull_request"]},
+    {"file": "release.yml",  "triggers": ["workflow_dispatch"]}
+  ],
+  "pull_request_trigger_conflicts": ["build.yml"]
+}
+```
+
+### Markdown summary
+
+| Field                  | Value                              |
+|------------------------|------------------------------------|
+| Build system           | Gradle — Kotlin DSL                |
+| Languages              | kotlin, java                       |
+| CI JDK                 | 17                                 |
+| Module structure       | multi-module                       |
+| Sub-projects           | core, plugin, ft                   |
+| Frontend               | no                                 |
+| FT signals             | docker-compose, task `ft`          |
+| FT exclusions          | (none — orchestrator to decide)    |
+| Coverage enabled       | yes — baseline 67 %                |
+| PR-trigger conflicts   | `build.yml`                        |
+
+### Recommended orchestrator parameters
+
+```
+REPO_NAME        = {{REPO_NAME}}
+JAVA_VERSION     = 17
+FLOW_TYPE        = <determined by orchestrator from existing build workflow>
+FT_EXCLUSIONS    =
+COVERAGE_ENABLED = true
+LANGUAGES        = kotlin,java
+```

--- a/.agents/prompts/post-merge-verifier.md
+++ b/.agents/prompts/post-merge-verifier.md
@@ -1,0 +1,149 @@
+# Sub-Agent Playbook: Post-Merge Verifier
+
+## Purpose
+
+After a quality-gates PR merges to `main`, confirm that the repository is correctly
+configured: the branch ruleset is active, the `gate/merge` check-run appears in CI,
+and (optionally) a smoke PR demonstrates that merging is actually blocked when the
+gate fails.
+
+## Parameters (filled in by the orchestrator)
+
+| Placeholder       | Example value   | Meaning                        |
+|-------------------|-----------------|--------------------------------|
+| `{{REPO_OWNER}}`  | `octopusden`    | GitHub organisation or user    |
+| `{{REPO_NAME}}`   | `octopus-release-plugin` | Repository name      |
+
+---
+
+## Step 1 — Confirm ruleset exists
+
+Run:
+
+```bash
+gh api repos/{{REPO_OWNER}}/{{REPO_NAME}}/rulesets
+```
+
+Expected: the JSON array contains an entry whose `name` is `jvm-strict` and whose
+`enforcement` is either `"active"` or `"evaluate"` (evaluate is acceptable during
+the rollout; active is the target state).
+
+**FAIL** conditions:
+- The array is empty.
+- No entry with `name == "jvm-strict"` exists.
+
+---
+
+## Step 2 — Confirm `gate/merge` appears in check-runs on the PR head commit
+
+> **Why the PR head commit, not the merge commit?**
+> `gate/merge` is defined with `on: pull_request`, so GitHub attaches its check-runs to
+> the PR's head commit — not to the merge commit that lands on `main`.  Querying
+> the merge commit's check-runs will always return an empty list for this check.
+
+Obtain the head SHA of the most recently merged PR:
+
+```bash
+PR_HEAD_SHA=$(gh pr list \
+  --repo {{REPO_OWNER}}/{{REPO_NAME}} \
+  --state merged --limit 1 \
+  --json headRefOid \
+  --jq '.[0].headRefOid')
+```
+
+Then list check-runs for that commit:
+
+```bash
+gh api repos/{{REPO_OWNER}}/{{REPO_NAME}}/commits/${PR_HEAD_SHA}/check-runs \
+  --jq '.check_runs[].name'
+```
+
+Expected: the output contains `gate/merge` on its own line.
+
+**FAIL** conditions:
+- `gate/merge` is absent from the list.
+- The check-run list is empty (workflows may not have run yet — wait up to 3 minutes and retry once).
+
+Also verify that the `gate/merge` check-run concluded with `conclusion == "success"`:
+
+```bash
+gh api repos/{{REPO_OWNER}}/{{REPO_NAME}}/commits/${PR_HEAD_SHA}/check-runs \
+  --jq '.check_runs[] | select(.name == "gate/merge") | .conclusion'
+```
+
+Expected output: `"success"`
+
+---
+
+## Step 3 — Smoke PR (optional but recommended)
+
+This step verifies the blocking contract end-to-end.
+
+1. Create a trivial branch off `main`:
+
+   ```bash
+   git checkout -b chore/smoke-test-gate-{{REPO_NAME}}
+   # make a no-op change, e.g. add a blank line to README
+   git commit -m "chore: smoke test — delete this PR"
+   git push -u origin chore/smoke-test-gate-{{REPO_NAME}}
+   pr_url="$(gh pr create --title "chore: smoke test (delete me)" \
+                --body "Automated smoke test for gate/merge blocking." \
+                --base main)"
+   pr_number="$(echo "$pr_url" | grep -o '[0-9]*$')"
+   ```
+
+2. Wait for the `gate/merge` check-run to appear on the smoke PR (poll every 30 s, timeout 5 min):
+
+   ```bash
+   SMOKE_SHA=$(gh pr view "$pr_number" --json headRefOid --jq '.headRefOid')
+   gh api repos/{{REPO_OWNER}}/{{REPO_NAME}}/commits/${SMOKE_SHA}/check-runs \
+     --jq '.check_runs[] | select(.name == "gate/merge") | .conclusion'
+   ```
+
+3. Attempt to merge via the API and confirm it is blocked when `gate/merge` is pending or failing:
+
+   ```bash
+   gh api repos/{{REPO_OWNER}}/{{REPO_NAME}}/pulls/${pr_number}/merge \
+     --method PUT --field merge_method=squash 2>&1 | grep -i "blocked\|required status"
+   ```
+
+   Expected: the API returns an error referencing required status checks.
+
+4. Close and delete the smoke PR and branch:
+
+   ```bash
+   gh pr close "$pr_number" --delete-branch --repo {{REPO_OWNER}}/{{REPO_NAME}}
+   ```
+
+---
+
+## Output Format
+
+Emit one of the following verdicts.
+
+### PASS
+
+```
+PASS
+
+Step 1: ruleset `jvm-strict` found (enforcement: evaluate).
+Step 2: `gate/merge` check-run present on PR head commit <sha> with conclusion `success`.
+Step 3: smoke PR blocked as expected.
+```
+
+### FAIL
+
+```
+FAIL
+
+Step 2: `gate/merge` check-run not found on PR head commit abc1234.
+  → Workflow may not have triggered. Check Actions tab:
+    https://github.com/{{REPO_OWNER}}/{{REPO_NAME}}/actions
+
+Remediation:
+  - Verify .github/workflows/merge-gate.yml has `on: pull_request` trigger.
+  - Re-run the failing workflow manually if needed.
+```
+
+Provide the relevant GitHub Actions URL and the exact failing assertion so the
+operator can act without additional investigation.

--- a/.agents/prompts/pr-reviewer.md
+++ b/.agents/prompts/pr-reviewer.md
@@ -1,0 +1,117 @@
+# Sub-Agent Playbook: PR Reviewer — Quality-Gates Acceptance Criteria
+
+## Purpose
+
+Review a pull-request diff that enables quality gates on a consumer JVM repository.
+Emit either `GO` (the PR is ready to merge) or `CHANGE_REQUEST` (with a numbered list
+of specific items that must be fixed before re-review).
+
+---
+
+## Inputs
+
+- Pull-request diff (provided by the orchestrator via `gh pr diff <number>` or equivalent)
+- Repo metadata: `{{JAVA_VERSION}}`, `{{FLOW_TYPE}}`, `{{COVERAGE_ENABLED}}`, `{{REPO_NAME}}`, `{{FT_EXCLUSIONS}}`, `{{LANGUAGES}}`
+
+---
+
+## Checklist
+
+Work through each item in order.  Mark it **PASS** or **FAIL**.  
+If any item is **FAIL**, the overall verdict is `CHANGE_REQUEST`.
+
+### W1 — `merge-gate.yml` has `on: pull_request` trigger
+
+- The file must exist at `.github/workflows/merge-gate.yml`.
+- The `on:` block must contain a `pull_request:` key targeting `main` (or the repo's default branch).
+- **FAIL** if the file is absent or the trigger is missing.
+
+### W2 — `merge-gate.yml` contains a `gate-merge` job named `gate/merge`
+
+- A job with key `gate-merge` (or equivalent) must exist.
+- That job must have `name: gate/merge` exactly.
+- The job must have `if: always()` so it runs even when upstream jobs fail.
+- The job must declare `needs:` covering at least the `build` and `security` jobs.
+- **FAIL** if any of the above is missing.
+
+### W3 — `quality.yml` does NOT have `pull_request:` trigger
+
+- The file must exist at `.github/workflows/quality.yml`.
+- The `on:` block must **not** contain `pull_request:`.
+- Acceptable triggers: `push`, `workflow_dispatch`, `workflow_call`.
+- **FAIL** if `pull_request:` appears anywhere in the `on:` block.
+
+### W4 — `security.yml` does NOT have `pull_request:` trigger
+
+- Same rule as W3 but for `.github/workflows/security.yml`.
+- **FAIL** if `pull_request:` appears anywhere in the `on:` block.
+
+### W5 — Convention plugin is applied
+
+- `build.gradle.kts` (root) must contain `id("org.octopusden.octopus-quality")` inside the `plugins {}` block.
+- **FAIL** if the plugin ID is absent.
+
+### W6 — Action refs use immutable pinning (tag or SHA), not mutable branch refs
+
+- Every `uses:` referencing `octopusden/octopus-base` must end with either:
+  - a semver tag (e.g. `@v2.0.3`), or
+  - a full commit SHA (e.g. `@abc123def456...`).
+- Mutable branch refs `@main`, `@master`, and `@HEAD` are **not** acceptable because they resolve to a moving target.
+- **FAIL** if any such ref uses a mutable branch pointer.
+
+### W7 — `java-version` matches the repo's CI runtime JDK
+
+- Every `actions/setup-java` step across all three new workflow files must specify the same `java-version`
+  that was already used by the repo's existing CI workflows (or the value supplied by the orchestrator).
+- **FAIL** if the version differs or is absent.
+
+### W8 — Baselines committed (Kotlin repos only)
+
+- If `{{LANGUAGES}}` contains `kotlin`, the diff must include:
+  - At least one `detekt-baseline.xml` file
+  - At least one baseline file produced by `ktlintGenerateBaseline`
+- **FAIL** if baselines are absent for a Kotlin repo.
+- **SKIP** this check for Java / Groovy repos.
+
+### W9 — No secrets or credentials in the diff
+
+- Scan the diff for patterns that suggest credentials: API keys, tokens, passwords, private keys, `.env` content.
+- Use heuristics: strings matching `ghp_`, `-----BEGIN`, `password=`, `secret=`, `token=` (case-insensitive).
+- **FAIL** if any match is found; escalate to a human immediately.
+
+### W10 — Coverage settings match repo state
+
+- If `{{COVERAGE_ENABLED}}` is `true`, `build.gradle.kts` must contain an `octopusQuality { coverage { … } }` block
+  with `minimumLineCoverage.set(…)` and/or `overallMinimum.set(…)` using `java.math.BigDecimal`.
+- The `overallMinimum` threshold must be current measured coverage + 5 % (±1 pp tolerance).
+- If `{{COVERAGE_ENABLED}}` is `false`, the block must contain `coverage { enabled.set(false) }`.
+- **FAIL** if the configuration contradicts the expected state.
+
+---
+
+## Output Format
+
+Emit one of the following verdicts, followed by details.
+
+### GO
+
+```
+GO
+
+All acceptance criteria passed.
+PR is ready to merge.
+```
+
+### CHANGE_REQUEST
+
+```
+CHANGE_REQUEST
+
+The following items must be fixed before this PR can be merged:
+
+1. [W2] gate-merge job is missing `if: always()`.
+2. [W6] Action ref `octopusden/octopus-base/.github/actions/merge-gate@main` must use a semver tag.
+3. [W8] No detekt-baseline.xml found; run `./gradlew detektBaseline` and commit the result.
+```
+
+List only failing items.  Be specific: quote the offending line or file path where possible.


### PR DESCRIPTION
## Summary
- Add 4 prompt templates in `.agents/prompts/`:
  - `consumer-implementer.md` — playbook for applying quality gates to a consumer repo
  - `pr-reviewer.md` — acceptance criteria checklist (10 checks)
  - `post-merge-verifier.md` — post-merge smoke test commands
  - `discovery.md` — repo classification questionnaire
- Templates use consistent `{{PLACEHOLDER}}` tokens; DSL examples match the actual `OctopusQualityExtension` API

**Step 2.6** of the [quality gates rollout plan](https://github.com/octopusden/octopus-base/issues/113).
Stacked on #122 (Step 2.3).

## Test plan
- [ ] Templates are syntactically valid and self-contained
- [ ] DSL examples in consumer-implementer.md match `OctopusQualityExtension` API
- [ ] Placeholder tokens are consistent across all 4 templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)