### PR TITLE
chore: hardcoded fragility cleanup in convention plugin and workflows

### DIFF
--- a/.github/workflows/check-octopus-test-consumer.yml
+++ b/.github/workflows/check-octopus-test-consumer.yml
@@ -24,6 +24,11 @@ on:
         required: true
         type: number
         default: 30
+      actionlint_image:
+        description: 'Docker image (with tag) used for actionlint workflow linting'
+        required: false
+        type: string
+        default: rhysd/actionlint:1.7.7
 
 permissions:
   contents: read
@@ -77,13 +82,16 @@ jobs:
   workflow-lint:
     name: workflow-lint
     runs-on: ubuntu-latest
+    # `pull_request` triggers cannot supply inputs, so default explicitly.
+    env:
+      ACTIONLINT_IMAGE: ${{ inputs.actionlint_image || 'rhysd/actionlint:1.7.7' }}
     steps:
       - uses: actions/checkout@v4
       - name: actionlint
         shell: bash
         run: |
           set -euo pipefail
-          docker run --rm --entrypoint sh -v "$PWD:/repo" -w /repo rhysd/actionlint:1.7.7 -lc '
+          docker run --rm --entrypoint sh -v "$PWD:/repo" -w /repo "$ACTIONLINT_IMAGE" -lc '
             set -euo pipefail
             actionlint -color \
               -ignore "the runner of \".+\" action is too old to run on GitHub Actions" \

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -10,6 +10,14 @@ on:
       release-version:
         type: string
         required: true
+      release-log-dispatch-url:
+        type: string
+        required: false
+        default: https://api.github.com/repos/octopusden/octopus-release-log/dispatches
+      github-api-version:
+        type: string
+        required: false
+        default: '2022-11-28'
 
 jobs:
   build:
@@ -30,7 +38,7 @@ jobs:
           -X POST \
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: Bearer ${{ secrets.OCTOPUS_GITHUB_TOKEN }}" \
-          -H "X-GitHub-Api-Version: 2022-11-28" \
-          https://api.github.com/repos/octopusden/octopus-release-log/dispatches \
+          -H "X-GitHub-Api-Version: ${{ inputs.github-api-version }}" \
+          ${{ inputs.release-log-dispatch-url }} \
           -d '{ "event_type": "register-release", "client_payload": {"octopus-module-name": "${{ env.OCTOPUS_MODULE_NAME }}", "release-version": "${{ inputs.release-version }}"} }' \
           --fail

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -10,10 +10,13 @@ on:
       release-version:
         type: string
         required: true
-      release-log-dispatch-url:
+      # Owner/repo of the release-log repository the dispatch is posted to. Constrained
+      # to a github.com path — accepting an arbitrary URL would let a caller redirect the
+      # bearer token to a non-GitHub host, so we construct the URL ourselves below.
+      release-log-repository:
         type: string
         required: false
-        default: https://api.github.com/repos/octopusden/octopus-release-log/dispatches
+        default: octopusden/octopus-release-log
       github-api-version:
         type: string
         required: false
@@ -29,16 +32,32 @@ jobs:
     steps:
       - name: Set module name
         id: set-module-name
+        env:
+          OCTOPUS_REPOSITORY: ${{ inputs.octopus-repository }}
         run: |
-          echo "OCTOPUS_MODULE_NAME=$(echo ${{ inputs.octopus-repository }} | cut -d'/' -f2)" >> $GITHUB_ENV
+          set -euo pipefail
+          echo "OCTOPUS_MODULE_NAME=${OCTOPUS_REPOSITORY##*/}" >> "$GITHUB_ENV"
 
       - name: Launch action using REST
+        env:
+          OCTOPUS_GITHUB_TOKEN: ${{ secrets.OCTOPUS_GITHUB_TOKEN }}
+          RELEASE_LOG_REPOSITORY: ${{ inputs.release-log-repository }}
+          GITHUB_API_VERSION: ${{ inputs.github-api-version }}
+          RELEASE_VERSION: ${{ inputs.release-version }}
         run: |
+          set -euo pipefail
+          # Build the JSON payload via jq so neither the module name nor the version can
+          # break out of the JSON quoting, regardless of what characters they contain.
+          payload="$(jq -n \
+            --arg name "$OCTOPUS_MODULE_NAME" \
+            --arg version "$RELEASE_VERSION" \
+            '{event_type: "register-release", client_payload: {"octopus-module-name": $name, "release-version": $version}}')"
+
           curl -L \
-          -X POST \
-          -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer ${{ secrets.OCTOPUS_GITHUB_TOKEN }}" \
-          -H "X-GitHub-Api-Version: ${{ inputs.github-api-version }}" \
-          ${{ inputs.release-log-dispatch-url }} \
-          -d '{ "event_type": "register-release", "client_payload": {"octopus-module-name": "${{ env.OCTOPUS_MODULE_NAME }}", "release-version": "${{ inputs.release-version }}"} }' \
-          --fail
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${OCTOPUS_GITHUB_TOKEN}" \
+            -H "X-GitHub-Api-Version: ${GITHUB_API_VERSION}" \
+            "https://api.github.com/repos/${RELEASE_LOG_REPOSITORY}/dispatches" \
+            -d "$payload" \
+            --fail

--- a/.github/workflows/verify-octopus-test-consumer.yml
+++ b/.github/workflows/verify-octopus-test-consumer.yml
@@ -36,6 +36,16 @@ on:
         required: false
         type: string
         default: ''
+      octopus_test_repository:
+        description: 'GitHub owner/repo of the consumer test repository to verify against'
+        required: false
+        type: string
+        default: octopusden/octopus-test
+      poll_interval_seconds:
+        description: 'Seconds to wait between consumer-workflow status polls'
+        required: false
+        type: number
+        default: 15
   workflow_call:
     inputs:
       enabled:
@@ -62,6 +72,14 @@ on:
         required: false
         type: string
         default: ''
