### PR TITLE
ci: branch protection baseline + ruleset infrastructure (Steps 2.1, 2.4)

### DIFF
--- a/.github/rulesets/jvm-strict.json
+++ b/.github/rulesets/jvm-strict.json
@@ -1,0 +1,50 @@
+{
+  "name": "jvm-strict",
+  "target": "branch",
+  "enforcement": "evaluate",
+  "do_not_enforce_on_create": true,
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "bypass_actors": [],
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": true,
+        "required_approving_review_count": 2,
+        "required_review_thread_resolution": true,
+        "allowed_merge_methods": ["merge", "squash", "rebase"]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "required_status_checks": [
+          {
+            "context": "gate/merge",
+            "integration_id": null
+          },
+          {
+            "context": "GitGuardian Security Checks",
+            "integration_id": null
+          }
+        ]
+      }
+    },
+    {
+      "type": "required_linear_history"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "deletion"
+    }
+  ]
+}

--- a/.github/rulesets/jvm-strict.targets.txt
+++ b/.github/rulesets/jvm-strict.targets.txt
@@ -1,0 +1,1 @@
+octopusden/octopus-base

--- a/.github/workflows/sync-rulesets.yml
+++ b/.github/workflows/sync-rulesets.yml
@@ -1,0 +1,96 @@
+name: Sync Repository Rulesets
+
+on:
+  # NOTE: push trigger is deliberately disabled for initial rollout.
+  # The first sync must be operator-triggered via workflow_dispatch to control timing.
+  # After validating evaluate-mode behavior, uncomment the push trigger:
+  #
+  # push:
+  #   branches: [main]
+  #   paths:
+  #     - '.github/rulesets/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    name: sync-rulesets
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Sync rulesets to targets
+        env:
+          GH_TOKEN: ${{ secrets.RULESETS_ADMIN_TOKEN }}
+        shell: bash
+        run: |
+          set -uo pipefail
+
+          # Pre-flight: verify token
+          if ! gh api user --jq '.login' >/dev/null 2>&1; then
+            echo "::error::RULESETS_ADMIN_TOKEN is invalid or expired"
+            exit 1
+          fi
+          echo "Authenticated as: $(gh api user --jq '.login')"
+
+          ruleset_file=".github/rulesets/jvm-strict.json"
+          targets_file=".github/rulesets/jvm-strict.targets.txt"
+          ruleset_name="jvm-strict"
+          failed=0
+          total=0
+          skipped=0
+
+          while IFS= read -r repo; do
+            # Skip empty lines and comments
+            [[ -z "${repo}" || "${repo}" == \#* ]] && continue
+            total=$((total + 1))
+
+            echo "--- Processing: ${repo}"
+
+            # Check if archived
+            archived="$(gh api "repos/${repo}" --jq '.archived' 2>/dev/null)" || true
+            if [[ "${archived}" == "true" ]]; then
+              echo "  SKIP: ${repo} is archived"
+              skipped=$((skipped + 1))
+              sleep 1
+              continue
+            fi
+
+            # Check for existing ruleset
+            existing_id="$(gh api "repos/${repo}/rulesets" --jq ".[] | select(.name == \"${ruleset_name}\") | .id" 2>/dev/null)" || true
+
+            if [[ -n "${existing_id}" ]]; then
+              echo "  Updating existing ruleset (id: ${existing_id})"
+              if output="$(gh api "repos/${repo}/rulesets/${existing_id}" \
+                --method PUT \
+                --input "${ruleset_file}" 2>&1)"; then
+                echo "  OK: updated"
+              else
+                echo "  FAIL: update failed for ${repo}: ${output}"
+                failed=$((failed + 1))
+              fi
+            else
+              echo "  Creating new ruleset"
+              if output="$(gh api "repos/${repo}/rulesets" \
+                --method POST \
+                --input "${ruleset_file}" 2>&1)"; then
+                echo "  OK: created"
+              else
+                echo "  FAIL: create failed for ${repo}: ${output}"
+                failed=$((failed + 1))
+              fi
+            fi
+
+            sleep 1
+          done < "${targets_file}"
+
+          echo ""
+          echo "=== Summary ==="
+          echo "Total: ${total}, Skipped: ${skipped}, Failed: ${failed}"
+
+          if [[ "${failed}" -gt 0 ]]; then
+            echo "::error::${failed} repo(s) failed ruleset sync"
+            exit 1
+          fi

--- a/docs/branch-protection-current-state.md
+++ b/docs/branch-protection-current-state.md
@@ -1,0 +1,229 @@
+# Branch Protection Baseline Snapshot
+
+**Captured:** 2026-04-16
+**Purpose:** Pre-rollout baseline for Step 2.1 of the merge-gate quality gates initiative.
+**Scope:** Classic branch protection state and active check-context names across octopusden JVM repos.
+
+> **Note:** The classic branch protection API requires admin-level access. Queries with
+> a non-admin token return HTTP 403/404. All data below was captured using the `octopusden`
+> admin account's fine-grained PAT with `Administration: read` permission.
+
+---
+
+## Summary: Classic Branch Protection State
+
+Classic branch protection **is configured** on `main` for octopusden repos. The configuration
+is uniform across repos — same settings everywhere.
+
+| Setting | Value |
+|---------|-------|
+| Required approving reviews | **2** |
+| Dismiss stale reviews | **yes** |
+| Require code owner review | **yes** |
+| Require last push approval | no |
+| Enforce for admins | **yes** |
+| Required linear history | **yes** |
+| Allow force pushes | **no** |
+| Allow deletions | **no** |
+| Required conversation resolution | no |
+| Required status checks | **none** |
+| Required signatures | no |
+
+**Key observations:**
+- No required status checks are configured — this is what the rollout adds (`gate/merge` + `GitGuardian Security Checks`).
+- `required_conversation_resolution` is `false` — the new ruleset intentionally upgrades this to `true`.
+- All other settings are preserved in `jvm-strict.json` (Step 2.4).
+
+### Mapping to ruleset rules
+
+| Classic setting | Ruleset equivalent in `jvm-strict.json` |
+|----------------|----------------------------------------|
+| 2 required approvals | `pull_request.required_approving_review_count: 2` |
+| Dismiss stale reviews | `pull_request.dismiss_stale_reviews_on_push: true` |
+| Require code owner review | `pull_request.require_code_owner_review: true` |
+| Enforce for admins | `bypass_actors: []` (no bypasses) |
+| Required linear history | `required_linear_history` rule |
+| No force pushes | `non_fast_forward` rule |
+| No deletions | `deletion` rule |
+| (new) Conversation resolution | `pull_request.required_review_thread_resolution: true` |
+| (new) Status checks | `required_status_checks`: `gate/merge`, `GitGuardian Security Checks` |
+
+---
+
+## Active Check-Context Names (octopus-base)
+
+Check runs were captured from PR #119
+(`fix/release-sources-javadoc-validator`, head SHA `972caf8604b2d7bb693573fd0a6f357739c42013`,
+merged 2026-04-15).
+
+| Check Name | App | Conclusion |
+|---|---|---|
+| **`gate/merge`** | `github-actions` | success |
+| `build` | `github-actions` | success |
+| `quality` | `github-actions` | success |
+| `security` | `github-actions` | success |
+| `workflow-lint` | `github-actions` | success |
+| `consumer-verify / verify` | `github-actions` | success |
+| `consumer-verify-scope` | `github-actions` | success |
+| `GitGuardian Security Checks` | `gitguardian` | success |
+
+**Confirmed:** The required check-context name for the merge-gate ruleset is **`gate/merge`**.
+This is the value to specify in the `required_status_checks` array when configuring rulesets
+in Step 2.4.
+
+---
+
+## PAT Rotation Procedure
+
+> **Note:** The PAT itself must be created and stored by the repo admin (`octopusden`).
+> `octopusden` is a **User account** (not an Organization), so secrets are stored as
+> repository secrets, not organization secrets.
+
+### Why a PAT is needed
+
+The `sync-rulesets.yml` workflow needs admin-level access to create/update rulesets on
+target repos. The default `GITHUB_TOKEN` issued to Actions workflows has insufficient
+privileges for ruleset management.
+
+### Steps for the operator
+
+1. **Create a fine-grained PAT** under the `octopusden` account.
+   - Resource owner: `octopusden`
+   - Repository access: all target repos (or All repositories)
+   - Permissions: `Administration` (Read & Write)
+2. **Store the PAT as a repository secret** named `RULESETS_ADMIN_TOKEN` in `octopus-base`
+   (Settings → Secrets and variables → Actions → New repository secret).
+3. **Set a rotation reminder** — recommended rotation interval: 90 days.
+   Document the expiry date in the team runbook or a calendar event.
+4. **Test** by triggering `.github/workflows/sync-rulesets.yml` manually via
+   **Actions → Sync Repository Rulesets → Run workflow** after creation.
+
+---
+
+## Raw API Responses
+
+### Branch protection (octopus-base)
+
+<details>
+<summary><code>GET /repos/octopusden/octopus-base/branches/main/protection</code></summary>
+
+```json
+{
+  "required_pull_request_reviews": {
+    "dismiss_stale_reviews": true,
+    "require_code_owner_reviews": true,
+    "require_last_push_approval": false,
+    "required_approving_review_count": 2
+  },
+  "required_signatures": {
+    "enabled": false
+  },
+  "enforce_admins": {
+    "enabled": true
+  },
+  "required_linear_history": {
+    "enabled": true
+  },
+  "allow_force_pushes": {
+    "enabled": false
+  },
+  "allow_deletions": {
+    "enabled": false
+  },
+  "block_creations": {
+    "enabled": false
+  },
+  "required_conversation_resolution": {
+    "enabled": false
+  },
+  "lock_branch": {
+    "enabled": false
+  },
+  "allow_fork_syncing": {
+    "enabled": false
+  }
+}
+```
+
+</details>
+
+### Branch protection (octopus-components-registry-service)
+
+<details>
+<summary><code>GET /repos/octopusden/octopus-components-registry-service/branches/main/protection</code></summary>
+
+```json
+{
+  "required_pull_request_reviews": {
+    "dismiss_stale_reviews": true,
+    "require_code_owner_reviews": true,
+    "require_last_push_approval": false,
+    "required_approving_review_count": 2
+  },
+  "required_signatures": {
+    "enabled": false
+  },
+  "enforce_admins": {
+    "enabled": true
+  },
+  "required_linear_history": {
+    "enabled": true
+  },
+  "allow_force_pushes": {
+    "enabled": false
+  },
+  "allow_deletions": {
+    "enabled": false
+  },
+  "block_creations": {
+    "enabled": false
+  },
+  "required_conversation_resolution": {
+    "enabled": false
+  },
+  "lock_branch": {
+    "enabled": false
+  },
+  "allow_fork_syncing": {
+    "enabled": false
+  }
+}
+```
+
+</details>
+
+### Check runs for PR #119 (octopus-base, SHA 972caf8604b2d7bb693573fd0a6f357739c42013)
+
+<details>
+<summary>GET check-runs — condensed</summary>
+
+```json
+{
+  "total_count": 8,
+  "check_runs": [
+    { "name": "gate/merge",                  "app": "github-actions", "status": "completed", "conclusion": "success" },
+    { "name": "consumer-verify / verify",    "app": "github-actions", "status": "completed", "conclusion": "success" },
+    { "name": "security",                    "app": "github-actions", "status": "completed", "conclusion": "success" },
+    { "name": "workflow-lint",               "app": "github-actions", "status": "completed", "conclusion": "success" },
+    { "name": "build",                       "app": "github-actions", "status": "completed", "conclusion": "success" },
+    { "name": "quality",                     "app": "github-actions", "status": "completed", "conclusion": "success" },
+    { "name": "consumer-verify-scope",       "app": "github-actions", "status": "completed", "conclusion": "success" },
+    { "name": "GitGuardian Security Checks", "app": "gitguardian",    "status": "completed", "conclusion": "success" }
+  ]
+}
+```
+
+</details>
+
+---
+
+## Next Steps
+
+| Step | Description |
+|---|---|
+| 2.2 | Add public/internal convention + naming lint to `octopus-base` |
+| 2.3 | Extract `gate/merge` composite action into reusable action |
+| 2.4 | Create repo-level ruleset (evaluate mode) requiring `gate/merge` + `GitGuardian` |
+| 2.4 | Store `RULESETS_ADMIN_TOKEN` as repository secret (operator action) |
+| 2.5 | Switch ruleset to active; remove legacy classic protection |
+| 2.6 | Sub-agent prompt templates for rolling out to consumer repos |

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -1,0 +1,95 @@
+# Branch Protection via Repository Rulesets
+
+This document describes how the `jvm-strict` GitHub repository ruleset is managed, what it enforces, and how to opt repos in or out.
+
+## What `jvm-strict` Enforces
+
+The ruleset targets the **default branch** of each enrolled repository and enforces the following rules:
+
+| Rule | Detail |
+|---|---|
+| **Pull request reviews** | 2 approving reviews required before merge |
+| **Code-owner review** | At least one approval must come from a code owner |
+| **Stale review dismissal** | Approvals are dismissed when new commits are pushed |
+| **Thread resolution** | All review comment threads must be resolved before merge |
+| **Required status checks** | `gate/merge` and `GitGuardian Security Checks` must pass |
+| **Linear history** | Merge commits that rewrite history are blocked |
+| **No force-push** | `non_fast_forward` rule prevents rewriting history |
+| **No branch deletion** | The default branch cannot be deleted |
+
+## Evaluate vs Active Mode
+
+The ruleset is initially deployed in **evaluate (shadow) mode** (`"enforcement": "evaluate"`). In this mode:
+
+- Rules are evaluated but **not enforced** — PRs and pushes are not blocked.
+- Violations are visible in the GitHub UI under _Insights → Rule insights_ for each repository.
+- This allows teams to observe compliance before hard enforcement begins.
+
+When the rollout is ready to enforce, update the `enforcement` field in `jvm-strict.json` to `"active"` and merge to `main`, then manually trigger the `sync-rulesets` workflow. The sync will propagate the change to all enrolled repos.
+
+## Opting a Repo In
+
+1. Open a PR against `octopus-base` `main` branch.
+2. Add one line to `.github/rulesets/jvm-strict.targets.txt`:
+   ```
+   octopusden/<repo-name>
+   ```
+3. Get the PR approved and merged.
+4. Trigger the `sync-rulesets` workflow manually via **Actions → Sync Repository Rulesets → Run workflow**. The push trigger is disabled during initial rollout; after the rollout stabilizes, it will be enabled for automatic sync on merge.
+
+The token used (`RULESETS_ADMIN_TOKEN`) must have admin access to the target repository.
+
+## Opting a Repo Out
+
+Opting out is a two-step process:
+
+**Step 1 — Stop future syncs.** Remove the repo line from `jvm-strict.targets.txt` via a PR. Once merged, the workflow will no longer touch that repo.
+
+**Step 2 — Remove the existing ruleset.** Find the ruleset ID and delete it:
+
+```bash
+# List rulesets to find the ID
+gh api repos/octopusden/<repo-name>/rulesets --jq '.[] | select(.name == "jvm-strict") | {id, name}'
+
+# Delete by ID
+gh api repos/octopusden/<repo-name>/rulesets/<id> --method DELETE
+```
+
+Skipping Step 2 leaves the ruleset in place on the repo even though the sync no longer manages it.
+
+## Emergency Rollback
+
+If the ruleset causes unexpected issues across all repos, perform a full rollback:
+
+### Option A — Switch back to evaluate mode (preferred)
+
+1. Edit `jvm-strict.json`: change `"enforcement": "active"` → `"enforcement": "evaluate"`.
+2. Merge to `main`, then manually trigger the `sync-rulesets` workflow via **Actions → Sync Repository Rulesets → Run workflow**. The sync will propagate the change to all enrolled repos.
+
+### Option B — Remove the ruleset from all repos
+
+Run the following script locally with a token that has admin access:
+
+```bash
+export GH_TOKEN="<your-admin-token>"
+while IFS= read -r repo; do
+  [[ -z "${repo}" || "${repo}" == \#* ]] && continue
+  id="$(gh api "repos/${repo}/rulesets" --jq '.[] | select(.name == "jvm-strict") | .id' 2>/dev/null)" || true
+  if [[ -n "${id}" ]]; then
+    echo "Deleting ruleset ${id} from ${repo}"
+    gh api "repos/${repo}/rulesets/${id}" --method DELETE
+  fi
+  sleep 1
+done < .github/rulesets/jvm-strict.targets.txt
+```
+
+After the emergency is resolved, restore the ruleset by re-merging `jvm-strict.json` (or updating enforcement mode) so the sync workflow recreates it.
+
+## Sync Workflow Details
+
+The `sync-rulesets.yml` workflow (`Sync Repository Rulesets`) currently runs on:
+- Manual trigger via `workflow_dispatch` only
+
+> **Note:** The push trigger (on changes to `.github/rulesets/**`) is commented out during initial rollout to ensure the first sync is operator-controlled. After validating evaluate-mode behavior, uncomment the push trigger in `sync-rulesets.yml` to enable automatic sync on merge.
+
+It requires the `RULESETS_ADMIN_TOKEN` repository secret. Archived repositories are automatically skipped. Failures per repo are accumulated and reported at the end; the job exits non-zero if any repo fails, so CI is red but all repos are attempted.


### PR DESCRIPTION
## Summary
- Capture branch protection baseline for merge-gate rollout (Step 2.1)
- Add `jvm-strict.json` ruleset in evaluate mode with `do_not_enforce_on_create` (Step 2.4)
- Add `sync-rulesets.yml` workflow (manual dispatch only for initial rollout)
- Add onboarding docs (`branch-protection.md`, `branch-protection-current-state.md`)

Consolidates #120 + #123 into a single PR.

## Operator actions required
- [ ] Create fine-grained PAT with `Administration: write`, store as `RULESETS_ADMIN_TOKEN` repo secret
- [ ] After merge, manually trigger `sync-rulesets.yml` via workflow_dispatch
- [ ] Observe evaluate-mode behavior on test PRs

## Test plan
- [ ] `gh api repos/octopusden/octopus-base/rulesets` shows `jvm-strict` after manual sync
- [ ] Test PR shows "would block" in Rule Insights but merge button stays enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added branch protection ruleset configuration to establish default branch protection standards.
  * Added automated workflow to synchronize branch protection rulesets across target repositories.

* **Documentation**
  * Added comprehensive guides for branch protection management, rollout procedures, and emergency rollback instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->