### PR TITLE
chore: add Kover coverage gate for gradle-quality-plugin

### DIFF
--- a/.github/workflows/check-octopus-test-consumer.yml
+++ b/.github/workflows/check-octopus-test-consumer.yml
@@ -70,9 +70,9 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Static analysis
+      - name: Static analysis and coverage gate
         working-directory: gradle-quality-plugin
-        run: ./gradlew detekt ktlintCheck --no-daemon --stacktrace
+        run: ./gradlew detekt ktlintCheck koverXmlReport koverVerify --no-daemon --stacktrace
 
   workflow-lint:
     name: workflow-lint

--- a/gradle-quality-plugin/build.gradle.kts
+++ b/gradle-quality-plugin/build.gradle.kts
@@ -8,6 +8,59 @@ plugins {
     id("io.gitlab.arturbosch.detekt")
     id("org.jlleitschuh.gradle.ktlint")
     id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
+    // kover version resolved via settings.gradle.kts pluginManagement from koverVersion property
+    id("org.jetbrains.kotlinx.kover")
+}
+
+// Kover: measure coverage only for pure-logic classes that are reachable by in-process unit tests.
+//
+// Why the exclusions?
+// Gradle plugin wiring code (apply(), configure lambdas, task registration) runs exclusively
+// inside a GradleRunner subprocess during functional tests — Kover's JVM agent cannot instrument
+// code in a different JVM process.  Excluding those classes keeps the gate honest: the threshold
+// applies only to code we can actually measure, not to code that is structurally untestable with
+// in-process instrumentation.  The excluded code IS tested — by the 11 GradleRunner functional
+// tests — just not via Kover.
+kover {
+    reports {
+        // Filters here apply to BOTH koverXmlReport AND the verify rule — Kover 0.9.4
+        // DSL does not support per-rule filters scoped to `verify` only. This is an
+        // accepted trade-off: the XML report shows the same narrowed scope that the
+        // gate enforces, which is consistent for dashboards.
+        filters {
+            excludes {
+                classes(
+                    // Plugin entry-point and all Gradle-lifecycle lambdas/anonymous classes
+                    "org.octopusden.octopus.quality.OctopusQualityPlugin",
+                    "org.octopusden.octopus.quality.OctopusQualityPlugin\$*",
+                    // Extension classes — constructed via Gradle ObjectFactory, not unit-testable
+                    "org.octopusden.octopus.quality.OctopusQualityExtension",
+                    "org.octopusden.octopus.quality.CoverageExtension",
+                    "org.octopusden.octopus.quality.KotlinExtension",
+                    "org.octopusden.octopus.quality.JavaExtension",
+                    "org.octopusden.octopus.quality.GroovyExtension",
+                    // Internal helpers that touch Gradle Project / task graph / file system
+                    "org.octopusden.octopus.quality.internal.ConfigExtractor",
+                    "org.octopusden.octopus.quality.internal.LanguageDetector",
+                    "org.octopusden.octopus.quality.internal.SubprojectConfigurer",
+                    "org.octopusden.octopus.quality.internal.SubprojectConfigurer\$*",
+                    "org.octopusden.octopus.quality.internal.TaskRegistrar",
+                    "org.octopusden.octopus.quality.internal.TaskRegistrar\$*",
+                    "org.octopusden.octopus.quality.internal.PublicationValidator",
+                    "org.octopusden.octopus.quality.internal.PublicationValidator\$*",
+                )
+            }
+        }
+        verify {
+            rule {
+                // After exclusions the report covers only pure-logic classes:
+                //   CoverageToolResolverKt (100%), DetectedLanguages (100%),
+                //   CoverageExtension.Tool (100%).
+                // 80% gives a small regression buffer for future additions to those classes.
+                minBound(minValue = 80, coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE)
+            }
+        }
+    }
 }
 
 val detektVersion: String by project

