### PR TITLE
feat: bundle .editorconfig in convention plugin to lock ktlint rules

### DIFF
--- a/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/ConfigExtractor.kt
+++ b/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/ConfigExtractor.kt
@@ -18,6 +18,7 @@ internal object ConfigExtractor {
             "checkstyle.xml",
             "pmd-ruleset.xml",
             "codenarc.groovy",
+            ".editorconfig",
         )
 
     /**

--- a/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/EditorConfigParser.kt
+++ b/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/EditorConfigParser.kt
@@ -1,0 +1,64 @@
+package org.octopusden.octopus.quality.internal
+
+import java.io.File
+
+/**
+ * Reads the bundled `.editorconfig` and returns flat key/value pairs from the
+ * Kotlin sections, suitable for ktlint-gradle's `additionalEditorconfig`
+ * `MapProperty`.
+ *
+ * Filters to keys ktlint's EditorConfigPropertyRegistry recognizes — feeding
+ * an unknown key (e.g. `charset`) through `additionalEditorconfig` causes
+ * `EditorConfigPropertyNotFoundException` at task wiring. Allow-list is preferred
+ * over deny-list so an accidental edit to the bundled file (e.g. someone adds
+ * `tab_width`) doesn't silently break ktlint.
+ *
+ * Top-level `root = true` and comment/blank lines are skipped.
+ */
+internal object EditorConfigParser {
+    private val KOTLIN_SECTIONS = setOf("*.{kt,kts}", "*.kt", "*.kts")
+
+    // ktlint 1.5.0 EditorConfigPropertyRegistry core keys (verified against
+    // ktlint-gradle 14.0.1 / 14.2.0). Keep in sync if/when the bundled file
+    // adds new core editorconfig knobs.
+    private val ALLOWED_CORE_KEYS =
+        setOf(
+            "end_of_line",
+            "indent_style",
+            "indent_size",
+            "insert_final_newline",
+            "max_line_length",
+        )
+
+    fun parseKotlinSection(file: File): Map<String, String> {
+        val result = LinkedHashMap<String, String>()
+        var inKotlinSection = false
+        for (raw in file.readLines()) {
+            val line = raw.trim()
+            when {
+                line.isEmpty() || line.startsWith("#") || line.startsWith(";") -> Unit
+                line.startsWith("[") && line.endsWith("]") -> {
+                    inKotlinSection = line.substring(1, line.length - 1).trim() in KOTLIN_SECTIONS
+                }
+                inKotlinSection -> appendAssignment(line, result)
+            }
+        }
+        return result
+    }
+
+    private fun appendAssignment(
+        line: String,
+        result: MutableMap<String, String>,
+    ) {
+        val eq = line.indexOf('=')
+        if (eq <= 0) return
+        val key = line.substring(0, eq).trim()
+        val value = line.substring(eq + 1).trim()
+        if (isKtlintKey(key)) result[key] = value
+    }
+
+    private fun isKtlintKey(key: String): Boolean =
+        key.startsWith("ktlint_") ||
+            key.startsWith("ij_kotlin_") ||
+            key in ALLOWED_CORE_KEYS
+}

