### PR TITLE
ci: publish quality-plugin -SNAPSHOT on push to main

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,0 +1,74 @@
+name: Publish quality-plugin SNAPSHOT
+
+# Publishes a -SNAPSHOT of org.octopusden.octopus-quality on every push to main that
+# touches the plugin, so consumers can pin the latest (unreleased) convention plugin
+# during the Phase 4 quality-gates rollout without waiting for a tagged release.
+# workflow_dispatch allows a manual publish from any branch (e.g. a pre-merge feature
+# branch). On a real release, consumers re-pin from the SNAPSHOT to the release tag.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'gradle-quality-plugin/**'
+      - '.github/workflows/publish-snapshot.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish-snapshot:
+    name: Publish quality convention plugin SNAPSHOT
+    runs-on: ubuntu-latest
+    environment: Prod
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: temurin
+
+      - name: Validate Gradle wrapper
+        uses: gradle/actions/wrapper-validation@v5
+        with:
+          min-wrapper-count: 0
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Compute SNAPSHOT version
+        id: ver
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --tags --force
+          latest_tag="$(git tag -l 'v*' --sort=-v:refname | head -n1 || true)"
+          latest_tag="${latest_tag:-v0.0.0}"
+          base="${latest_tag#v}"
+          IFS='.' read -r maj min pat <<< "$base"
+          snapshot="${maj}.${min}.$((pat + 1))-SNAPSHOT"
+          echo "snapshot_version=${snapshot}" >> "$GITHUB_OUTPUT"
+          echo "Publishing ${snapshot} (next patch after ${latest_tag})"
+
+      - name: Build and publish SNAPSHOT
+        working-directory: gradle-quality-plugin
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          # SNAPSHOT versions route to snapshotRepositoryUrl; no staging repo to close
+          # (that's release-only via closeAndReleaseSonatypeStagingRepository).
+          ./gradlew build publishToSonatype \
+            -Pversion=${{ steps.ver.outputs.snapshot_version }} \
+            -Pnexus=true \
+            --no-daemon --info -s


### PR DESCRIPTION
Enables the **branch-until-release** pin strategy for the Phase 4 quality-gates rollout (see rollout plan §7-G / D1): consumers pin the convention plugin to the latest **unreleased** version without waiting for a tag.

## What
Adds `.github/workflows/publish-snapshot.yml`:
- **Trigger:** push to `main` touching `gradle-quality-plugin/**` (+ `workflow_dispatch` for manual/pre-merge publish).
- **Version:** `<next-patch>-SNAPSHOT` computed from the latest `v*` tag (e.g. `2.3.6-SNAPSHOT` after `v2.3.5`).
- **Publish:** `./gradlew build publishToSonatype -Pversion=…-SNAPSHOT -Pnexus=true`. Mirrors the release job's auth (`OSSRH_*`, `GPG_*`) and setup; **omits** `closeAndReleaseSonatypeStagingRepository` (release-only — SNAPSHOTs go straight to `snapshotRepositoryUrl`, no staging).

## How consumers use it
Pin reusable workflows `@main` + `octopus-quality.version=2.3.6-SNAPSHOT` + add the Sonatype snapshot repo to `pluginManagement.repositories`. This is what carries the hollow-gate guard (#145) and future unreleased fixes into consumers during rollout. On a real release, re-pin to the tag.

## Notes / to confirm
- Uses `environment: Prod` to reach the publish secrets (same as the release job). **If `Prod` has a required-reviewer gate (#141), snapshot publishes will wait for approval** — if unattended snapshots are wanted, move the secrets to repo scope or a dedicated environment.
- Recommended sequence: merge #145 (guard) → this → main auto-publishes `2.3.6-SNAPSHOT` (with guard) → consumers adopt against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)