+      octopus_test_repository:
+        required: false
+        type: string
+        default: octopusden/octopus-test
+      poll_interval_seconds:
+        required: false
+        type: number
+        default: 15
     secrets:
       octopus_test_push_token:
         required: false
@@ -73,7 +91,7 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     env:
-      OCTOPUS_TEST_REPOSITORY: octopusden/octopus-test
+      OCTOPUS_TEST_REPOSITORY: ${{ inputs.octopus_test_repository }}
       REQUIRED_WORKFLOWS_JSON: '["Merge Gate"]'
       OPTIONAL_WORKFLOWS_JSON: '[]'
       # Uppercase fallback keeps manual workflow_dispatch compatible with repository-level secret.
@@ -199,6 +217,7 @@ jobs:
         env:
           GH_TOKEN: ${{ env.OCTOPUS_TEST_PUSH_TOKEN }}
           TIMEOUT_MINUTES: ${{ inputs.timeout_minutes }}
+          POLL_INTERVAL_SECONDS: ${{ inputs.poll_interval_seconds }}
           VERIFY_BRANCH: ${{ steps.context.outputs.verify_branch }}
           VERIFY_SHA: ${{ steps.push.outputs.verify_sha }}
         run: |
@@ -241,7 +260,7 @@ jobs:
                 -r '[ $required[] as $workflow | select(($runs | map(.workflowName) | index($workflow)) | not) ] | join(", ")' \
               )"
               echo "Waiting for workflow runs to appear (found ${found_count}/${expected_count}). Missing: ${missing_workflows}"
-              sleep 15
+              sleep "$POLL_INTERVAL_SECONDS"
               continue
             fi
 
@@ -249,7 +268,7 @@ jobs:
             if (( required_pending_count > 0 )); then
               pending_required="$(jq -r '[.[] | select(.status != "completed") | .workflowName] | join(", ")' <<<"${required_runs}")"
               echo "Waiting for required workflows to complete (pending ${required_pending_count}): ${pending_required}"
-              sleep 15
+              sleep "$POLL_INTERVAL_SECONDS"
               continue
             fi
 
@@ -259,7 +278,7 @@ jobs:
             if [[ "${optional_stabilized}" != "true" ]]; then
               optional_stabilized=true
               echo "Required workflows completed. Waiting one extra poll cycle for optional workflows."
-              sleep 15
+              sleep "$POLL_INTERVAL_SECONDS"
               continue
             fi
 
@@ -272,7 +291,7 @@ jobs:
             if (( pending_count > 0 )); then
               pending_workflows="$(jq -r '[.[] | select(.status != "completed") | .workflowName] | join(", ")' <<<"${matching_runs}")"
               echo "Waiting for workflows to complete (pending ${pending_count}): ${pending_workflows}"
-              sleep 15
+              sleep "$POLL_INTERVAL_SECONDS"
               continue
             fi
 

--- a/gradle-quality-plugin/build.gradle.kts
+++ b/gradle-quality-plugin/build.gradle.kts
@@ -14,6 +14,8 @@ val detektVersion: String by project
 val ktlintGradleVersion: String by project
 val koverVersion: String by project
 val spotbugsGradleVersion: String by project
