### PR TITLE
fix: extract quality configs to .gradle/ so they survive clean builds

### DIFF
--- a/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/ConfigExtractor.kt
+++ b/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/ConfigExtractor.kt
@@ -4,8 +4,10 @@ import org.gradle.api.Project
 import java.io.File
 
 /**
- * Extracts bundled config files from plugin resources into the build directory
- * so that Gradle quality tools can reference them by file path.
+ * Extracts bundled config files from plugin resources into Gradle's project cache
+ * directory (`.gradle/` by default, overridable via `--project-cache-dir`) so that
+ * Gradle quality tools can reference them by file path and the files survive
+ * `./gradlew clean`.
  */
 internal object ConfigExtractor {
     private const val RESOURCE_PREFIX = "org/octopusden/octopus/quality/config"
@@ -19,17 +21,26 @@ internal object ConfigExtractor {
         )
 
     /**
-     * Extract all config files to `<rootBuildDir>/octopus-quality/config/`.
+     * Extract all config files to `<projectCacheDir>/octopus-quality/config/`.
+     *
+     * Uses Gradle's project cache directory (not `build/`) so the extracted config
+     * survives `./gradlew clean` — otherwise a `clean build` run deletes configs
+     * between configuration phase (when extraction happens) and execution phase
+     * (when detekt etc. read them).
+     *
+     * Respects `--project-cache-dir` / `projectCacheDir` settings overrides and
+     * falls back to the Gradle default (`<rootDir>/.gradle`) when unset.
+     *
      * Returns the config directory.
      */
     fun extractTo(project: Project): File {
-        val configDir =
-            File(
-                project.layout.buildDirectory.asFile
-                    .get(),
-                "octopus-quality/config",
-            )
-        configDir.mkdirs()
+        val projectCacheDir =
+            project.gradle.startParameter.projectCacheDir
+                ?: File(project.rootDir, ".gradle")
+        val configDir = File(projectCacheDir, "octopus-quality/config")
+        if (!configDir.isDirectory && !configDir.mkdirs()) {
+            error("Failed to create config directory: ${configDir.absolutePath}")
+        }
 
         for (fileName in CONFIG_FILES) {
             val target = File(configDir, fileName)

--- a/gradle-quality-plugin/src/test/kotlin/org/octopusden/octopus/quality/OctopusQualityPluginFunctionalTest.kt
+++ b/gradle-quality-plugin/src/test/kotlin/org/octopusden/octopus/quality/OctopusQualityPluginFunctionalTest.kt
@@ -493,4 +493,43 @@ class OctopusQualityPluginFunctionalTest {
         // url is set, so should NOT be in errors
         assertTrue(!result.output.contains("POM <url> is missing"))
     }
+
+    // ---------------------------------------------------------------
+    // Regression: config extraction must survive `clean` task
+    // ---------------------------------------------------------------
+    @Test
+    fun `detekt config survives clean build cycle`() {
+        settingsFile(kotlinSettings("test-clean-cycle"))
+        buildFile(
+            """
+            plugins {
+                kotlin("jvm") version "1.9.25"
+                id("io.gitlab.arturbosch.detekt") version "1.23.5"
+                id("org.jlleitschuh.gradle.ktlint") version "14.0.1"
+                id("org.octopusden.octopus-quality")
+            }
+            repositories { mavenCentral() }
+            octopusQuality {
+                kotlin { failOnViolation.set(false) }
+                java { failOnViolation.set(false) }
+                coverage { enabled.set(false) }
+            }
+            // Explicit ordering: detekt must run AFTER clean, so the test
+            // deterministically exercises the "config wiped by clean" path.
+            tasks.named("detekt") { mustRunAfter(tasks.named("clean")) }
+            """.trimIndent(),
+        )
+        writeKotlinFile(
+            "src/main/kotlin/com/example/Hello.kt",
+            "package com.example\nfun hello() = \"Hello\"\n",
+        )
+
+        // Clean and detekt in a single build — reproduces CI `gradle clean build` scenario.
+        // If config lived under build/, :clean would delete it before :detekt reads it.
+        val result = runner("clean", "detekt").build()
+        // :clean may be UP_TO_DATE on a fresh workspace (no build dir to remove);
+        // the important invariant is that it executed and :detekt succeeded afterwards.
+        assertTrue(result.task(":clean")?.outcome in setOf(TaskOutcome.SUCCESS, TaskOutcome.UP_TO_DATE))
+        assertEquals(TaskOutcome.SUCCESS, result.task(":detekt")?.outcome)
+    }
 }


### PR DESCRIPTION
## Problem
ORMS build fails in TeamCity with:
```
Execution failed for task ':automation:detekt'.
> Provided path '.../build/octopus-quality/config/detekt.yml' does not exist!
```

`ConfigExtractor` writes bundled configs (detekt.yml, checkstyle.xml, etc.) into `build/octopus-quality/config/` at **configuration phase**. When CI runs `./gradlew clean build`, the `:clean` task deletes the build directory at **execution phase**, wiping the extracted configs before `:detekt` tries to read them.

## Fix
Extract configs into Gradle's project cache directory (`.gradle/` by default, overridable via `--project-cache-dir` or `StartParameter.projectCacheDir`) — specifically `<projectCacheDir>/octopus-quality/config/`. This directory is Gradle-managed and never touched by `clean`, and the implementation respects consumer overrides of the cache location.

Also hardens `mkdirs()` with an explicit `isDirectory || mkdirs()` guard that fails fast with the absolute path if the directory can't be created (permissions, read-only checkout, etc.).

## Test
Added regression test `detekt config survives clean build cycle` that runs `gradle clean detekt` in a single build. Verified:
- Fails against the old path (reproduces the bug)
- Passes on the new path

All existing tests still green.

## Impact
- First caught by ORMS pilot (octopusden/octopus-release-management-service#57)
- Needs a v2.3.1 release after merge; ORMS will then bump to consume the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)