--- a/gradle-quality-plugin/settings.gradle.kts
+++ b/gradle-quality-plugin/settings.gradle.kts
@@ -1,10 +1,12 @@
 pluginManagement {
     val detektVersion: String by settings
     val ktlintGradleVersion: String by settings
+    val koverVersion: String by settings
 
     plugins {
         id("io.gitlab.arturbosch.detekt") version detektVersion
         id("org.jlleitschuh.gradle.ktlint") version ktlintGradleVersion
+        id("org.jetbrains.kotlinx.kover") version koverVersion
     }
 
     repositories {

--- a/gradle-quality-plugin/src/test/kotlin/org/octopusden/octopus/quality/internal/CoverageToolResolverTest.kt
+++ b/gradle-quality-plugin/src/test/kotlin/org/octopusden/octopus/quality/internal/CoverageToolResolverTest.kt
@@ -1,0 +1,90 @@
+package org.octopusden.octopus.quality.internal
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.octopusden.octopus.quality.CoverageExtension
+
+class CoverageToolResolverTest {
+    private fun languages(
+        hasKotlin: Boolean = false,
+        hasJava: Boolean = false,
+        hasGroovy: Boolean = false,
+    ) = DetectedLanguages(hasKotlin = hasKotlin, hasJava = hasJava, hasGroovy = hasGroovy)
+
+    // AUTO + Kotlin-only → KOVER
+    @Test
+    fun `AUTO on kotlin-only project resolves to KOVER`() {
+        val result =
+            resolveCoverageTool(
+                CoverageExtension.Tool.AUTO,
+                languages(hasKotlin = true),
+            )
+        assertEquals(CoverageExtension.Tool.KOVER, result)
+    }
+
+    // AUTO + Kotlin + Java (mixed) → JACOCO
+    @Test
+    fun `AUTO on mixed kotlin-java project resolves to JACOCO`() {
+        val result =
+            resolveCoverageTool(
+                CoverageExtension.Tool.AUTO,
+                languages(hasKotlin = true, hasJava = true),
+            )
+        assertEquals(CoverageExtension.Tool.JACOCO, result)
+    }
+
+    // AUTO + Java-only → JACOCO
+    @Test
+    fun `AUTO on java-only project resolves to JACOCO`() {
+        val result =
+            resolveCoverageTool(
+                CoverageExtension.Tool.AUTO,
+                languages(hasJava = true),
+            )
+        assertEquals(CoverageExtension.Tool.JACOCO, result)
+    }
+
+    // AUTO + Groovy → JACOCO (not kotlin-only)
+    @Test
+    fun `AUTO on groovy project resolves to JACOCO`() {
+        val result =
+            resolveCoverageTool(
+                CoverageExtension.Tool.AUTO,
+                languages(hasGroovy = true),
+            )
+        assertEquals(CoverageExtension.Tool.JACOCO, result)
+    }
+
+    // AUTO + Kotlin + Groovy (mixed) → JACOCO
+    @Test
+    fun `AUTO on kotlin-groovy project resolves to JACOCO`() {
+        val result =
+            resolveCoverageTool(
+                CoverageExtension.Tool.AUTO,
+                languages(hasKotlin = true, hasGroovy = true),
+            )
+        assertEquals(CoverageExtension.Tool.JACOCO, result)
+    }
+
+    // Explicit JACOCO overrides AUTO logic
+    @Test
+    fun `explicit JACOCO is returned unchanged regardless of languages`() {
+        val result =
+            resolveCoverageTool(
+                CoverageExtension.Tool.JACOCO,
+                languages(hasKotlin = true),
+            )
+        assertEquals(CoverageExtension.Tool.JACOCO, result)
+    }
+
+    // Explicit KOVER overrides AUTO logic
+    @Test
+    fun `explicit KOVER is returned unchanged regardless of languages`() {
+        val result =
+            resolveCoverageTool(
+                CoverageExtension.Tool.KOVER,
+                languages(hasJava = true),
+            )
+        assertEquals(CoverageExtension.Tool.KOVER, result)
+    }
+}

--- a/gradle-quality-plugin/src/test/kotlin/org/octopusden/octopus/quality/internal/DetectedLanguagesTest.kt
+++ b/gradle-quality-plugin/src/test/kotlin/org/octopusden/octopus/quality/internal/DetectedLanguagesTest.kt
@@ -1,0 +1,59 @@
+package org.octopusden.octopus.quality.internal
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class DetectedLanguagesTest {
+    @Test
+    fun `isKotlinOnly is true when only kotlin is detected`() {
+        val langs = DetectedLanguages(hasKotlin = true, hasJava = false, hasGroovy = false)
+        assertTrue(langs.isKotlinOnly)
+    }
+
+    @Test
+    fun `isKotlinOnly is false when kotlin and java are both present`() {
+        val langs = DetectedLanguages(hasKotlin = true, hasJava = true, hasGroovy = false)
+        assertFalse(langs.isKotlinOnly)
+    }
+
+    @Test
+    fun `isKotlinOnly is false when kotlin and groovy are both present`() {
+        val langs = DetectedLanguages(hasKotlin = true, hasJava = false, hasGroovy = true)
+        assertFalse(langs.isKotlinOnly)
+    }
+
+    @Test
+    fun `isKotlinOnly is false when only java is detected`() {
+        val langs = DetectedLanguages(hasKotlin = false, hasJava = true, hasGroovy = false)
+        assertFalse(langs.isKotlinOnly)
+    }
+
+    @Test
+    fun `isKotlinOnly is false when only groovy is detected`() {
+        val langs = DetectedLanguages(hasKotlin = false, hasJava = false, hasGroovy = true)
+        assertFalse(langs.isKotlinOnly)
+    }
+
+    @Test
+    fun `isKotlinOnly is false when no languages are detected`() {
+        val langs = DetectedLanguages(hasKotlin = false, hasJava = false, hasGroovy = false)
+        assertFalse(langs.isKotlinOnly)
+    }
+
+    @Test
+    fun `data class equality holds for identical values`() {
+        val a = DetectedLanguages(hasKotlin = true, hasJava = false, hasGroovy = false)
+        val b = DetectedLanguages(hasKotlin = true, hasJava = false, hasGroovy = false)
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun `data class equality distinguishes differing values`() {
+        val a = DetectedLanguages(hasKotlin = true, hasJava = false, hasGroovy = false)
+        val b = DetectedLanguages(hasKotlin = false, hasJava = true, hasGroovy = false)
+        assertNotEquals(a, b)
+    }
+}


### PR DESCRIPTION
Closes #118.

## Problem
Convention plugin enforces coverage gates on consumer repos but does not measure its own coverage. Eat our own dogfood.

## What's added
- `org.jetbrains.kotlinx.kover` applied in `gradle-quality-plugin/build.gradle.kts` (version 0.9.4, pinned in existing `gradle.properties`)
- Kover verify rule with **80% line coverage threshold** on the measured scope
- Two new in-process unit test files for pure-logic classes:
  - `CoverageToolResolverTest.kt` — 7 tests covering all AUTO/JACOCO/KOVER resolutions
  - `DetectedLanguagesTest.kt` — 8 tests for the data class and derived properties
- `koverXmlReport koverVerify` added to the `quality` job in `check-octopus-test-consumer.yml`

## Scope & honest trade-off
GradleRunner tests spawn a separate JVM subprocess, and Kover's JVM agent instruments only the test process — not the subprocess. Gradle-lifecycle code (`OctopusQualityPlugin.apply()`, `SubprojectConfigurer`, `TaskRegistrar`, `PublicationValidator`, `ConfigExtractor`, `LanguageDetector`, extension classes) is reached only by the 11 functional tests and cannot be measured in-process.

The verify rule uses `filters.excludes.classes(...)` to restrict coverage to pure-logic classes that can be unit-tested in-process. Currently measured:
- `CoverageToolResolverKt` — tool resolution logic (AUTO detection, explicit Jacoco/Kover)
- `DetectedLanguages` — derived-property logic (`isKotlinOnly`)
- `CoverageExtension.Tool` — enum

**What this gate catches:** any regression in the pure-logic classes that ships without a corresponding test update. At current 100% on ~8 lines, a single uncovered branch drops below 80% and the gate fails.

**What this gate does not catch:** regressions in the Gradle-bound classes — those remain exclusively tested via functional tests. Expanding measurable surface requires either extracting more pure-logic from Gradle-bound classes, or running Kover in subprocess-instrumentation mode (not trivial with TestKit). Tracked as a follow-up.

## Test plan
- [ ] Quality job runs `koverXmlReport koverVerify` and passes on main
- [ ] Future regressions in the measured pure-logic classes are caught by the gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)