### PR TITLE
feat(quality): guard against hollow static-analysis gate (#144)

### DIFF
--- a/gradle-quality-plugin/build.gradle.kts
+++ b/gradle-quality-plugin/build.gradle.kts
@@ -48,6 +48,8 @@ kover {
                     "org.octopusden.octopus.quality.internal.TaskRegistrar\$*",
                     "org.octopusden.octopus.quality.internal.PublicationValidator",
                     "org.octopusden.octopus.quality.internal.PublicationValidator\$*",
+                    "org.octopusden.octopus.quality.internal.HollowGateGuard",
+                    "org.octopusden.octopus.quality.internal.HollowGateGuard\$*",
                 )
             }
         }

--- a/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/HollowGateGuard.kt
+++ b/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/HollowGateGuard.kt
@@ -1,0 +1,66 @@
+package org.octopusden.octopus.quality.internal
+
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+
+/**
+ * Guards against a "hollow" static-analysis gate.
+ *
+ * The convention plugin *self-applies* the Java/Groovy analysers (checkstyle/pmd/spotbugs/codenarc)
+ * but only *reactively configures* detekt/ktlint via `plugins.withId(...)` — the consumer must apply
+ * those plugins per Kotlin subproject (see `OctopusQualityPlugin` KDoc). If a module has Kotlin
+ * sources but never applied them, no `detekt`/`ktlintCheck` tasks are created, `qualityStatic`'s
+ * `dependOnIfExists` finds nothing, and the gate passes green while analysing zero Kotlin — a false
+ * assurance (observed in octopus-components-registry-service).
+ *
+ * This registers `verifyStaticAnalysisApplied`, wired as a dependency of `qualityStatic`, which fails
+ * the build with a per-module message when a Kotlin module is missing its analysis tasks.
+ *
+ * Self-apply of detekt/ktlint is deliberately NOT done: they are declared `compileOnly` (consumer
+ * provides the version via `pluginManagement`) because both are Kotlin-version-coupled — bundling
+ * them would force a Kotlin version onto every consumer. The assertion works over the
+ * consumer-provided plugins instead.
+ */
+internal object HollowGateGuard {
+    private val REQUIRED_KOTLIN_TASKS = listOf("detekt", "ktlintCheck")
+
+    fun register(
+        rootProject: Project,
+        targets: List<Project>,
+    ) {
+        // Computed here (from `gradle.projectsEvaluated`, so tasks are resolved) and captured into the
+        // task action as plain strings — no Project/task references leak into execution, keeping the
+        // guard configuration-cache friendly.
+        val problems =
+            targets.mapNotNull { project ->
+                if (!LanguageDetector.detect(project).hasKotlin) return@mapNotNull null
+                val missing = REQUIRED_KOTLIN_TASKS.filter { project.tasks.findByName(it) == null }
+                if (missing.isEmpty()) {
+                    null
+                } else {
+                    "${project.path}: Kotlin sources present but ${missing.joinToString(", ")} " +
+                        "task(s) missing — apply the plugin(s) in this module's build script."
+                }
+            }
+
+        val guard =
+            rootProject.tasks.register("verifyStaticAnalysisApplied") { task ->
+                task.group = "verification"
+                task.description =
+                    "Fails if a module has Kotlin sources but its static-analysis tasks were never " +
+                    "created (a hollow quality gate)."
+                task.doLast {
+                    if (problems.isNotEmpty()) {
+                        throw GradleException(
+                            "Hollow quality gate — static analysis would pass without scanning Kotlin:\n" +
+                                problems.joinToString("\n") { "  - $it" } +
+                                "\nSee OctopusQualityPlugin KDoc: consumers must apply detekt & ktlint " +
+                                "per Kotlin subproject.",
+                        )
+                    }
+                }
+            }
+
+        rootProject.tasks.named("qualityStatic").configure { it.dependsOn(guard) }
+    }
+}

--- a/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/TaskRegistrar.kt
+++ b/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/TaskRegistrar.kt
@@ -29,6 +29,7 @@ internal object TaskRegistrar {
         val excludedTasks = extension.excludedTasks.get()
 
         registerQualityStatic(rootProject, allProjects, excludedTasks)
+        HollowGateGuard.register(rootProject, allProjects)
         registerQualityCoverage(rootProject, coverageProjects, extension, excludedTasks)
         registerQualityCheck(rootProject)
     }

