### PR TITLE
ci: add ORMS to jvm-strict ruleset targets

### DIFF
--- a/.github/rulesets/jvm-strict.targets.txt
+++ b/.github/rulesets/jvm-strict.targets.txt
@@ -1,1 +1,2 @@
 octopusden/octopus-base
+octopusden/octopus-release-management-service


### PR DESCRIPTION
## Summary
Add `octopusden/octopus-release-management-service` to `jvm-strict.targets.txt`.
ORMS is the first pilot consumer (Step 3.1 of the quality gates rollout).

## Operator actions after merge
1. Trigger `sync-rulesets.yml` manually via **Actions → Sync Repository Rulesets → Run workflow**
2. Verify ruleset applied: `gh api repos/octopusden/octopus-release-management-service/rulesets`
3. Ruleset is in `evaluate` mode — observe behavior on ORMS PRs before flipping to `active`

🤖 Generated with [Claude Code](https://claude.com/claude-code)