--- a/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/SubprojectConfigurer.kt
+++ b/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/SubprojectConfigurer.kt
@@ -30,7 +30,7 @@ internal object SubprojectConfigurer {
     ) {
         val configDir = resolveConfigDir(rootProject)
         project.plugins.withId("org.jlleitschuh.gradle.ktlint") {
-            configureKtlint(project, extension)
+            configureKtlint(project, configDir, extension)
         }
         project.plugins.withId("io.gitlab.arturbosch.detekt") {
             configureDetektEarly(project, configDir)
@@ -204,8 +204,20 @@ internal object SubprojectConfigurer {
      */
     private fun configureKtlint(
         project: Project,
+        configDir: File,
         extension: OctopusQualityExtension,
     ) {
+        // Bundled .editorconfig is the authoritative source for ktlint editorconfig
+        // values across the org. Parse it once at configuration time and feed the
+        // ktlint-recognized keys into ktlint-gradle's additionalEditorconfig
+        // MapProperty (14.x has no path-based editorconfig API). Fail-fast if the
+        // resource is missing — that means jar packaging dropped the dotfile.
+        val editorConfig = File(configDir, ".editorconfig")
+        require(editorConfig.isFile) {
+            "Bundled .editorconfig missing at ${editorConfig.absolutePath}. " +
+                "Check gradle-quality-plugin resource packaging."
+        }
+        val editorConfigEntries = EditorConfigParser.parseKotlinSection(editorConfig)
         project.extensions.configure(org.jlleitschuh.gradle.ktlint.KtlintExtension::class.java) { ext ->
             ext.ignoreFailures.set(extension.kotlin.failOnViolation.map { !it })
             ext.outputToConsole.set(true)
@@ -224,6 +236,7 @@ internal object SubprojectConfigurer {
                 it.exclude("**/build/**")
                 it.include("**/*.kt", "**/*.kts")
             }
+            ext.additionalEditorconfig.putAll(editorConfigEntries)
         }
     }
 

--- a/gradle-quality-plugin/src/main/resources/org/octopusden/octopus/quality/config/.editorconfig
+++ b/gradle-quality-plugin/src/main/resources/org/octopusden/octopus/quality/config/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*.{kt,kts}]
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+max_line_length = 140
+ij_kotlin_allow_trailing_comma = true
+ij_kotlin_allow_trailing_comma_on_call_site = true
+
+ktlint_standard_multiline-expression-wrapping = disabled

--- a/gradle-quality-plugin/src/test/kotlin/org/octopusden/octopus/quality/OctopusQualityPluginFunctionalTest.kt
+++ b/gradle-quality-plugin/src/test/kotlin/org/octopusden/octopus/quality/OctopusQualityPluginFunctionalTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
 
+@Suppress("LargeClass") // Functional smoke-tests for the whole plugin surface — splitting would just relocate cases.
 class OctopusQualityPluginFunctionalTest {
     @TempDir
     lateinit var projectDir: File
@@ -656,6 +657,169 @@ class OctopusQualityPluginFunctionalTest {
         assertTrue(
             result.output.contains("Wildcard import"),
             "Expected ktlintCheck failure to fire the wildcard-import rule; got: ${result.output}",
+        )
+    }
+
+    // ---------------------------------------------------------------
+    // #136 D: bundled .editorconfig fixes max_line_length at 140 — a 150-char
+    // source line must fail ktlintCheck. Combined with the consumer override
+    // test below, this locks in plugin-config-is-authoritative semantics.
+    // ---------------------------------------------------------------
+    @Test
+    fun `bundled editorconfig sets max_line_length to 140`() {
+        settingsFile(kotlinSettings("test-editorconfig-max-line-length"))
+        buildFile(
+            """
+            plugins {
+                kotlin("jvm") version "1.9.25"
+                id("org.jlleitschuh.gradle.ktlint") version "14.0.1"
+                id("org.octopusden.octopus-quality")
+            }
+            repositories { mavenCentral() }
+            octopusQuality {
+                kotlin { failOnViolation.set(true) }
+                coverage { enabled.set(false) }
+            }
+            """.trimIndent() + "\n",
+        )
+        // Long arithmetic expression — non-comment code so ktlint can't apply any
+        // single-string-literal or comment-only exemption. Line length below works
+        // out to 153 chars, well over 140.
+        val longExpr = (1..30).joinToString(" + ") { it.toString() }
+        writeKotlinFile(
+            "src/main/kotlin/com/example/A.kt",
+            "package com.example\n\nfun a(): Int = $longExpr\n",
+        )
+
+        val result = runner("ktlintCheck").buildAndFail()
+        assertTrue(
+            result.output.contains("Exceeded max line length (140)"),
+            "Expected ktlint violation against bundled max_line_length=140; got: ${result.output}",
+        )
+    }
+
+    // ---------------------------------------------------------------
+    // #136 E: bundled .editorconfig disables multiline-expression-wrapping.
+    // Fixture lives in build.gradle.kts so the test simultaneously proves the
+    // rule is off AND that bundled config is applied to .kts files (#138 broadened
+    // the ktlint filter to include *.kts; this test confirms our bundled values
+    // ride along the same selector).
+    // ---------------------------------------------------------------
+    @Test
+    fun `bundled editorconfig disables multiline-expression-wrapping on kts files`() {
+        settingsFile(kotlinSettings("test-editorconfig-disable-rule"))
+        // The trailing `listOf(...)` form on the right-hand side of `=` is the
+        // canonical violation for ktlint_standard_multiline-expression-wrapping
+        // — pre-fix it would force the call onto a new line. Bundled config
+        // disables the rule, so this build script must lint clean.
+        buildFile(
+            """
+            plugins {
+                kotlin("jvm") version "1.9.25"
+                id("org.jlleitschuh.gradle.ktlint") version "14.0.1"
+                id("org.octopusden.octopus-quality")
+            }
+            repositories { mavenCentral() }
+            octopusQuality {
+                kotlin { failOnViolation.set(true) }
+                coverage { enabled.set(false) }
+            }
+            val triggerList: List<String> = listOf(
+                "a",
+                "b",
+            )
+            // Reference the val so the Kotlin compiler doesn't strip it as unused.
+            tasks.register("printTrigger") { doLast { println(triggerList) } }
+            """.trimIndent() + "\n",
+        )
+
+        val result = runner("ktlintCheck").build()
+        assertEquals(TaskOutcome.SUCCESS, result.task(":ktlintCheck")?.outcome)
+    }
+
+    // ---------------------------------------------------------------
+    // #136 F: plugin-bundled values take precedence over a consumer-level
+    // <projectDir>/.editorconfig. ktlint-gradle's additionalEditorconfig is
+    // applied as an EditorConfigOverride, so a 100-char line must PASS even
+    // though the local .editorconfig sets max_line_length=80 — plugin's 140
+    // wins. Implicitly also asserts startup doesn't throw
+    // EditorConfigPropertyNotFoundException (would occur if the parser leaked
+    // a non-ktlint key like `charset`).
+    // ---------------------------------------------------------------
+    @Test
+    fun `plugin editorconfig values override consumer-level dot-editorconfig`() {
+        settingsFile(kotlinSettings("test-editorconfig-plugin-wins"))
+        File(projectDir, ".editorconfig").writeText(
+            """
+            [*.{kt,kts}]
+            max_line_length = 80
+            """.trimIndent(),
+        )
+        buildFile(
+            """
+            plugins {
+                kotlin("jvm") version "1.9.25"
+                id("org.jlleitschuh.gradle.ktlint") version "14.0.1"
+                id("org.octopusden.octopus-quality")
+            }
+            repositories { mavenCentral() }
+            octopusQuality {
+                kotlin { failOnViolation.set(true) }
+                coverage { enabled.set(false) }
+            }
+            """.trimIndent() + "\n",
+        )
+        // 100 chars: violates local 80, well within plugin's 140.
+        val line100 = "// " + "x".repeat(97)
+        writeKotlinFile(
+            "src/main/kotlin/com/example/A.kt",
+            "package com.example\n\nfun a() {\n    $line100\n}\n",
+        )
+
+        val result = runner("ktlintCheck").build()
+        assertEquals(TaskOutcome.SUCCESS, result.task(":ktlintCheck")?.outcome)
+    }
+
+    // ---------------------------------------------------------------
+    // #136 G: a consumer can still override plugin-bundled values from their
+    // build.gradle.kts via `ktlint { additionalEditorconfig.put(...) }` —
+    // MapProperty last-set-wins semantics. Documents the supported escape
+    // hatch: a 130-char line is within plugin's 140 limit but breaks the
+    // consumer's lowered 100 limit.
+    // ---------------------------------------------------------------
+    @Test
+    fun `consumer can override plugin editorconfig via build script`() {
+        settingsFile(kotlinSettings("test-editorconfig-consumer-override"))
+        buildFile(
+            """
+            plugins {
+                kotlin("jvm") version "1.9.25"
+                id("org.jlleitschuh.gradle.ktlint") version "14.0.1"
+                id("org.octopusden.octopus-quality")
+            }
+            repositories { mavenCentral() }
+            octopusQuality {
+                kotlin { failOnViolation.set(true) }
+                coverage { enabled.set(false) }
+            }
+            ktlint {
+                additionalEditorconfig.put("max_line_length", "100")
+            }
+            """.trimIndent() + "\n",
+        )
+        // Long arithmetic expression — non-comment code so ktlint can't apply any
+        // single-literal or comment-only exemption. 113 chars: passes plugin's
+        // 140, breaks consumer's 100.
+        val longExpr = (1..22).joinToString(" + ") { it.toString() }
+        writeKotlinFile(
+            "src/main/kotlin/com/example/A.kt",
+            "package com.example\n\nfun a(): Int = $longExpr\n",
+        )
+
+        val result = runner("ktlintCheck").buildAndFail()
+        assertTrue(
+            result.output.contains("max line length"),
+            "Expected ktlint violation against consumer override; got: ${result.output}",
         )
     }
 }

--- a/gradle-quality-plugin/src/test/kotlin/org/octopusden/octopus/quality/internal/EditorConfigParserTest.kt
+++ b/gradle-quality-plugin/src/test/kotlin/org/octopusden/octopus/quality/internal/EditorConfigParserTest.kt
@@ -1,0 +1,145 @@
+package org.octopusden.octopus.quality.internal
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+
+class EditorConfigParserTest {
+    @TempDir
+    lateinit var tempDir: Path
+
+    private fun writeEditorConfig(content: String): File {
+        val file = tempDir.resolve(".editorconfig").toFile()
+        file.writeText(content)
+        return file
+    }
+
+    @Test
+    fun `parses Kotlin section, drops root and other-language sections and comments`() {
+        val file =
+            writeEditorConfig(
+                """
+                # leading comment
+                root = true
+
+                [*.{kt,kts}]
+                indent_style = space
+                ; semicolon comment
+                max_line_length = 140
+
+                [*.java]
+                indent_size = 2
+                """.trimIndent(),
+            )
+        val parsed = EditorConfigParser.parseKotlinSection(file)
+
+        assertEquals(mapOf("indent_style" to "space", "max_line_length" to "140"), parsed)
+        assertFalse(parsed.containsKey("root"), "root meta-key must be skipped")
+        assertFalse(parsed.containsKey("indent_size"), "java-section keys must be skipped")
+    }
+
+    @Test
+    fun `drops charset because ktlint registry does not recognize it`() {
+        val file =
+            writeEditorConfig(
+                """
+                [*.{kt,kts}]
+                charset = utf-8
+                max_line_length = 140
+                """.trimIndent(),
+            )
+        val parsed = EditorConfigParser.parseKotlinSection(file)
+
+        assertFalse(parsed.containsKey("charset"), "charset is not a ktlint-recognized key")
+        assertEquals("140", parsed["max_line_length"])
+    }
+
+    @Test
+    fun `keeps ktlint-, ij_kotlin- and core editorconfig keys`() {
+        val file =
+            writeEditorConfig(
+                """
+                [*.{kt,kts}]
+                ktlint_standard_foo = disabled
+                ij_kotlin_allow_trailing_comma = true
+                max_line_length = 140
+                """.trimIndent(),
+            )
+        val parsed = EditorConfigParser.parseKotlinSection(file)
+
+        assertTrue(parsed.containsKey("ktlint_standard_foo"))
+        assertTrue(parsed.containsKey("ij_kotlin_allow_trailing_comma"))
+        assertTrue(parsed.containsKey("max_line_length"))
+        assertEquals(3, parsed.size)
+    }
+
+    @Test
+    fun `drops keys that are neither prefixed nor in the core allow-list`() {
+        val file =
+            writeEditorConfig(
+                """
+                [*.{kt,kts}]
+                tab_width = 4
+                max_line_length = 140
+                """.trimIndent(),
+            )
+        val parsed = EditorConfigParser.parseKotlinSection(file)
+
+        assertFalse(parsed.containsKey("tab_width"), "tab_width is not in the allow-list")
+        assertEquals("140", parsed["max_line_length"])
+    }
+
+    @Test
+    fun `aggregates entries from multiple Kotlin-matching selectors`() {
+        val file =
+            writeEditorConfig(
+                """
+                [*.kt]
+                max_line_length = 140
+
+                [*.kts]
+                indent_style = space
+
+                [*.{kt,kts}]
+                ij_kotlin_allow_trailing_comma = true
+                """.trimIndent(),
+            )
+        val parsed = EditorConfigParser.parseKotlinSection(file)
+
+        assertEquals(
+            mapOf(
+                "max_line_length" to "140",
+                "indent_style" to "space",
+                "ij_kotlin_allow_trailing_comma" to "true",
+            ),
+            parsed,
+        )
+    }
+
+    @Test
+    fun `real bundled editorconfig parses to expected canonical map`() {
+        val resourcePath = "org/octopusden/octopus/quality/config/.editorconfig"
+        val resourceStream =
+            javaClass.classLoader.getResourceAsStream(resourcePath)
+                ?: error("Bundled .editorconfig resource missing on classpath: $resourcePath")
+        val target = tempDir.resolve(".editorconfig").toFile()
+        resourceStream.use { input -> target.outputStream().use { output -> input.copyTo(output) } }
+
+        val expected =
+            mapOf(
+                "end_of_line" to "lf",
+                "indent_style" to "space",
+                "indent_size" to "4",
+                "insert_final_newline" to "true",
+                "max_line_length" to "140",
+                "ij_kotlin_allow_trailing_comma" to "true",
+                "ij_kotlin_allow_trailing_comma_on_call_site" to "true",
+                "ktlint_standard_multiline-expression-wrapping" to "disabled",
+            )
+        assertEquals(expected, EditorConfigParser.parseKotlinSection(target))
+    }
+}


### PR DESCRIPTION
## Summary

- Bundle a canonical `.editorconfig` in the quality convention plugin and wire it into ktlint via `additionalEditorconfig` (ktlint-gradle 14.x has no path-based editorconfig API).
- Lock `max_line_length=140`, IntelliJ trailing-comma defaults, and explicitly disable `multiline-expression-wrapping` — the rule that broke octopusden/octopus-release-management-service#57 on a ktlint-gradle upgrade and motivated this change.
- Apply automatically to both `*.kt` and `*.gradle.kts` (build scripts share the `[*.{kt,kts}]` section after #138 broadened the ktlint filter).

## Wiring

- `SubprojectConfigurer.configureKtlint` now takes `configDir` and calls `additionalEditorconfig.putAll(EditorConfigParser.parseKotlinSection(...))` inside the existing `extensions.configure(KtlintExtension)` block.
- `EditorConfigParser` filters to ktlint-recognized keys (`ktlint_*`, `ij_kotlin_*`, plus an allow-listed set of core editorconfig knobs). Non-ktlint values like `charset` are dropped — feeding them through `additionalEditorconfig` would throw `EditorConfigPropertyNotFoundException` at task wiring.
- Bundled file is fail-fast: `require(editorConfig.isFile)` at the wiring site so a future `processResources` filter that drops the dotfile crashes loudly during plugin apply rather than silently shipping default ktlint behavior.

## Precedence — plugin config is authoritative

Values are passed through ktlint-gradle's `additionalEditorconfig`, which acts as an `EditorConfigOverride` — i.e. plugin-bundled values take precedence over any consumer-level `<projectRoot>/.editorconfig` for the keys the plugin sets. Consumers that need different values should change the canonical bundled file (PR to octopus-base) or, as a per-repo escape hatch, override after the plugin runs:

```kotlin
ktlint {
    additionalEditorconfig.put("max_line_length", "120")
}
```

`MapProperty` last-set-wins semantics make this work. Both directions are covered by functional tests below.

## Tests

Unit (`EditorConfigParserTest`, 6 cases): synthetic fixtures via `@TempDir` covering section selection, comment/blank skipping, the `charset` drop, allow-list enforcement, and multi-section aggregation; plus one case loading the real bundled resource via classloader and asserting exact map equality (catches accidental drops/additions on the canonical file in review).

Functional (`OctopusQualityPluginFunctionalTest`, 4 new cases on top of #138's regressions A/B/C):

- `bundled editorconfig sets max_line_length to 140` — long arithmetic expression in a `.kt` file fails `ktlintCheck` with `Exceeded max line length (140)`.
- `bundled editorconfig disables multiline-expression-wrapping on kts files` — multiline `listOf(...)` in `build.gradle.kts` lints clean (also implicit `.kts`-coverage check).
- `plugin editorconfig values override consumer-level dot-editorconfig` — consumer's `<projectDir>/.editorconfig` with `max_line_length=80` is overridden by plugin's 140; a 100-char line passes.
- `consumer can override plugin editorconfig via build script` — consumer's `ktlint { additionalEditorconfig.put("max_line_length", "100") }` after plugin apply wins via MapProperty last-set-wins; a 130-char line fails.

`./gradlew check` is green: 40 tests + ktlint + detekt + Kover gate (#133).

## Pre-merge gate

Built and verified against octopusden/octopus-release-management-service#57 with the ORMS-local root `.editorconfig` moved aside: `./gradlew ktlintCheck` PASSES on all 45 ktlint tasks across modules, no `multiline-expression-wrapping` violations. Cleanup of the redundant local `.editorconfig` is staged in the ORMS clone (waiting on a v2.3.3 release before push).

## Test plan

- [x] `./gradlew check` green locally
- [x] ORMS PR #57 ktlintCheck PASS against this SNAPSHOT
- [ ] CI green on this PR
- [ ] After merge: cut v2.3.3 via `release-octopus-base.yml` (patch increment)
- [ ] After v2.3.3 release: push the ORMS cleanup commit (remove redundant `.editorconfig`, bump pin to 2.3.3)

## Out of scope

- ktlint-gradle 14.0.1 → 14.2.0 bump (separate task; no breaking changes per upstream changelog).
- Expanding the minimal allow-list for detekt/checkstyle/pmd/codenarc — issue body explicitly defers.
- Replacing `.editorconfig` with JSON/YAML — `.editorconfig` is what ktlint reads natively.

## References

- Closes #136
- Builds on #138 (closed #135) — `additionalEditorconfig` must be set during the early `plugins.withId(...)` callback registered before `afterEvaluate`; the timing fix is a hard prerequisite.
- Related to #112 (canonical Kotlin quality-rule configs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)