--- a/gradle-quality-plugin/src/test/kotlin/org/octopusden/octopus/quality/OctopusQualityPluginFunctionalTest.kt
+++ b/gradle-quality-plugin/src/test/kotlin/org/octopusden/octopus/quality/OctopusQualityPluginFunctionalTest.kt
@@ -975,4 +975,38 @@ class OctopusQualityPluginFunctionalTest {
             "Expected ktlint violation against consumer override; got: ${result.output}",
         )
     }
+
+    // ---------------------------------------------------------------
+    // #144: hollow-gate guard — a Kotlin module that never applied detekt/ktlint
+    // must FAIL qualityStatic instead of passing green with zero analysis.
+    // ---------------------------------------------------------------
+    @Test
+    fun `hollow gate - Kotlin without detekt-ktlint fails qualityStatic`() {
+        settingsFile(kotlinSettings("test-hollow-gate"))
+        buildFile(
+            """
+            plugins {
+                kotlin("jvm") version "1.9.25"
+                id("org.octopusden.octopus-quality")
+            }
+            repositories { mavenCentral() }
+            octopusQuality {
+                kotlin { failOnViolation.set(false) }
+                java { failOnViolation.set(false) }
+                coverage { enabled.set(false) }
+            }
+            """.trimIndent(),
+        )
+        writeKotlinFile(
+            "src/main/kotlin/com/example/Hello.kt",
+            "package com.example\nfun hello() = \"Hello\"\n",
+        )
+
+        val result = runner("qualityStatic").buildAndFail()
+        assertEquals(TaskOutcome.FAILED, result.task(":verifyStaticAnalysisApplied")?.outcome)
+        assertTrue(
+            result.output.contains("Hollow quality gate"),
+            "Expected the hollow-gate guard to fail qualityStatic; got: ${result.output}",
+        )
+    }
 }


### PR DESCRIPTION
Closes #144.

## Problem
The convention plugin **self-applies** the Java/Groovy analysers (checkstyle/pmd/spotbugs/codenarc) but only **reactively configures** detekt/ktlint via `plugins.withId(...)` — consumers must apply those plugins per Kotlin subproject (see `OctopusQualityPlugin` KDoc). If a Kotlin module never applies them, no `detekt`/`ktlintCheck` tasks are created, `qualityStatic`'s `dependOnIfExists` finds nothing, and the gate passes **green while analysing zero Kotlin** — a false-assurance gate (observed in `octopus-components-registry-service`; would repeat across every Kotlin repo in the Phase 4 rollout).

## Change (Variant A — assertion)
- New `HollowGateGuard` registers **`verifyStaticAnalysisApplied`**, wired as a dependency of `qualityStatic`, that **fails the build with a per-module message** when a module has Kotlin sources but is missing its `detekt`/`ktlintCheck` tasks.
- Problems are computed at `projectsEvaluated` (tasks resolved) and captured into the task action as plain strings — no Project/task references leak into execution (configuration-cache friendly).

## Why not self-apply detekt/ktlint (Variant B, rejected)
Self-apply would require moving detekt/ktlint from `compileOnly` → `implementation` in `gradle-quality-plugin/build.gradle.kts`. They are `compileOnly` **on purpose**: both are **Kotlin-version-coupled**, so bundling them forces a Kotlin version onto every consumer (SpotBugs is bundled only because it has no such coupling). The assertion works over consumer-provided plugins with no coupling.

## Test
Adds a TestKit functional test: a Kotlin project **without** detekt/ktlint applied → `qualityStatic` fails with the hollow-gate message (`verifyStaticAnalysisApplied` = FAILED). Existing single/multi-module positive cases still pass (guard is a no-op when the tasks exist). Verified locally: `ktlintCheck`, `detekt`, and the affected functional tests all green.

## Notes
Prerequisite for the Phase 4 quality-gates mass rollout (Batch B gate). Separate from #112 (canonical configs, already shipped) — this is the *apply/enforcement* gap, not config sharing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to ensure Kotlin modules have the required static-analysis checks enabled.
  * The quality verification now fails with a clear message when required checks are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->