### PR TITLE
fix(quality): correct three convention-plugin gate gaps (Phase-4 findings)

### DIFF
--- a/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/OctopusQualityPlugin.kt
+++ b/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/OctopusQualityPlugin.kt
@@ -2,6 +2,7 @@ package org.octopusden.octopus.quality
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.octopusden.octopus.quality.internal.LanguageDetector
 import org.octopusden.octopus.quality.internal.PublicationValidator
 import org.octopusden.octopus.quality.internal.SubprojectConfigurer
 import org.octopusden.octopus.quality.internal.TaskRegistrar
@@ -58,11 +59,15 @@ class OctopusQualityPlugin : Plugin<Project> {
     override fun apply(project: Project) {
         val extension = project.extensions.create("octopusQuality", OctopusQualityExtension::class.java)
 
+        // In a multi-module build the root project is normally a pure aggregator (no sources),
+        // so targets = subprojects. But if the root ALSO carries its own JVM sources, it must be
+        // configured/gated too — otherwise root-module code silently escapes the quality gate.
+        val subprojects = project.allprojects.filter { it != project }
         val targets =
-            if (project.subprojects.isEmpty()) {
-                listOf(project)
-            } else {
-                project.allprojects.filter { it != project }
+            when {
+                subprojects.isEmpty() -> listOf(project)
+                LanguageDetector.hasAnySource(project) -> subprojects + project
+                else -> subprojects
             }
 
         // Phase 1 — synchronous, BEFORE subproject scripts evaluate. Registers

--- a/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/LanguageDetector.kt
+++ b/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/LanguageDetector.kt
@@ -28,6 +28,9 @@ internal object LanguageDetector {
         return DetectedLanguages(hasKotlin, hasJava, hasGroovy)
     }
 
+    /** True if the project carries any JVM source (kotlin/java/groovy) of its own. */
+    fun hasAnySource(project: Project): Boolean = detect(project).let { it.hasKotlin || it.hasJava || it.hasGroovy }
+
     /**
      * Detect languages across all subprojects (or the root project if single-module).
      */

--- a/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/SubprojectConfigurer.kt
+++ b/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/SubprojectConfigurer.kt
@@ -242,9 +242,26 @@ internal object SubprojectConfigurer {
             // convention path directly, so consumers don't need to relocate the file
             // from ktlint-gradle's own default (`config/ktlint/baseline.xml`).
             ext.baseline.set(File(project.projectDir, "ktlint-baseline.xml"))
+            // Exclude the project's ACTUAL build output dir by absolute path — NOT a "**/build/**"
+            // glob. That glob matches any path segment named "build", so a repo whose package path
+            // contains `build` (e.g. org.octopusden.octopus.build.integration) would have EVERY source
+            // file excluded and ktlint would run hollow (0 files) despite the task existing.
+            val buildPath =
+                project.layout.buildDirectory
+                    .get()
+                    .asFile
+                    .toPath()
+                    .toAbsolutePath()
+                    .normalize()
             ext.filter {
+                it.exclude { element ->
+                    element.file
+                        .toPath()
+                        .toAbsolutePath()
+                        .normalize()
+                        .startsWith(buildPath)
+                }
                 it.exclude("**/generated/**")
-                it.exclude("**/build/**")
                 it.include("**/*.kt", "**/*.kts")
             }
             ext.additionalEditorconfig.putAll(editorConfigEntries)
@@ -316,7 +333,28 @@ internal object SubprojectConfigurer {
         rootProject: Project,
         extension: OctopusQualityExtension,
     ) {
-        // Kover is applied by consumer (with their version via pluginManagement).
-        // Convention plugin only wires qualityCoverage tasks to kover tasks if they exist.
+        // Kover is applied by the consumer (version via pluginManagement). When present, enforce the
+        // same per-module line-coverage floor the JaCoCo path enforces. Previously this was a no-op,
+        // so `koverVerify` passed with NO threshold — a coverage gate that measured nothing.
+        project.plugins.withId("org.jetbrains.kotlinx.kover") {
+            val minPercent =
+                extension.coverage.minimumLineCoverage
+                    .get()
+                    .movePointRight(2)
+                    .toInt()
+                    .coerceIn(0, 100)
+            project.extensions.configure(kotlinx.kover.gradle.plugin.dsl.KoverProjectExtension::class.java) { kover ->
+                kover.reports { reports ->
+                    reports.verify { verify ->
+                        verify.rule { rule ->
+                            rule.minBound(
+                                minValue = minPercent,
+                                coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE,
+                            )
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/SubprojectConfigurer.kt
+++ b/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/SubprojectConfigurer.kt
@@ -246,15 +246,18 @@ internal object SubprojectConfigurer {
             // glob. That glob matches any path segment named "build", so a repo whose package path
             // contains `build` (e.g. org.octopusden.octopus.build.integration) would have EVERY source
             // file excluded and ktlint would run hollow (0 files) despite the task existing.
-            val buildPath =
-                project.layout.buildDirectory
-                    .get()
-                    .asFile
-                    .toPath()
-                    .toAbsolutePath()
-                    .normalize()
+            // buildDirectory is resolved lazily INSIDE the exclude spec (evaluated at task time) so a
+            // consumer's later buildDir customization is honored.
+            val buildDirectory = project.layout.buildDirectory
             ext.filter {
                 it.exclude { element ->
+                    val buildPath =
+                        buildDirectory
+                            .get()
+                            .asFile
+                            .toPath()
+                            .toAbsolutePath()
+                            .normalize()
                     element.file
                         .toPath()
                         .toAbsolutePath()

--- a/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/TaskRegistrar.kt
+++ b/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/TaskRegistrar.kt
@@ -266,10 +266,12 @@ internal object TaskRegistrar {
 
     private fun allTargetProjects(rootProject: Project): List<Project> {
         val allSubs = rootProject.allprojects.filter { it != rootProject }
-        return if (allSubs.isEmpty()) {
-            listOf(rootProject)
-        } else {
-            allSubs
+        return when {
+            allSubs.isEmpty() -> listOf(rootProject)
+            // Include the root when it carries its own sources, so root-module code is wired into
+            // qualityStatic (otherwise it escapes the gate in multi-module repos with a source root).
+            LanguageDetector.hasAnySource(rootProject) -> allSubs + rootProject
+            else -> allSubs
         }
     }
 
@@ -279,10 +281,13 @@ internal object TaskRegistrar {
     ): List<Project> {
         val excluded = extension.coverageExcludedProjects.get()
         val allSubs = rootProject.allprojects.filter { it != rootProject }
-        return if (allSubs.isEmpty()) {
-            listOf(rootProject)
-        } else {
-            allSubs.filter { it.name !in excluded }
+        return when {
+            allSubs.isEmpty() -> listOf(rootProject)
+            else -> {
+                val withRoot =
+                    if (LanguageDetector.hasAnySource(rootProject)) allSubs + rootProject else allSubs
+                withRoot.filter { it.name !in excluded }
+            }
         }
     }
 

--- a/gradle-quality-plugin/src/test/kotlin/org/octopusden/octopus/quality/OctopusQualityPluginFunctionalTest.kt
+++ b/gradle-quality-plugin/src/test/kotlin/org/octopusden/octopus/quality/OctopusQualityPluginFunctionalTest.kt
@@ -1009,4 +1009,85 @@ class OctopusQualityPluginFunctionalTest {
             "Expected the hollow-gate guard to fail qualityStatic; got: ${result.output}",
         )
     }
+
+    // ---------------------------------------------------------------
+    // Fix: ktlint must NOT be excluded just because the package path contains a
+    // "build" segment. Pre-fix, the `**/build/**` glob excluded any source under a
+    // `.../build/...` package (e.g. org.octopusden.octopus.build.integration), so
+    // ktlint ran hollow (0 files). A violation in such a file must now be caught.
+    // ---------------------------------------------------------------
+    @Test
+    fun `ktlint scans sources under a build package segment - not excluded by build glob`() {
+        settingsFile(kotlinSettings("test-ktlint-build-segment"))
+        buildFile(
+            """
+            plugins {
+                kotlin("jvm") version "1.9.25"
+                id("org.jlleitschuh.gradle.ktlint") version "14.0.1"
+                id("org.octopusden.octopus-quality")
+            }
+            repositories { mavenCentral() }
+            octopusQuality {
+                kotlin { failOnViolation.set(true) }
+                coverage { enabled.set(false) }
+            }
+            """.trimIndent(),
+        )
+        // Package path contains a literal `build` segment; file has a wildcard import (violation).
+        writeKotlinFile(
+            "src/main/kotlin/org/octopusden/octopus/build/integration/Bad.kt",
+            "package org.octopusden.octopus.build.integration\n\nimport java.util.*\n\nval x: UUID? = null\n",
+        )
+
+        val result = runner("ktlintCheck").buildAndFail()
+        assertTrue(
+            result.output.contains("Bad.kt") && result.output.contains("Wildcard import"),
+            "Expected ktlint to scan the file under a 'build' package segment; got: ${result.output}",
+        )
+    }
+
+    // ---------------------------------------------------------------
+    // Fix: in a multi-module build whose ROOT project also carries Kotlin sources,
+    // the root module must be wired into qualityStatic (previously only subprojects
+    // were, so root-module code escaped the gate).
+    // ---------------------------------------------------------------
+    @Test
+    fun `multi-module with root sources - root detekt-ktlint wired into qualityStatic`() {
+        settingsFile(kotlinSettings("test-root-sources", """include("lib")"""))
+        buildFile(
+            """
+            plugins {
+                kotlin("jvm") version "1.9.25"
+                id("io.gitlab.arturbosch.detekt") version "1.23.5"
+                id("org.jlleitschuh.gradle.ktlint") version "14.0.1"
+                id("org.octopusden.octopus-quality")
+            }
+            subprojects {
+                apply(plugin = "org.jetbrains.kotlin.jvm")
+                apply(plugin = "io.gitlab.arturbosch.detekt")
+                apply(plugin = "org.jlleitschuh.gradle.ktlint")
+                repositories { mavenCentral() }
+            }
+            repositories { mavenCentral() }
+            octopusQuality {
+                kotlin { failOnViolation.set(false) }
+                java { failOnViolation.set(false) }
+                coverage { enabled.set(false) }
+            }
+            """.trimIndent(),
+        )
+        // Root project has its own Kotlin source (in addition to the :lib subproject).
+        writeKotlinFile("src/main/kotlin/com/example/Root.kt", "package com.example\nfun root() = 1\n")
+        writeKotlinFile("lib/src/main/kotlin/com/example/Lib.kt", "package com.example\nfun lib() = 2\n")
+
+        val result = runner("qualityStatic", "--dry-run").build()
+        val lines = result.output.lines().map { it.trim() }
+        // Root-module tasks are printed with a single leading colon (`:detekt`); subproject tasks
+        // as `:lib:detekt`. Match by line prefix so the root task isn't confused with :lib:detekt.
+        val hasRootDetekt = lines.any { it.startsWith(":detekt ") || it == ":detekt" }
+        val hasRootKtlint = lines.any { it.startsWith(":ktlintCheck ") || it == ":ktlintCheck" }
+        assertTrue(hasRootDetekt, "root :detekt not wired; got: ${result.output}")
+        assertTrue(hasRootKtlint, "root :ktlintCheck not wired; got: ${result.output}")
+        assertTrue(result.output.contains(":lib:detekt"), "subproject :lib:detekt missing")
+    }
 }


### PR DESCRIPTION
Three real gaps in `gradle-quality-plugin` surfaced while adopting the gate across the octopusden Gradle repos. Each let the gate pass while silently doing less than intended.

## 1. ktlint hollow-gate via package path
The ktlint filter excluded `**/build/**` — a glob that matches ANY path segment named `build`. A repo whose package path contains `build` (e.g. `org.octopusden.octopus.build.integration`) had **every** source file excluded, so ktlint ran on **0 files** despite the task existing. → Exclude the project's **actual build output dir by absolute path**, not a glob.

## 2. root-module sources escape the gate
In a multi-module build only *subprojects* were wired into `qualityStatic`/`qualityCoverage`. A repo with Kotlin in the **root** project + subprojects (e.g. sonar-automation) had its root code skipped. → Include the root project in the target set when it carries its own JVM sources (`OctopusQualityPlugin` + `TaskRegistrar`), via a new `LanguageDetector.hasAnySource`.

## 3. Kover coverage floor never enforced
`configureKover` was a no-op, so `koverVerify` passed with **no threshold** — a coverage gate that measured nothing. → Wire the per-module `minBound(minimumLineCoverage, LINE)` rule, mirroring the JaCoCo path.

## Tests / verification
Adds two functional tests: ktlint scanning a source under a `build` package segment, and root-module detekt/ktlint wired into `qualityStatic` in a multi-module build with a source root. Full `./gradlew check` (ktlint, detekt, all functional tests, koverVerify, validatePublications) is green.

Found during the Phase-4 quality-gate rollout. Independent of the hollow-gate guard PR (#145) — complementary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Quality checks now include source code in the root project of multi-module builds.
  * Kotlin sources in package paths containing “build” are no longer incorrectly skipped by linting.
  * Kover coverage verification now enforces the configured minimum line-coverage threshold for each module.

* **Quality Improvements**
  * Static analysis and coverage checks now provide more complete and reliable validation across project layouts.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->