+val checkstyleVersion: String by project
+val pmdVersion: String by project
 
 repositories {
     mavenCentral()
@@ -65,6 +67,32 @@ kotlin {
     // Repos with bytecode target 1.8 (octopus-rm-gradle-plugin, octopus-license-gradle-plugin)
     // run CI on JDK 11+ — only bytecode target stays 1.8, not the build JVM.
     jvmToolchain(11)
+}
+
+// Surface gradle.properties versions to plugin runtime via a generated Kotlin source.
+val generateBuildConstants by tasks.registering {
+    val outDir = layout.buildDirectory.dir("generated/source/buildConstants/kotlin")
+    outputs.dir(outDir)
+    inputs.property("checkstyleVersion", checkstyleVersion)
+    inputs.property("pmdVersion", pmdVersion)
+    doLast {
+        val pkgDir = outDir.get().dir("org/octopusden/octopus/quality/internal").asFile
+        pkgDir.mkdirs()
+        File(pkgDir, "BuildConstants.kt").writeText(
+            """
+            package org.octopusden.octopus.quality.internal
+
+            internal object BuildConstants {
+                const val CHECKSTYLE_VERSION = "$checkstyleVersion"
+                const val PMD_VERSION = "$pmdVersion"
+            }
+            """.trimIndent() + "\n",
+        )
+    }
+}
+
+kotlin.sourceSets.named("main") {
+    kotlin.srcDir(generateBuildConstants)
 }
 
 detekt {

--- a/gradle-quality-plugin/gradle.properties
+++ b/gradle-quality-plugin/gradle.properties
@@ -7,3 +7,5 @@ ktlintGradleVersion=14.0.1
 koverVersion=0.9.4
 spotbugsGradleVersion=6.0.26
 kotlinGradlePluginVersion=1.9.25
+checkstyleVersion=10.17.0
+pmdVersion=6.55.0

--- a/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/OctopusQualityPlugin.kt
+++ b/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/OctopusQualityPlugin.kt
@@ -55,17 +55,26 @@ class OctopusQualityPlugin : Plugin<Project> {
     override fun apply(project: Project) {
         val extension = project.extensions.create("octopusQuality", OctopusQualityExtension::class.java)
 
-        // Configure subprojects after they are evaluated (plugins and source sets resolved).
-        // Use subproject.afterEvaluate so that the consumer's build.gradle.kts has been processed.
-        if (project.subprojects.isEmpty()) {
-            project.afterEvaluate {
-                SubprojectConfigurer.configure(project, project, extension)
+        val targets =
+            if (project.subprojects.isEmpty()) {
+                listOf(project)
+            } else {
+                project.allprojects.filter { it != project }
             }
-        } else {
-            project.allprojects.filter { it != project }.forEach { sub ->
-                sub.afterEvaluate {
-                    SubprojectConfigurer.configure(sub, project, extension)
-                }
+
+        // Phase 1 — synchronous, BEFORE subproject scripts evaluate. Registers
+        // `plugins.withId(...)` callbacks for ktlint/detekt so that settings whose
+        // upstream tools read them during their own configuration (notably ktlint's
+        // baseline) actually land before task wiring. Lazy `Provider` mapping is used
+        // for any consumer-driven property — never `.get()` here.
+        targets.forEach { sub -> SubprojectConfigurer.registerEarly(sub, project, extension) }
+
+        // Phase 2 — afterEvaluate for source-set-dependent wiring (LanguageDetector,
+        // checkstyle/pmd/spotbugs/codenarc/jacoco/kover, and detekt's eager-Boolean
+        // `ignoreFailures` which has no lazy hook in detekt-gradle 1.23.x).
+        targets.forEach { sub ->
+            sub.afterEvaluate {
+                SubprojectConfigurer.configure(sub, project, extension)
             }
         }
 

--- a/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/SubprojectConfigurer.kt
+++ b/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/SubprojectConfigurer.kt
@@ -213,10 +213,12 @@ internal object SubprojectConfigurer {
                 it.reporter(org.jlleitschuh.gradle.ktlint.reporter.ReporterType.PLAIN)
                 it.reporter(org.jlleitschuh.gradle.ktlint.reporter.ReporterType.CHECKSTYLE)
             }
-            val baselineFile = File(project.projectDir, "ktlint-baseline.xml")
-            if (baselineFile.exists()) {
-                ext.baseline.set(baselineFile)
-            }
+            // Set the baseline path unconditionally — ktlint-gradle 14.0.1 treats a
+            // missing baseline file as empty at task-execution time, so this is safe on
+            // a fresh checkout. Side effect: `ktlintGenerateBaseline` writes to this
+            // convention path directly, so consumers don't need to relocate the file
+            // from ktlint-gradle's own default (`config/ktlint/baseline.xml`).
+            ext.baseline.set(File(project.projectDir, "ktlint-baseline.xml"))
             ext.filter {
                 it.exclude("**/generated/**")
                 it.exclude("**/build/**")

--- a/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/SubprojectConfigurer.kt
+++ b/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/SubprojectConfigurer.kt
@@ -9,24 +9,40 @@ import java.io.File
  * Configures quality tool plugins on individual subprojects (or root if single-module)
  * based on detected languages.
  */
+@Suppress("TooManyFunctions") // One configurer per supported tool — splitting would just relocate the count.
 internal object SubprojectConfigurer {
-    private const val CHECKSTYLE_VERSION = "10.17.0"
-    private const val PMD_VERSION = "6.55.0"
+    /**
+     * Phase 1 — synchronous, runs during root script evaluation (before any subproject
+     * `afterEvaluate`). Registers `plugins.withId(...)` callbacks for tools whose tasks
+     * read settings during their own configuration (ktlint, detekt). Settings made here
+     * land before the upstream tool wires its tasks, so things like baselines actually
+     * take effect on the first build.
+     *
+     * Inside the registered callbacks, NEVER call `.get()` on consumer-extension
+     * properties — the consumer's `octopusQuality { ... }` block may not have been
+     * processed yet. Use lazy `Provider` wiring (`.map { ... }`) instead, or defer the
+     * setting to the afterEvaluate path (see `configureDetektFailureFlag`).
+     */
+    fun registerEarly(
+        project: Project,
+        rootProject: Project,
+        extension: OctopusQualityExtension,
+    ) {
+        val configDir = resolveConfigDir(rootProject)
+        project.plugins.withId("org.jlleitschuh.gradle.ktlint") {
+            configureKtlint(project, extension)
+        }
+        project.plugins.withId("io.gitlab.arturbosch.detekt") {
+            configureDetektEarly(project, configDir)
+        }
+    }
 
     fun configure(
         project: Project,
         rootProject: Project,
         extension: OctopusQualityExtension,
     ) {
-        val configDir =
-            rootProject.extensions.extraProperties.let { extra ->
-                val key = "octopusQuality.configDir"
-                if (extra.has(key)) {
-                    extra.get(key) as File
-                } else {
-                    ConfigExtractor.extractTo(rootProject).also { extra.set(key, it) }
-                }
-            }
+        val configDir = resolveConfigDir(rootProject)
         val languages = LanguageDetector.detect(project)
 
         // Java/Groovy built-in tools: always safe to apply (Gradle core, no external classloader)
@@ -40,14 +56,13 @@ internal object SubprojectConfigurer {
             configureCodeNarc(project, configDir, extension)
         }
 
-        // Kotlin tools (detekt, ktlint): compileOnly deps — consumer provides versions
-        // via pluginManagement. We only configure when the consumer has applied them.
+        // Detekt's `ignoreFailures` is a plain `var Boolean` (no lazy Provider hook in
+        // 1.23.x), so the failure flag must be applied AFTER the consumer's
+        // `octopusQuality { ... }` block — i.e. from this afterEvaluate path. Everything
+        // else for detekt (config, baseline, reports) is set early via `registerEarly`.
         if (languages.hasKotlin) {
             project.plugins.withId("io.gitlab.arturbosch.detekt") {
-                configureDetekt(project, configDir, extension)
-            }
-            project.plugins.withId("org.jlleitschuh.gradle.ktlint") {
-                configureKtlint(project, extension)
+                configureDetektFailureFlag(project, extension)
             }
         }
 
@@ -64,6 +79,16 @@ internal object SubprojectConfigurer {
         }
     }
 
+    private fun resolveConfigDir(rootProject: Project): File =
+        rootProject.extensions.extraProperties.let { extra ->
+            val key = "octopusQuality.configDir"
+            if (extra.has(key)) {
+                extra.get(key) as File
+            } else {
+                ConfigExtractor.extractTo(rootProject).also { extra.set(key, it) }
+            }
+        }
+
     private fun configureCheckstyle(
         project: Project,
         configDir: File,
@@ -71,7 +96,7 @@ internal object SubprojectConfigurer {
     ) {
         project.pluginManager.apply("checkstyle")
         project.extensions.configure(org.gradle.api.plugins.quality.CheckstyleExtension::class.java) { ext ->
-            ext.toolVersion = CHECKSTYLE_VERSION
+            ext.toolVersion = BuildConstants.CHECKSTYLE_VERSION
             ext.configFile = File(configDir, "checkstyle.xml")
             ext.isShowViolations = true
             ext.isIgnoreFailures = !extension.java.failOnViolation.get()
@@ -91,7 +116,7 @@ internal object SubprojectConfigurer {
     ) {
         project.pluginManager.apply("pmd")
         project.extensions.configure(org.gradle.api.plugins.quality.PmdExtension::class.java) { ext ->
-            ext.toolVersion = PMD_VERSION
+            ext.toolVersion = BuildConstants.PMD_VERSION
             ext.isConsoleOutput = true
             ext.incrementalAnalysis.set(true)
             ext.isIgnoreFailures = !extension.java.failOnViolation.get()
@@ -128,12 +153,17 @@ internal object SubprojectConfigurer {
         }
     }
 
-    private fun configureDetekt(
+    /**
+     * Detekt's settings that must be in place before its tasks are wired (config,
+     * baseline, reports). Runs from a `plugins.withId` callback during root script
+     * evaluation — never call `.get()` on consumer extension properties here.
+     * `ignoreFailures` is intentionally NOT set here (no lazy Provider hook exists in
+     * detekt-gradle-plugin 1.23.x); see `configureDetektFailureFlag`.
+     */
+    private fun configureDetektEarly(
         project: Project,
         configDir: File,
-        extension: OctopusQualityExtension,
     ) {
-        // Plugin already applied by consumer — we only configure it
         project.extensions.configure(io.gitlab.arturbosch.detekt.extensions.DetektExtension::class.java) { ext ->
             ext.buildUponDefaultConfig = true
             ext.allRules = false
@@ -142,7 +172,6 @@ internal object SubprojectConfigurer {
             if (baselineFile.exists()) {
                 ext.baseline = baselineFile
             }
-            ext.ignoreFailures = !extension.kotlin.failOnViolation.get()
         }
         project.tasks.withType(io.gitlab.arturbosch.detekt.Detekt::class.java).configureEach { task ->
             task.reports {
@@ -154,13 +183,31 @@ internal object SubprojectConfigurer {
         }
     }
 
+    /**
+     * Detekt's `DetektExtension.ignoreFailures` is a plain `var Boolean` with no lazy
+     * Provider hook, so it must be set after the consumer's `octopusQuality { ... }`
+     * block has been processed — i.e. from the afterEvaluate path.
+     */
+    private fun configureDetektFailureFlag(
+        project: Project,
+        extension: OctopusQualityExtension,
+    ) {
+        project.extensions.configure(io.gitlab.arturbosch.detekt.extensions.DetektExtension::class.java) { ext ->
+            ext.ignoreFailures = !extension.kotlin.failOnViolation.get()
+        }
+    }
+
+    /**
+     * Runs from a `plugins.withId` callback during root script evaluation — never call
+     * `.get()` on consumer extension properties here; use `.map { }` so the consumer's
+     * `octopusQuality { ... }` override is observed when the property is finally read.
+     */
     private fun configureKtlint(
         project: Project,
         extension: OctopusQualityExtension,
     ) {
-        // Plugin already applied by consumer — we only configure it
         project.extensions.configure(org.jlleitschuh.gradle.ktlint.KtlintExtension::class.java) { ext ->
-            ext.ignoreFailures.set(!extension.kotlin.failOnViolation.get())
+            ext.ignoreFailures.set(extension.kotlin.failOnViolation.map { !it })
             ext.outputToConsole.set(true)
             ext.reporters {
                 it.reporter(org.jlleitschuh.gradle.ktlint.reporter.ReporterType.PLAIN)
@@ -173,17 +220,9 @@ internal object SubprojectConfigurer {
             ext.filter {
                 it.exclude("**/generated/**")
                 it.exclude("**/build/**")
-                it.include("**/src/**/*.kt")
+                it.include("**/*.kt", "**/*.kts")
             }
         }
-        // Disable Kotlin script checks
-        project.tasks
-            .matching { task ->
-                task.name == "runKtlintCheckOverKotlinScripts" ||
-                    task.name == "ktlintKotlinScriptCheck" ||
-                    task.name == "runKtlintFormatOverKotlinScripts" ||
-                    task.name == "ktlintKotlinScriptFormat"
-            }.configureEach { it.enabled = false }
     }
 
     private fun configureCodeNarc(
@@ -209,33 +248,29 @@ internal object SubprojectConfigurer {
         extension: OctopusQualityExtension,
     ) {
         project.pluginManager.apply("jacoco")
-        project.tasks.matching { it.name == "test" }.configureEach { testTask ->
-            testTask.finalizedBy(project.tasks.matching { it.name == "jacocoTestReport" })
+        val testTasks = project.tasks.withType(org.gradle.api.tasks.testing.Test::class.java)
+        val reportTasks = project.tasks.withType(org.gradle.testing.jacoco.tasks.JacocoReport::class.java)
+        val verifyTasks = project.tasks.withType(org.gradle.testing.jacoco.tasks.JacocoCoverageVerification::class.java)
+
+        testTasks.configureEach { testTask -> testTask.finalizedBy(reportTasks) }
+        reportTasks.configureEach { task ->
+            task.dependsOn(testTasks)
+            task.reports.xml.required
+                .set(true)
+            task.reports.html.required
+                .set(true)
         }
-        project.tasks
-            .withType(org.gradle.testing.jacoco.tasks.JacocoReport::class.java)
-            .matching { it.name == "jacocoTestReport" }
-            .configureEach { task ->
-                task.dependsOn(project.tasks.matching { it.name == "test" })
-                task.reports.xml.required
-                    .set(true)
-                task.reports.html.required
-                    .set(true)
-            }
-        project.tasks
-            .withType(org.gradle.testing.jacoco.tasks.JacocoCoverageVerification::class.java)
-            .matching { it.name == "jacocoTestCoverageVerification" }
-            .configureEach { task ->
-                task.dependsOn(project.tasks.matching { it.name == "test" })
-                task.violationRules.rule { rule ->
-                    rule.element = "BUNDLE"
-                    rule.limit { limit ->
-                        limit.counter = "LINE"
-                        limit.value = "COVEREDRATIO"
-                        limit.minimum = extension.coverage.minimumLineCoverage.get()
-                    }
+        verifyTasks.configureEach { task ->
+            task.dependsOn(testTasks)
+            task.violationRules.rule { rule ->
+                rule.element = "BUNDLE"
+                rule.limit { limit ->
+                    limit.counter = "LINE"
+                    limit.value = "COVEREDRATIO"
+                    limit.minimum = extension.coverage.minimumLineCoverage.get()
                 }
             }
+        }
     }
 
     @Suppress("UnusedParameter")

--- a/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/SubprojectConfigurer.kt
+++ b/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/SubprojectConfigurer.kt
@@ -248,20 +248,31 @@ internal object SubprojectConfigurer {
         extension: OctopusQualityExtension,
     ) {
         project.pluginManager.apply("jacoco")
-        val testTasks = project.tasks.withType(org.gradle.api.tasks.testing.Test::class.java)
+        // Type-based filtering applies report config (XML+HTML, violation rules) to ANY
+        // JacocoReport / JacocoCoverageVerification instance the consumer registers.
         val reportTasks = project.tasks.withType(org.gradle.testing.jacoco.tasks.JacocoReport::class.java)
         val verifyTasks = project.tasks.withType(org.gradle.testing.jacoco.tasks.JacocoCoverageVerification::class.java)
 
-        testTasks.configureEach { testTask -> testTask.finalizedBy(reportTasks) }
+        // Dependency wiring is scoped to the standard `test` ↔ `jacocoTestReport` /
+        // `jacocoTestCoverageVerification` triplet. Coupling every Test task to every
+        // JacocoReport (and vice versa) over-couples projects with extra source sets
+        // (e.g. `integrationTest` + `jacocoIntegrationTestReport`).
+        val testTask = project.tasks.withType(org.gradle.api.tasks.testing.Test::class.java)
+            .matching { it.name == "test" }
+        val defaultReportTask = reportTasks.matching { it.name == "jacocoTestReport" }
+        val defaultVerifyTask = verifyTasks.matching { it.name == "jacocoTestCoverageVerification" }
+
+        testTask.configureEach { task -> task.finalizedBy(defaultReportTask) }
+        defaultReportTask.configureEach { task -> task.dependsOn(testTask) }
+        defaultVerifyTask.configureEach { task -> task.dependsOn(testTask) }
+
         reportTasks.configureEach { task ->
-            task.dependsOn(testTasks)
             task.reports.xml.required
                 .set(true)
             task.reports.html.required
                 .set(true)
         }
         verifyTasks.configureEach { task ->
-            task.dependsOn(testTasks)
             task.violationRules.rule { rule ->
                 rule.element = "BUNDLE"
                 rule.limit { limit ->

--- a/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/SubprojectConfigurer.kt
+++ b/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/SubprojectConfigurer.kt
@@ -259,14 +259,14 @@ internal object SubprojectConfigurer {
         // `jacocoTestCoverageVerification` triplet. Coupling every Test task to every
         // JacocoReport (and vice versa) over-couples projects with extra source sets
         // (e.g. `integrationTest` + `jacocoIntegrationTestReport`).
-        val testTask = project.tasks.withType(org.gradle.api.tasks.testing.Test::class.java)
-            .matching { it.name == "test" }
+        val testTasks = project.tasks.withType(org.gradle.api.tasks.testing.Test::class.java)
+        val defaultTestTask = testTasks.matching { it.name == "test" }
         val defaultReportTask = reportTasks.matching { it.name == "jacocoTestReport" }
         val defaultVerifyTask = verifyTasks.matching { it.name == "jacocoTestCoverageVerification" }
 
-        testTask.configureEach { task -> task.finalizedBy(defaultReportTask) }
-        defaultReportTask.configureEach { task -> task.dependsOn(testTask) }
-        defaultVerifyTask.configureEach { task -> task.dependsOn(testTask) }
+        defaultTestTask.configureEach { task -> task.finalizedBy(defaultReportTask) }
+        defaultReportTask.configureEach { task -> task.dependsOn(defaultTestTask) }
+        defaultVerifyTask.configureEach { task -> task.dependsOn(defaultTestTask) }
 
         reportTasks.configureEach { task ->
             task.reports.xml.required

--- a/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/TaskRegistrar.kt
+++ b/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/TaskRegistrar.kt
@@ -11,6 +11,15 @@ import org.octopusden.octopus.quality.OctopusQualityExtension
  * Called from `gradle.projectsEvaluated` so all subproject plugins and tasks are already resolved.
  */
 internal object TaskRegistrar {
+    // Kover does not expose stable public types for these report tasks, so type-based
+    // matching is not viable. Names are extracted to constants so a Kover rename
+    // surfaces in one place; `dependOnExpectedTask` logs a warning when the named
+    // task is absent so silent breakage doesn't happen on a tool upgrade.
+    private const val KOVER_XML_REPORT = "koverXmlReport"
+    private const val KOVER_VERIFY = "koverVerify"
+    private const val KOVER_MERGED_XML_REPORT = "koverMergedXmlReport"
+    private const val KOVER_MERGED_VERIFY = "koverMergedVerify"
+
     fun register(
         rootProject: Project,
         extension: OctopusQualityExtension,
@@ -98,8 +107,8 @@ internal object TaskRegistrar {
                         dependOnIfExists(task, project, "jacocoTestCoverageVerification", excludedTasks)
                     }
                     CoverageExtension.Tool.KOVER -> {
-                        dependOnIfExists(task, project, "koverXmlReport", excludedTasks)
-                        dependOnIfExists(task, project, "koverVerify", excludedTasks)
+                        dependOnExpectedTask(task, project, KOVER_XML_REPORT, excludedTasks)
+                        dependOnExpectedTask(task, project, KOVER_VERIFY, excludedTasks)
                     }
                     else -> {}
                 }
@@ -112,10 +121,14 @@ internal object TaskRegistrar {
                 task.dependsOn("jacocoOverallCoverageVerification")
             }
             if (coverageTool == CoverageExtension.Tool.KOVER) {
-                dependOnRootIfExists(task, rootProject, "koverMergedXmlReport")
-                dependOnRootIfExists(task, rootProject, "koverXmlReport")
-                dependOnRootIfExists(task, rootProject, "koverMergedVerify")
-                dependOnRootIfExists(task, rootProject, "koverVerify")
+                // Either merged-* (multi-module) or single-module — exactly one set is
+                // expected to exist. Use the silent helper here so the absent half
+                // doesn't fire a spurious warning. If BOTH are missing, the per-project
+                // `dependOnExpectedTask` calls above will already have warned.
+                dependOnRootIfExists(task, rootProject, KOVER_MERGED_XML_REPORT)
+                dependOnRootIfExists(task, rootProject, KOVER_XML_REPORT)
+                dependOnRootIfExists(task, rootProject, KOVER_MERGED_VERIFY)
+                dependOnRootIfExists(task, rootProject, KOVER_VERIFY)
             }
         }
     }
@@ -278,6 +291,30 @@ internal object TaskRegistrar {
         if (taskName in excludedTasks || fullPath in excludedTasks) return
         if (taskName in project.tasks.names) {
             task.dependsOn(fullPath)
+        }
+    }
+
+    /**
+     * Like `dependOnIfExists` but logs a warning when the named task is absent and
+     * was not explicitly excluded. Use for tasks that the convention plugin requires
+     * by name (e.g. Kover's report tasks) so that an upstream rename surfaces loudly
+     * instead of becoming a silent no-op.
+     */
+    private fun dependOnExpectedTask(
+        task: Task,
+        project: Project,
+        taskName: String,
+        excludedTasks: Set<String>,
+    ) {
+        val fullPath = if (project.path == ":") ":$taskName" else "${project.path}:$taskName"
+        if (taskName in excludedTasks || fullPath in excludedTasks) return
+        if (taskName in project.tasks.names) {
+            task.dependsOn(fullPath)
+        } else {
+            project.logger.warn(
+                "octopusQuality: expected task '$taskName' not found on project '${project.path}'. " +
+                    "If the upstream tool renamed it, update the convention plugin.",
+            )
         }
     }
 

--- a/gradle-quality-plugin/src/test/kotlin/org/octopusden/octopus/quality/OctopusQualityPluginFunctionalTest.kt
+++ b/gradle-quality-plugin/src/test/kotlin/org/octopusden/octopus/quality/OctopusQualityPluginFunctionalTest.kt
@@ -564,13 +564,11 @@ class OctopusQualityPluginFunctionalTest {
         )
 
         // Phase 1: capture the violation into a real baseline file via ktlint-gradle's
-        // own task — avoids us hand-rolling the baseline XML schema. ktlint-gradle 14.0.1
-        // writes to its default path (config/ktlint/baseline.xml); the convention plugin
-        // expects the project-root convention path, so we copy.
+        // own task — avoids us hand-rolling the baseline XML schema. The convention
+        // plugin sets ext.baseline to <projectDir>/ktlint-baseline.xml unconditionally,
+        // so ktlintGenerateBaseline writes there directly (no copy needed).
         runner("ktlintGenerateBaseline").build()
-        val generatedBaseline = File(projectDir, "config/ktlint/baseline.xml")
-        assertTrue(generatedBaseline.exists(), "ktlintGenerateBaseline did not write its default baseline")
-        generatedBaseline.copyTo(File(projectDir, "ktlint-baseline.xml"))
+        assertTrue(File(projectDir, "ktlint-baseline.xml").exists(), "baseline not written to convention path")
 
         // Phase 2: with the baseline file pre-existing on the next Gradle invocation,
         // the convention plugin must wire it BEFORE ktlint-gradle reads its task config.

--- a/gradle-quality-plugin/src/test/kotlin/org/octopusden/octopus/quality/OctopusQualityPluginFunctionalTest.kt
+++ b/gradle-quality-plugin/src/test/kotlin/org/octopusden/octopus/quality/OctopusQualityPluginFunctionalTest.kt
@@ -650,5 +650,12 @@ class OctopusQualityPluginFunctionalTest {
             result.output.contains("build.gradle.kts"),
             "Expected ktlintCheck failure to mention build.gradle.kts; got: ${result.output}",
         )
+        // Rule-message assertion guards against false positives where "build.gradle.kts"
+        // appears in unrelated error output (deprecation warnings, stack traces).
+        // ktlint's PLAIN reporter prints the human message, not the rule id.
+        assertTrue(
+            result.output.contains("Wildcard import"),
+            "Expected ktlintCheck failure to fire the wildcard-import rule; got: ${result.output}",
+        )
     }
 }

--- a/gradle-quality-plugin/src/test/kotlin/org/octopusden/octopus/quality/OctopusQualityPluginFunctionalTest.kt
+++ b/gradle-quality-plugin/src/test/kotlin/org/octopusden/octopus/quality/OctopusQualityPluginFunctionalTest.kt
@@ -532,4 +532,125 @@ class OctopusQualityPluginFunctionalTest {
         assertTrue(result.task(":clean")?.outcome in setOf(TaskOutcome.SUCCESS, TaskOutcome.UP_TO_DATE))
         assertEquals(TaskOutcome.SUCCESS, result.task(":detekt")?.outcome)
     }
+
+    // ---------------------------------------------------------------
+    // Regression A: ktlint baseline must take effect on the first build cycle.
+    // Locks in the timing fix — pre-fix, `ext.baseline.set(...)` ran inside
+    // subproject.afterEvaluate, too late for ktlint-gradle 14.0.1 to wire the
+    // baseline into its check tasks, so a baselined violation still failed the build.
+    // ---------------------------------------------------------------
+    @Test
+    fun `ktlint baselined violation passes after clean - locks in timing fix`() {
+        settingsFile(kotlinSettings("test-ktlint-baseline"))
+        buildFile(
+            """
+            plugins {
+                kotlin("jvm") version "1.9.25"
+                id("org.jlleitschuh.gradle.ktlint") version "14.0.1"
+                id("org.octopusden.octopus-quality")
+            }
+            repositories { mavenCentral() }
+            octopusQuality {
+                kotlin { failOnViolation.set(true) }
+                coverage { enabled.set(false) }
+            }
+            tasks.named("ktlintCheck") { mustRunAfter(tasks.named("clean")) }
+            """.trimIndent(),
+        )
+        // Missing final newline → ktlint flags `standard:final-newline`.
+        writeKotlinFile(
+            "src/main/kotlin/com/example/Bad.kt",
+            "package com.example\nfun foo() = 1",
+        )
+
+        // Phase 1: capture the violation into a real baseline file via ktlint-gradle's
+        // own task — avoids us hand-rolling the baseline XML schema. ktlint-gradle 14.0.1
+        // writes to its default path (config/ktlint/baseline.xml); the convention plugin
+        // expects the project-root convention path, so we copy.
+        runner("ktlintGenerateBaseline").build()
+        val generatedBaseline = File(projectDir, "config/ktlint/baseline.xml")
+        assertTrue(generatedBaseline.exists(), "ktlintGenerateBaseline did not write its default baseline")
+        generatedBaseline.copyTo(File(projectDir, "ktlint-baseline.xml"))
+
+        // Phase 2: with the baseline file pre-existing on the next Gradle invocation,
+        // the convention plugin must wire it BEFORE ktlint-gradle reads its task config.
+        // Pre-fix: this would still fail with the baselined violation reported.
+        val result = runner("clean", "ktlintCheck").build()
+        assertEquals(TaskOutcome.SUCCESS, result.task(":ktlintCheck")?.outcome)
+    }
+
+    // ---------------------------------------------------------------
+    // Regression B: an unbaselined violation must fail the build when the consumer
+    // sets `failOnViolation = true`. Locks in lazy `Provider` wiring — pre-fix, an
+    // eager `.get()` inside the early withId callback would freeze the convention
+    // default (`false`), translating the consumer's `true` override into
+    // `ignoreFailures = true` and silently passing.
+    // ---------------------------------------------------------------
+    @Test
+    fun `ktlint unbaselined violation fails when failOnViolation is true - locks in lazy provider wiring`() {
+        settingsFile(kotlinSettings("test-ktlint-fail-on-violation"))
+        buildFile(
+            """
+            plugins {
+                kotlin("jvm") version "1.9.25"
+                id("org.jlleitschuh.gradle.ktlint") version "14.0.1"
+                id("org.octopusden.octopus-quality")
+            }
+            repositories { mavenCentral() }
+            octopusQuality {
+                kotlin { failOnViolation.set(true) }
+                coverage { enabled.set(false) }
+            }
+            tasks.named("ktlintCheck") { mustRunAfter(tasks.named("clean")) }
+            """.trimIndent(),
+        )
+        writeKotlinFile(
+            "src/main/kotlin/com/example/Bad.kt",
+            "package com.example\nfun foo() = 1",
+        )
+
+        val result = runner("clean", "ktlintCheck").buildAndFail()
+        assertTrue(
+            result.output.contains("Bad.kt"),
+            "Expected ktlint failure output to mention Bad.kt; got: ${result.output}",
+        )
+    }
+
+    // ---------------------------------------------------------------
+    // Regression C: ktlint must inspect *.gradle.kts files. Locks in the filter
+    // broadening (`include("**/*.kt", "**/*.kts")`) and the removal of the
+    // hardcoded ktlint script-task disable. Pre-fix, build scripts were silently
+    // skipped — a violation in `build.gradle.kts` would never be reported.
+    // ---------------------------------------------------------------
+    @Test
+    fun `ktlintCheck inspects build_gradle_kts violations - locks in filter broadening`() {
+        settingsFile(kotlinSettings("test-ktlint-kts-coverage"))
+        // Build script with a wildcard import (violates `no-wildcard-imports`).
+        // Wildcard imports are flagged on .kts as on .kt; the settings file has none.
+        buildFile(
+            """
+            import java.util.*
+
+            plugins {
+                kotlin("jvm") version "1.9.25"
+                id("org.jlleitschuh.gradle.ktlint") version "14.0.1"
+                id("org.octopusden.octopus-quality")
+            }
+            repositories { mavenCentral() }
+            octopusQuality {
+                kotlin { failOnViolation.set(true) }
+                coverage { enabled.set(false) }
+            }
+            // Reference UUID so the Kotlin compiler doesn't strip the import.
+            val unused: UUID? = null
+            tasks.named("ktlintCheck") { mustRunAfter(tasks.named("clean")) }
+            """.trimIndent(),
+        )
+
+        val result = runner("clean", "ktlintCheck").buildAndFail()
+        assertTrue(
+            result.output.contains("build.gradle.kts"),
+            "Expected ktlintCheck failure to mention build.gradle.kts; got: ${result.output}",
+        )
+    }
 }


### PR DESCRIPTION
Closes #135.

## Problem

ORMS pilot (octopusden/octopus-release-management-service#57) hit a baseline-not-applied bug in `octopus-quality` v2.3.1: ktlint baseline set inside `subproject.afterEvaluate { }` is too late for ktlint-gradle 14.0.1 to wire correctly. ORMS worked around it in its root `build.gradle.kts` (commit `c1ee490`).

Investigation surfaced 12 similar hardcoded-fragility patterns across the convention plugin and shared workflows — task-name string matching, version constants in Kotlin source, octopus-test/octopus-release-log endpoints baked into shared workflows. One PR fixes them all so the next plugin release unblocks the ORMS workaround removal.

## Fix

### Convention plugin (`gradle-quality-plugin/`)

- **`OctopusQualityPlugin.apply()`** split into two phases: phase 1 (`registerEarly`, synchronous, before subproject script eval) installs `plugins.withId(...)` callbacks for ktlint/detekt; phase 2 (`afterEvaluate`) keeps source-set-dependent wiring. Settings made in phase 1 land *before* the upstream tool wires its tasks, so ktlint baselines actually take effect on the first build.
- **`configureKtlint`** uses lazy Provider wiring (`extension.kotlin.failOnViolation.map { !it }`) so the consumer's `octopusQuality { ... }` override is observed even though phase 1 fires before the consumer block runs. The hardcoded `runKtlintCheckOverKotlinScripts` script-disable block is gone; the filter glob now includes `**/*.kts`. The baseline path is set unconditionally so `ktlintGenerateBaseline` writes to the convention path directly.
- **Detekt** is split: config/baseline/reports go in phase 1; `ignoreFailures` (eager `var Boolean` with no Provider hook in detekt-gradle 1.23.x) stays in the afterEvaluate path so the consumer override is observed without needing a lazy hook.
- **JaCoCo** uses `tasks.withType<JacocoReport>()` / `<JacocoCoverageVerification>()` for report config (XML+HTML, violation rules — sensible defaults for any instance), but scopes `finalizedBy`/`dependsOn` to the standard `test` ↔ `jacocoTestReport` / `jacocoTestCoverageVerification` triplet by name to avoid over-coupling multi-source-set projects.
- **Kover** task names extracted to `KOVER_*` constants in `TaskRegistrar`; new `dependOnExpectedTask` helper logs a warning when an expected task is absent (silent renames → loud).
- **Versions** — `checkstyleVersion=10.17.0`, `pmdVersion=6.55.0` moved from Kotlin source to `gradle.properties`; surfaced via a `generateBuildConstants` task that writes `BuildConstants.kt`.

### Shared workflows (`.github/workflows/`)

All input additions are backward-compatible — defaults preserve current behavior.

- **`verify-octopus-test-consumer.yml`** — new inputs `octopus_test_repository` (default `octopusden/octopus-test`) and `poll_interval_seconds` (default `15`); replaces the four `sleep 15` calls and the hardcoded env literal.
- **`common-register-release.yml`** — replaces the full URL input with `release-log-repository` (`owner/repo`, default `octopusden/octopus-release-log`); the API URL is constructed from a fixed `https://api.github.com/repos/{repo}/dispatches` template, keeping the bearer token constrained to api.github.com regardless of caller input. Adds `github-api-version` input. All inputs threaded through `env:` blocks; JSON payload built via `jq` to eliminate shell- and JSON-injection vectors.
- **`check-octopus-test-consumer.yml`** — new input `actionlint_image` with job-`env:` fallback for `pull_request` triggers (which can't supply inputs).

## Test

Three new functional tests in `OctopusQualityPluginFunctionalTest.kt`:

1. **Baselined source violation passes after `clean`** — locks in the timing fix (pre-fix the baseline never reached the check tasks).
2. **Unbaselined source violation fails when `failOnViolation = true`** — locks in lazy Provider wiring (eager `.get()` would freeze the convention default and the build would silently pass).
3. **`ktlintCheck` inspects `build.gradle.kts` violations** — locks in the filter broadening + script-disable removal. Asserts both that the build script is mentioned in the failure output AND that the wildcard-import rule fired (so unrelated errors mentioning `build.gradle.kts` can't false-positive).

15 functional tests + plugin self-quality (`detekt`, `ktlintCheck`) green.

## Review feedback addressed

Two findings from the Copilot PR review:
- **JaCoCo over-coupling** (suggested by @copilot-pull-request-reviewer): the initial type-based replacement coupled every `Test` task to every `JacocoReport` task. Re-scoped `finalizedBy`/`dependsOn` to the standard triplet by name (`13e37ea`).
- **Token exfiltration via arbitrary dispatch URL** (suggested by @copilot-pull-request-reviewer): the initial `release-log-dispatch-url` input would have let a caller redirect the bearer token off-host. Replaced with `release-log-repository` and constructed the URL from a fixed template; threaded all inputs through `env:` and built JSON via `jq` (`6be015d`).

Two findings from a sub-agent review:
- **Test C not hermetic** — added rule-message assertion (`b30d37c`).
- **ktlint baseline path captured at phase-1 time** — set unconditionally; simplified Test A (`60847c7`).

## Impact

- Needs a `v2.3.2` release after merge; ORMS will then bump and remove its workaround in `build.gradle.kts` (commit `c1ee490`).
- Consumers that want to skip linting `*.gradle.kts` opt out explicitly: `ktlint { filter { exclude("**/*.gradle.kts") } }`. Pre-existing violations in build scripts can be baselined like any other source-set violation.

## Out of scope (handled elsewhere)

- `aquasecurity/trivy-action` bump → #111
- `ghcr.io` org parameterization in `common-java-gradle-release.yml` → #117
- CodeQL `actions` migration of `validate-workflow-injection.sh` → #134