### PR TITLE
ci: extend canary to cover action refs and convention plugin version

### DIFF
--- a/.github/scripts/update-octopus-test-refs.sh
+++ b/.github/scripts/update-octopus-test-refs.sh
@@ -41,18 +41,10 @@ if [[ ${#workflow_files[@]} -gt 0 ]]; then
 fi
 
 # --- Action ref rewriting ---
-# Scan ALL workflow files (not just those with workflow refs) for action refs.
-all_workflow_files=()
-while IFS= read -r -d '' f; do
-  all_workflow_files+=("$f")
-done < <(find "$workflow_dir" -type f \( -name '*.yml' -o -name '*.yaml' \) -print0 | sort -z)
-
 action_files=()
-for wf in "${all_workflow_files[@]}"; do
-  if grep -qE 'uses:[[:space:]]+octopusden/octopus-base/\.github/actions/' "$wf"; then
-    action_files+=("$wf")
-  fi
-done
+while IFS= read -r action_file; do
+  action_files+=("$action_file")
+done < <(bash "$collect_script" "$workflow_dir" "uses:[[:space:]]+octopusden/octopus-base/\\.github/actions/")
 
 if [[ ${#action_files[@]} -eq 0 ]]; then
   echo "No action refs found, skipping"
@@ -89,18 +81,16 @@ else
 
   if [[ -z "$settings_file" ]]; then
     echo "OCTOPUS_QUALITY_VERSION set but no settings.gradle(.kts) found under '$repo_dir' — skipping"
-  elif ! grep -qE 'org\.octopusden\.octopus-quality["\x27]' "$settings_file"; then
+  elif ! grep -qE "org\.octopusden\.octopus-quality[\"']" "$settings_file"; then
     echo "OCTOPUS_QUALITY_VERSION set but no org.octopusden.octopus-quality declaration in $settings_file — skipping"
   else
-    perl -pi -e 's#(org\.octopusden\.octopus-quality["\x27].*?version\s*\(?\s*["\x27])([^"'"'"']+)(["\x27])#${1}$ENV{OCTOPUS_QUALITY_VERSION}${3}#g' \
-      "$settings_file"
-    if grep -qF "${OCTOPUS_QUALITY_VERSION}" "$settings_file"; then
-      printf 'Updated octopus-quality plugin version to %s in %s\n' \
-        "$OCTOPUS_QUALITY_VERSION" \
-        "$settings_file"
-    else
+    if ! perl -0pi -e 'BEGIN { $updated = 0 } $updated += s#(org\.octopusden\.octopus-quality["\x27].*?version\s*\(?\s*["\x27])([^"'"'"']+)(["\x27])#${1}$ENV{OCTOPUS_QUALITY_VERSION}${3}#gs; END { exit($updated > 0 ? 0 : 1) }' \
+      "$settings_file"; then
       echo "Failed to update octopus-quality plugin version to ${OCTOPUS_QUALITY_VERSION} in ${settings_file}"
       exit 1
     fi
+    printf 'Updated octopus-quality plugin version to %s in %s\n' \
+      "$OCTOPUS_QUALITY_VERSION" \
+      "$settings_file"
   fi
 fi

--- a/.github/scripts/update-octopus-test-refs.sh
+++ b/.github/scripts/update-octopus-test-refs.sh
@@ -24,18 +24,83 @@ while IFS= read -r workflow_file; do
 done < <(bash "$collect_script" "$workflow_dir" "uses:[[:space:]]+octopusden/octopus-base/\\.github/workflows/")
 
 if [[ ${#workflow_files[@]} -eq 0 ]]; then
-  # For consumer verification this is mandatory; fail fast if no refs were rewritten.
   echo "No octopus-base reusable workflow references found under '$workflow_dir'"
-  exit 1
+  # Don't exit yet — action refs may still need rewriting.
 fi
 
 export OCTOPUS_BASE_REF="$octopus_base_ref"
 
-for workflow_file in "${workflow_files[@]}"; do
-  perl -0pi -e 's#(uses:\s+octopusden/octopus-base/\.github/workflows/[^@\s]+@)[^\s]+#$1$ENV{OCTOPUS_BASE_REF}#g' \
-    "$workflow_file"
+if [[ ${#workflow_files[@]} -gt 0 ]]; then
+  for workflow_file in "${workflow_files[@]}"; do
+    perl -0pi -e 's#(uses:\s+octopusden/octopus-base/\.github/workflows/[^@\s]+@)[^\s]+#$1$ENV{OCTOPUS_BASE_REF}#g' \
+      "$workflow_file"
+  done
+  printf 'Updated octopus-base workflow refs to %s in %s file(s)\n' \
+    "$octopus_base_ref" \
+    "${#workflow_files[@]}"
+fi
+
+# --- Action ref rewriting ---
+# Scan ALL workflow files (not just those with workflow refs) for action refs.
+all_workflow_files=()
+while IFS= read -r -d '' f; do
+  all_workflow_files+=("$f")
+done < <(find "$workflow_dir" -type f \( -name '*.yml' -o -name '*.yaml' \) -print0 | sort -z)
+
+action_files=()
+for wf in "${all_workflow_files[@]}"; do
+  if grep -qE 'uses:[[:space:]]+octopusden/octopus-base/\.github/actions/' "$wf"; then
+    action_files+=("$wf")
+  fi
 done
 
-printf 'Updated octopus-base workflow refs to %s in %s file(s)\n' \
-  "$octopus_base_ref" \
-  "${#workflow_files[@]}"
+if [[ ${#action_files[@]} -eq 0 ]]; then
+  echo "No action refs found, skipping"
+else
+  echo "Rewriting ${#action_files[@]} action ref(s)"
+  for action_file in "${action_files[@]}"; do
+    perl -0pi -e 's#(uses:\s+octopusden/octopus-base/\.github/actions/[^@\s]+@)[^\s]+#$1$ENV{OCTOPUS_BASE_REF}#g' \
+      "$action_file"
+  done
+fi
+
+# Fail if neither workflow nor action refs were found — nothing was rewritten.
+if [[ ${#workflow_files[@]} -eq 0 ]] && [[ ${#action_files[@]} -eq 0 ]]; then
+  echo "No octopus-base refs (workflow or action) found under '$workflow_dir'"
+  exit 1
+fi
+
+# --- Convention plugin version bump ---
+if [[ -z "${OCTOPUS_QUALITY_VERSION:-}" ]]; then
+  echo "OCTOPUS_QUALITY_VERSION not set, skipping plugin version bump"
+else
+  if [[ ! "${OCTOPUS_QUALITY_VERSION}" =~ ^[0-9A-Za-z._+-]+$ ]]; then
+    echo "Invalid OCTOPUS_QUALITY_VERSION: '${OCTOPUS_QUALITY_VERSION}'"
+    exit 1
+  fi
+
+  settings_file=""
+  for candidate in "$repo_dir/settings.gradle.kts" "$repo_dir/settings.gradle"; do
+    if [[ -f "$candidate" ]]; then
+      settings_file="$candidate"
+      break
+    fi
+  done
+
+  if [[ -z "$settings_file" ]]; then
+    echo "OCTOPUS_QUALITY_VERSION set but no settings.gradle(.kts) found under '$repo_dir' — skipping"
+  elif ! grep -qE 'org\.octopusden\.octopus-quality["\x27]' "$settings_file"; then
+    echo "OCTOPUS_QUALITY_VERSION set but no org.octopusden.octopus-quality declaration in $settings_file — skipping"
+  else
+    perl -pi -e 's#(org\.octopusden\.octopus-quality["\x27].*?version\s*\(?\s*["\x27])([^"'"'"']+)(["\x27])#${1}$ENV{OCTOPUS_QUALITY_VERSION}${3}#g' \
+      "$settings_file"
+    if grep -qF "${OCTOPUS_QUALITY_VERSION}" "$settings_file"; then
+      printf 'Updated octopus-quality plugin version to %s in %s\n' \
+        "$OCTOPUS_QUALITY_VERSION" \
+        "$settings_file"
+    else
+      echo "Failed to update octopus-quality plugin version to ${OCTOPUS_QUALITY_VERSION} in ${settings_file}"
+      exit 1
+    fi
+  fi
+fi

--- a/.github/workflows/verify-octopus-test-consumer.yml
+++ b/.github/workflows/verify-octopus-test-consumer.yml
@@ -28,6 +28,11 @@ on:
         required: true
         type: number
         default: 30
+      convention_plugin_version:
+        description: 'Convention plugin version to bump in octopus-test settings.gradle(.kts)'
+        required: false
+        type: string
+        default: ''
   workflow_call:
     inputs:
       enabled:
@@ -50,6 +55,10 @@ on:
         required: false
         type: number
         default: 30
+      convention_plugin_version:
+        required: false
+        type: string
+        default: ''
     secrets:
       octopus_test_push_token:
         required: false
@@ -148,6 +157,7 @@ jobs:
           OCTOPUS_BASE_REF: ${{ steps.context.outputs.octopus_base_ref }}
           OCTOPUS_TEST_BASE_REF: ${{ steps.context.outputs.octopus_test_base_ref }}
           VERIFY_BRANCH: ${{ steps.context.outputs.verify_branch }}
+          OCTOPUS_QUALITY_VERSION: ${{ inputs.convention_plugin_version }}
         run: |
           set -euo pipefail
 
@@ -162,6 +172,8 @@ jobs:
           bash "$GITHUB_WORKSPACE/.github/scripts/update-octopus-test-refs.sh" "$PWD" "$OCTOPUS_BASE_REF"
 
           git add .github/workflows
+          git add settings.gradle 2>/dev/null || true
+          git add settings.gradle.kts 2>/dev/null || true
           if git diff --cached --quiet; then
             git commit --allow-empty -m "ci: retrigger octopus-test verification for $OCTOPUS_BASE_REF"
           else

--- a/.github/workflows/verify-octopus-test-consumer.yml
+++ b/.github/workflows/verify-octopus-test-consumer.yml
@@ -28,8 +28,11 @@ on:
         required: true
         type: number
         default: 30
+      # Opt-in by design: plugin-version validation is manual/post-release.
+      # PR-time canary cannot test an unreleased plugin artifact without extra
+      # publish infrastructure (GitHub Packages etc.) — deferred as a follow-up.
       convention_plugin_version:
-        description: 'Convention plugin version to bump in octopus-test settings.gradle(.kts)'
+        description: 'Convention plugin version to bump in octopus-test settings.gradle(.kts). Leave empty for PR-time canary.'
         required: false
         type: string
         default: ''


### PR DESCRIPTION
## Summary
- Extend `update-octopus-test-refs.sh` to rewrite `octopusden/octopus-base/.github/actions/` refs (non-fatal if none found)
- Add opt-in convention plugin version bump via `OCTOPUS_QUALITY_VERSION` env var (handles both Kotlin DSL and Groovy DSL syntax)
- Add `convention_plugin_version` input to `verify-octopus-test-consumer.yml`
- Broaden canary scope trigger to include `gradle-quality-plugin/` changes
- Stage `settings.gradle`/`settings.gradle.kts` in addition to workflows

**Step 1.2** of the [quality gates rollout plan](https://github.com/octopusden/octopus-base/issues/113).
Related: #105, #110.

## Test plan
- [ ] Workflow dispatch with `convention_plugin_version` set → octopus-test `settings.gradle` updated
- [ ] Workflow dispatch without `convention_plugin_version` → skip message logged, no settings change
- [ ] PR touching only `gradle-quality-plugin/` triggers the canary
- [ ] Action refs (if present in octopus-test) are rewritten alongside workflow refs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Made automated reference rewriting more robust: it now continues when no reusable workflows are found, adds a separate pass to update action references, and reports counts or "no refs found" rather than failing immediately.
  * Added optional convention plugin version input to the verification workflow, validating and conditionally applying the version to project settings files when present, with clear success/error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->