### PR TITLE
ci: operational hardening for sync-rulesets.yml

### DIFF
--- a/.github/workflows/sync-rulesets.yml
+++ b/.github/workflows/sync-rulesets.yml
@@ -11,6 +11,10 @@ on:
   #     - '.github/rulesets/**'
   workflow_dispatch:
 
+concurrency:
+  group: sync-rulesets
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
@@ -28,9 +32,16 @@ jobs:
         run: |
           set -uo pipefail
 
-          # Pre-flight: verify token
+          # Pre-flight: verify token validity and Administration scope.
+          # The /rulesets probe requires Administration: read at minimum, so a PAT
+          # missing the rulesets scope fails here with a clear message instead of
+          # producing per-repo 403s inside the main loop.
           if ! gh api user --jq '.login' >/dev/null 2>&1; then
             echo "::error::RULESETS_ADMIN_TOKEN is invalid or expired"
+            exit 1
+          fi
+          if ! gh api repos/octopusden/octopus-base/rulesets >/dev/null 2>&1; then
+            echo "::error::RULESETS_ADMIN_TOKEN lacks required Administration scope on octopusden/octopus-base"
             exit 1
           fi
           echo "Authenticated as: $(gh api user --jq '.login')"
@@ -42,7 +53,7 @@ jobs:
           total=0
           skipped=0
 
-          while IFS= read -r repo; do
+          while IFS= read -r repo || [[ -n "${repo}" ]]; do
             # Skip empty lines and comments
             [[ -z "${repo}" || "${repo}" == \#* ]] && continue
             total=$((total + 1))

--- a/.github/workflows/sync-rulesets.yml
+++ b/.github/workflows/sync-rulesets.yml
@@ -32,16 +32,17 @@ jobs:
         run: |
           set -uo pipefail
 
-          # Pre-flight: verify token validity and Administration scope.
-          # The /rulesets probe requires Administration: read at minimum, so a PAT
-          # missing the rulesets scope fails here with a clear message instead of
-          # producing per-repo 403s inside the main loop.
+          # Pre-flight: verify token is valid and has at least Administration: read
+          # on this repository. The /rulesets probe catches a PAT with no rulesets
+          # access at all (the common mis-configuration). Full Administration: write
+          # cannot be probed without a side-effecting call and is still validated
+          # per-repo by the POST/PUT in the main loop.
           if ! gh api user --jq '.login' >/dev/null 2>&1; then
             echo "::error::RULESETS_ADMIN_TOKEN is invalid or expired"
             exit 1
           fi
-          if ! gh api repos/octopusden/octopus-base/rulesets >/dev/null 2>&1; then
-            echo "::error::RULESETS_ADMIN_TOKEN lacks required Administration scope on octopusden/octopus-base"
+          if ! gh api "repos/${GITHUB_REPOSITORY}/rulesets" >/dev/null 2>&1; then
+            echo "::error::RULESETS_ADMIN_TOKEN cannot read rulesets on ${GITHUB_REPOSITORY} — Administration scope is missing or insufficient (write scope is verified per-repo in the sync loop)"
             exit 1
           fi
           echo "Authenticated as: $(gh api user --jq '.login')"
@@ -53,7 +54,7 @@ jobs:
           total=0
           skipped=0
 
-          while IFS= read -r repo || [[ -n "${repo}" ]]; do
+          while IFS= read -r repo || [[ -n "${repo-}" ]]; do
             # Skip empty lines and comments
             [[ -z "${repo}" || "${repo}" == \#* ]] && continue
             total=$((total + 1))

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -31,9 +31,11 @@ When the rollout is ready to enforce, update the `enforcement` field in `jvm-str
 
 1. Open a PR against `octopus-base` `main` branch.
 2. Add one line to `.github/rulesets/jvm-strict.targets.txt`:
-   ```
+
+   ```text
    octopusden/<repo-name>
    ```
+
 3. Get the PR approved and merged.
 4. Trigger the `sync-rulesets` workflow manually via **Actions → Sync Repository Rulesets → Run workflow**. The push trigger is disabled during initial rollout; after the rollout stabilizes, it will be enabled for automatic sync on merge.
 

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -74,7 +74,7 @@ Run the following script locally with a token that has admin access:
 
 ```bash
 export GH_TOKEN="<your-admin-token>"
-while IFS= read -r repo; do
+while IFS= read -r repo || [[ -n "${repo-}" ]]; do
   [[ -z "${repo}" || "${repo}" == \#* ]] && continue
   id="$(gh api "repos/${repo}/rulesets" --jq '.[] | select(.name == "jvm-strict") | .id' 2>/dev/null)" || true
   if [[ -n "${id}" ]]; then


### PR DESCRIPTION
## Summary

Hardens `sync-rulesets.yml` + `docs/branch-protection.md` based on review feedback from #126 and this PR's own follow-up review. Closes the sync-rulesets hardening checklist in #129. The `bypass_actors` item in #129 stays open — it is a Step 2.5 prerequisite and not part of this follow-up.

### Round 1 — operational hardening from #126

- **Concurrency group** — serialize `workflow_dispatch` runs so two operator dispatches cannot race on GET-list / PUT-update of the same ruleset ID. Asked by @fishinitself on #126.
- **Read-loop trailing-newline** — switch `while read -r repo` to `|| [[ -n "$repo" ]]` so a `targets.txt` without a trailing newline does not silently drop its last entry.
- **Token Administration-scope pre-flight** — add a `GET /rulesets` probe so a mis-scoped PAT fails fast with a clear error instead of producing per-repo 403s in the main loop.
- **Markdownlint MD031/MD040** — blank lines + language tag around the fenced block in the opt-in step.

### Round 2 — follow-up review findings

- **`set -u` safety on read-loop guard** — use `${repo-}` in the `|| [[ -n ... ]]` condition so it stays safe under `set -u` if `read` returns before the variable is initialized.
- **`GITHUB_REPOSITORY` instead of hard-coded repo** — pre-flight probe uses `${GITHUB_REPOSITORY}` so the workflow keeps working if the repo is renamed or reused from a fork.
- **Truthful pre-flight wording** — the probe verifies Administration: **read** (catches the common no-scope PAT mis-config). Full Administration: **write** is still validated per-repo by the POST/PUT in the sync loop — the previous comment claimed more than the probe actually proves. Tightened both the doc comment and the error message.
- **Mirror read-loop guard in docs** — the emergency-rollback snippet in `docs/branch-protection.md` now has the same `||  [[ -n "${repo-}" ]]` guard so an operator copy-pasting it does not lose the last target when `jvm-strict.targets.txt` has no trailing newline.

## Test plan

- [ ] `workflow_dispatch` still completes end-to-end against a pilot target
- [ ] Run with a deliberately mis-scoped PAT → fails at pre-flight with the scope error, no main-loop 403 spam
- [ ] `targets.txt` with no trailing newline → last entry is still processed (check `Total:` in the summary)
- [ ] Markdown render of `docs/branch-protection.md` shows the `text`-tagged block with surrounding blank lines
- [ ] Emergency-rollback copy-paste preserves the last entry under the same missing-newline case

🤖 Generated with [Claude Code](https://claude.com/claude-code)