### PR TITLE
feat(quality): validatePublications opt-out and gate checkstyle/PMD to Java modules

### DIFF
--- a/docs/Octopus JVM Style Guidelines.md
+++ b/docs/Octopus JVM Style Guidelines.md
@@ -153,12 +153,14 @@ octopusQuality {
 
 | Language detected | Tools configured | Coverage |
 |-------------------|-----------------|----------|
-| Kotlin | detekt + ktlint + checkstyle + pmd | Kover (consumer applies kover plugin) |
+| Kotlin (no Java) | detekt + ktlint | Kover (consumer applies kover plugin) |
 | Java (no Kotlin) | checkstyle + pmd + spotbugs | JaCoCo (plugin applies jacoco) |
-| Groovy (no Java) | codenarc + checkstyle + pmd | JaCoCo (plugin applies jacoco) |
+| Groovy (no Java) | codenarc | JaCoCo (plugin applies jacoco) |
 | Mixed Java + Kotlin | detekt + ktlint + checkstyle + pmd | JaCoCo |
 
-> **SpotBugs** is wired only on modules that have Java **and no Kotlin** (Java-only or Java+Groovy). It analyses *bytecode* and false-positives heavily on compiled Kotlin (lateinit / DSL getters / synthetic accessors), so any module containing Kotlin is skipped. Checkstyle/PMD are applied broadly but only act on `.java` source.
+> **Checkstyle/PMD** are Java-only tools — they are applied only to modules that have Java source. A Kotlin-only module gets detekt + ktlint; a Groovy-only module gets codenarc; only Java (Java-only or mixed Java + Kotlin/Groovy) gets checkstyle + pmd.
+>
+> **SpotBugs** is wired only on modules that have Java **and no Kotlin** (Java-only or Java+Groovy). It analyses *bytecode* and false-positives heavily on compiled Kotlin (lateinit / DSL getters / synthetic accessors), so any module containing Kotlin is skipped.
 
 ### What stays local in each repo
 

--- a/gradle-quality-plugin/build.gradle.kts
+++ b/gradle-quality-plugin/build.gradle.kts
@@ -36,6 +36,7 @@ kover {
                     // Extension classes — constructed via Gradle ObjectFactory, not unit-testable
                     "org.octopusden.octopus.quality.OctopusQualityExtension",
                     "org.octopusden.octopus.quality.CoverageExtension",
+                    "org.octopusden.octopus.quality.PublicationExtension",
                     "org.octopusden.octopus.quality.KotlinExtension",
                     "org.octopusden.octopus.quality.JavaExtension",
                     "org.octopusden.octopus.quality.GroovyExtension",

--- a/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/OctopusQualityExtension.kt
+++ b/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/OctopusQualityExtension.kt
@@ -11,6 +11,7 @@ open class OctopusQualityExtension
         objects: ObjectFactory,
     ) {
         val coverage: CoverageExtension = objects.newInstance(CoverageExtension::class.java)
+        val publication: PublicationExtension = objects.newInstance(PublicationExtension::class.java)
         val kotlin: KotlinExtension = objects.newInstance(KotlinExtension::class.java)
         val java: JavaExtension = objects.newInstance(JavaExtension::class.java)
         val groovy: GroovyExtension = objects.newInstance(GroovyExtension::class.java)
@@ -18,10 +19,19 @@ open class OctopusQualityExtension
         /** Subproject names to exclude from coverage verification (qualityCoverage). */
         val coverageExcludedProjects: SetProperty<String> = objects.setProperty(String::class.java).convention(emptySet())
 
-        /** Task names to exclude from quality gate dependencies. Applies to both qualityStatic and qualityCoverage. */
+        /**
+         * Task names to exclude from the aggregate quality-gate task dependencies.
+         *
+         * Applies ONLY to the `qualityStatic` / `qualityCoverage` aggregate tasks (and, transitively,
+         * `qualityCheck`) — it prunes which analysis/coverage tasks those aggregates depend on.
+         * It does NOT touch the standard `check` → `test` task graph: an excluded `test` still runs
+         * under `check`, it is simply not pulled in by `qualityCoverage`.
+         */
         val excludedTasks: SetProperty<String> = objects.setProperty(String::class.java).convention(emptySet())
 
         fun coverage(action: Action<CoverageExtension>) = action.execute(coverage)
+
+        fun publication(action: Action<PublicationExtension>) = action.execute(publication)
 
         fun kotlin(action: Action<KotlinExtension>) = action.execute(kotlin)
 
@@ -62,6 +72,21 @@ open class CoverageExtension
             objects
                 .property(java.math.BigDecimal::class.java)
                 .convention(java.math.BigDecimal("0.70"))
+    }
+
+open class PublicationExtension
+    @Inject
+    constructor(
+        objects: ObjectFactory,
+    ) {
+        /**
+         * Enforce Maven Central readiness (`validatePublications` wired into `check`) for every
+         * `maven-publish` project. Set to false for repos that are not published to Maven Central,
+         * so `check` does not require sources/javadoc JARs and full POM metadata.
+         *
+         * Root-level / per-repo / all-or-nothing by design.
+         */
+        val validateForMavenCentral = objects.property(Boolean::class.java).convention(true)
     }
 
 open class KotlinExtension

--- a/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/OctopusQualityPlugin.kt
+++ b/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/OctopusQualityPlugin.kt
@@ -93,7 +93,9 @@ class OctopusQualityPlugin : Plugin<Project> {
         }
 
         // Validate Maven Central publication readiness (sources, javadoc, POM fields)
-        // for every project that applies maven-publish. Wired into `check`.
-        project.allprojects.forEach { PublicationValidator.register(it) }
+        // for every project that applies maven-publish. Wired into `check`, unless the repo
+        // opts out via octopusQuality { publication { validateForMavenCentral.set(false) } }
+        // (root-level / per-repo / all-or-nothing) — then the task is skipped on `check`.
+        project.allprojects.forEach { PublicationValidator.register(it, extension) }
     }
 }

--- a/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/OctopusQualityPlugin.kt
+++ b/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/OctopusQualityPlugin.kt
@@ -42,7 +42,8 @@ import org.octopusden.octopus.quality.internal.TaskRegistrar
  *
  * The plugin auto-detects languages per subproject and configures:
  * - **Kotlin** (when detekt/ktlint applied): shared detekt.yml, baseline support, report formats
- * - **Checkstyle / PMD** (any JVM module): bundled by plugin — Java-source analysers, no-op without `.java`
+ * - **Checkstyle / PMD** (Java-source modules only): applied and wired into `qualityStatic` only when the module
+ *   has `.java` sources (`hasJava`) — they are Java-only analysers and are skipped entirely on Kotlin-only/Groovy-only modules
  * - **SpotBugs** (Java module with no Kotlin): bytecode analyser — skipped on any module
  *   containing Kotlin (it false-positives on Kotlin bytecode)
  * - **CodeNarc** (Groovy): bundled by plugin

--- a/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/PublicationValidator.kt
+++ b/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/PublicationValidator.kt
@@ -4,6 +4,7 @@ import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.tasks.GenerateMavenPom
+import org.octopusden.octopus.quality.OctopusQualityExtension
 import javax.xml.parsers.DocumentBuilderFactory
 
 /**
@@ -18,9 +19,16 @@ import javax.xml.parsers.DocumentBuilderFactory
  * - Only POM metadata is validated (no sources/javadoc required)
  *
  * Wired into `check` (when available) so issues are caught on PR, not at publish time.
+ * Opt-out per repo via `octopusQuality { publication { validateForMavenCentral.set(false) } }`
+ * — the task stays registered but its action is skipped (lazy `onlyIf`), so it no longer
+ * enforces Maven Central readiness on `check` for repos that don't publish there.
  */
 internal object PublicationValidator {
-    fun register(project: Project) {
+    fun register(
+        project: Project,
+        rootExtension: OctopusQualityExtension,
+    ) {
+        val validateForMavenCentral = rootExtension.publication.validateForMavenCentral
         project.plugins.withId("maven-publish") {
             val validateTask =
                 project.tasks.register("validatePublications") { task ->
@@ -79,6 +87,13 @@ internal object PublicationValidator {
                         )
                     }
                 }
+
+            // Opt-out: skip enforcement when the repo opts out of Maven Central validation.
+            // Lazy `onlyIf` — the consumer's octopusQuality { publication { ... } } override is
+            // read at task-execution time, not at configuration time.
+            validateTask.configure { task ->
+                task.onlyIf { validateForMavenCentral.get() }
+            }
 
             // Wire into check lazily — safe regardless of plugin application order
             project.tasks.matching { it.name == "check" }.configureEach {

--- a/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/SubprojectConfigurer.kt
+++ b/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/SubprojectConfigurer.kt
@@ -45,14 +45,15 @@ internal object SubprojectConfigurer {
         val configDir = resolveConfigDir(rootProject)
         val languages = LanguageDetector.detect(project)
 
-        // Checkstyle/PMD analyse Java *source* — harmless no-ops on modules without `.java`,
-        // so keep them broadly applied. SpotBugs analyses *bytecode* and scans the module's
-        // whole compiled output: when Kotlin is present it reads the Kotlin classes too and
-        // produces ~95% false positives (lateinit / DSL getters / synthetic accessors). Gate it
-        // to modules that have Java and NO Kotlin (Java-only or Java+Groovy qualify — only Kotlin
-        // triggers the false-positive flood). Java 25 / class file v69 support is handled by the
-        // engine pin in configureSpotBugs.
-        if (languages.hasJava || languages.hasKotlin || languages.hasGroovy) {
+        // Checkstyle/PMD are Java-only tools (they analyse `.java` *source*), so apply them only
+        // to modules that actually have Java source — applying them to Kotlin-only / Groovy-only
+        // modules just adds no-op tasks (and misleadingly-named ones) to the graph. SpotBugs
+        // analyses *bytecode* and scans the module's whole compiled output: when Kotlin is present
+        // it reads the Kotlin classes too and produces ~95% false positives (lateinit / DSL getters
+        // / synthetic accessors). Gate it to modules that have Java and NO Kotlin (Java-only or
+        // Java+Groovy qualify — only Kotlin triggers the false-positive flood). Java 25 / class file
+        // v69 support is handled by the engine pin in configureSpotBugs.
+        if (languages.hasJava) {
             configureCheckstyle(project, configDir, extension)
             configurePmd(project, configDir, extension)
         }

--- a/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/TaskRegistrar.kt
+++ b/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/TaskRegistrar.kt
@@ -46,19 +46,27 @@ internal object TaskRegistrar {
             for (project in targets) {
                 val languages = LanguageDetector.detect(project)
 
-                // checkstyle/pmd are Java-source analysers (no-op without `.java`); spotbugs is
-                // bytecode-based and gated to Java-without-Kotlin modules (it would false-positive
-                // on co-located Kotlin classes) — see SubprojectConfigurer.configure.
-                if (languages.hasJava || languages.hasKotlin || languages.hasGroovy) {
+                // checkstyle/pmd are Java-only source analysers — gated (plugin-apply and here) to
+                // modules with Java source; see SubprojectConfigurer.configure.
+                if (languages.hasJava) {
                     dependOnIfExists(task, project, "checkstyleMain", excludedTasks)
                     dependOnIfExists(task, project, "checkstyleTest", excludedTasks)
                     dependOnIfExists(task, project, "checkstyleIntegrationTest", excludedTasks)
                     dependOnIfExists(task, project, "pmdMain", excludedTasks)
                     dependOnIfExists(task, project, "pmdTest", excludedTasks)
                     dependOnIfExists(task, project, "pmdIntegrationTest", excludedTasks)
+                }
+
+                // Compilation is needed by every JVM module's analysis (detekt/codenarc modules
+                // included), so `classes`/`testClasses` stay under the broad language condition —
+                // NOT gated to hasJava, which would silently drop compilation for Kotlin/Groovy.
+                if (languages.hasJava || languages.hasKotlin || languages.hasGroovy) {
                     dependOnIfExists(task, project, "classes", excludedTasks)
                     dependOnIfExists(task, project, "testClasses", excludedTasks)
                 }
+
+                // spotbugs is bytecode-based and gated to Java-without-Kotlin modules (it would
+                // false-positive on co-located Kotlin classes) — see SubprojectConfigurer.configure.
                 if (languages.hasJava && !languages.hasKotlin) {
                     dependOnIfExists(task, project, "spotbugsMain", excludedTasks)
                     dependOnIfExists(task, project, "spotbugsTest", excludedTasks)

--- a/gradle-quality-plugin/src/test/kotlin/org/octopusden/octopus/quality/OctopusQualityPluginFunctionalTest.kt
+++ b/gradle-quality-plugin/src/test/kotlin/org/octopusden/octopus/quality/OctopusQualityPluginFunctionalTest.kt
@@ -155,7 +155,7 @@ class OctopusQualityPluginFunctionalTest {
     }
 
     // ---------------------------------------------------------------
-    // 3. Groovy-only: codenarc + checkstyle + pmd applied
+    // 3. Groovy-only: codenarc only (checkstyle/pmd are Java-only, not applied)
     // ---------------------------------------------------------------
     @Test
     fun `groovy-only repo - qualityStatic applies codenarc`() {
@@ -1089,5 +1089,200 @@ class OctopusQualityPluginFunctionalTest {
         assertTrue(hasRootDetekt, "root :detekt not wired; got: ${result.output}")
         assertTrue(hasRootKtlint, "root :ktlintCheck not wired; got: ${result.output}")
         assertTrue(result.output.contains(":lib:detekt"), "subproject :lib:detekt missing")
+    }
+
+    // ---------------------------------------------------------------
+    // checkstyle/PMD are Java-only: a Kotlin-only module must get NO
+    // :checkstyleMain/:pmdMain, but must still get :classes + :detekt in qualityStatic.
+    // ---------------------------------------------------------------
+    @Test
+    fun `kotlin-only repo - no checkstyle or pmd but detekt and classes wired`() {
+        settingsFile(kotlinSettings("test-kotlin-no-checkstyle"))
+        buildFile(
+            """
+            plugins {
+                kotlin("jvm") version "1.9.25"
+                id("io.gitlab.arturbosch.detekt") version "1.23.5"
+                id("org.jlleitschuh.gradle.ktlint") version "14.0.1"
+                id("org.octopusden.octopus-quality")
+            }
+            repositories { mavenCentral() }
+            octopusQuality {
+                kotlin { failOnViolation.set(false) }
+                java { failOnViolation.set(false) }
+                coverage { enabled.set(false) }
+            }
+            """.trimIndent(),
+        )
+        writeKotlinFile(
+            "src/main/kotlin/com/example/Hello.kt",
+            "package com.example\nfun hello() = \"Hello\"\n",
+        )
+
+        val result = runner("qualityStatic", "--dry-run").build()
+        assertFalse(
+            result.output.contains(":checkstyleMain"),
+            "checkstyle is Java-only and must not be wired for a Kotlin-only module; got: ${result.output}",
+        )
+        assertFalse(
+            result.output.contains(":pmdMain"),
+            "pmd is Java-only and must not be wired for a Kotlin-only module; got: ${result.output}",
+        )
+        assertTrue(result.output.contains(":detekt"), "Kotlin-only module must still run :detekt")
+        assertTrue(result.output.contains(":classes"), "Kotlin-only module must still compile (:classes)")
+    }
+
+    // ---------------------------------------------------------------
+    // checkstyle/PMD are Java-only: a Groovy-only module must get NO
+    // :checkstyleMain/:pmdMain, but must still get :classes + :codenarcMain in qualityStatic.
+    // ---------------------------------------------------------------
+    @Test
+    fun `groovy-only repo - no checkstyle or pmd but codenarc and classes wired`() {
+        settingsFile(kotlinSettings("test-groovy-no-checkstyle"))
+        buildFile(
+            """
+            plugins {
+                groovy
+                id("org.octopusden.octopus-quality")
+            }
+            repositories { mavenCentral() }
+            dependencies { implementation(localGroovy()) }
+            octopusQuality {
+                groovy { failOnViolation.set(false) }
+                java { failOnViolation.set(false) }
+                coverage { enabled.set(false) }
+            }
+            """.trimIndent(),
+        )
+        subDir("src/main/groovy/com/example")
+        File(projectDir, "src/main/groovy/com/example/Hello.groovy")
+            .writeText("package com.example\nclass Hello { String greet() { 'hi' } }\n")
+
+        val result = runner("qualityStatic", "--dry-run").build()
+        assertFalse(
+            result.output.contains(":checkstyleMain"),
+            "checkstyle is Java-only and must not be wired for a Groovy-only module; got: ${result.output}",
+        )
+        assertFalse(
+            result.output.contains(":pmdMain"),
+            "pmd is Java-only and must not be wired for a Groovy-only module; got: ${result.output}",
+        )
+        assertTrue(result.output.contains(":codenarcMain"), "Groovy-only module must still run :codenarcMain")
+        assertTrue(result.output.contains(":classes"), "Groovy-only module must still compile (:classes)")
+    }
+
+    // ---------------------------------------------------------------
+    // A Java module still gets checkstyle + pmd wired into qualityStatic.
+    // ---------------------------------------------------------------
+    @Test
+    fun `java repo - checkstyle and pmd wired into qualityStatic`() {
+        settingsFile(kotlinSettings("test-java-checkstyle-pmd"))
+        buildFile(
+            """
+            plugins {
+                java
+                id("org.octopusden.octopus-quality")
+            }
+            repositories { mavenCentral() }
+            octopusQuality {
+                java { failOnViolation.set(false) }
+                coverage { enabled.set(false) }
+            }
+            """.trimIndent(),
+        )
+        subDir("src/main/java/com/example")
+        File(projectDir, "src/main/java/com/example/Hello.java")
+            .writeText("package com.example;\npublic class Hello { public String greet() { return \"hi\"; } }\n")
+
+        val result = runner("qualityStatic", "--dry-run").build()
+        assertTrue(result.output.contains(":checkstyleMain"), "Java module must wire :checkstyleMain")
+        assertTrue(result.output.contains(":pmdMain"), "Java module must wire :pmdMain")
+    }
+
+    // ---------------------------------------------------------------
+    // validatePublications opt-out: with validateForMavenCentral=false the task is
+    // SKIPPED on `check`, so a publication that would fail validation no longer blocks check.
+    // ---------------------------------------------------------------
+    @Test
+    fun `validatePublications skipped on check when validateForMavenCentral is false`() {
+        settingsFile(kotlinSettings("test-pub-optout"))
+        buildFile(
+            """
+            plugins {
+                java
+                `maven-publish`
+                id("org.octopusden.octopus-quality")
+            }
+            repositories { mavenCentral() }
+            group = "org.example"
+            version = "1.0.0"
+            publishing {
+                publications {
+                    // No sources/javadoc JARs and no POM metadata — would FAIL validation if enforced.
+                    create<MavenPublication>("mavenJava") {
+                        from(components["java"])
+                    }
+                }
+            }
+            octopusQuality {
+                java { failOnViolation.set(false) }
+                coverage { enabled.set(false) }
+                publication { validateForMavenCentral.set(false) }
+            }
+            """.trimIndent(),
+        )
+        subDir("src/main/java/com/example")
+        File(projectDir, "src/main/java/com/example/Hello.java")
+            .writeText("package com.example;\npublic class Hello { public String greet() { return \"hi\"; } }\n")
+
+        val result = runner("check").build()
+        assertEquals(
+            TaskOutcome.SKIPPED,
+            result.task(":validatePublications")?.outcome,
+            "validatePublications must be SKIPPED when validateForMavenCentral=false; got: ${result.output}",
+        )
+    }
+
+    // ---------------------------------------------------------------
+    // validatePublications default (true): still enforced on `check` — an incomplete
+    // publication fails the build.
+    // ---------------------------------------------------------------
+    @Test
+    fun `validatePublications enforced on check by default`() {
+        settingsFile(kotlinSettings("test-pub-default-enforced"))
+        buildFile(
+            """
+            plugins {
+                java
+                `maven-publish`
+                id("org.octopusden.octopus-quality")
+            }
+            repositories { mavenCentral() }
+            group = "org.example"
+            version = "1.0.0"
+            publishing {
+                publications {
+                    // No sources/javadoc JARs and no POM metadata — must FAIL validation (default true).
+                    create<MavenPublication>("mavenJava") {
+                        from(components["java"])
+                    }
+                }
+            }
+            octopusQuality {
+                java { failOnViolation.set(false) }
+                coverage { enabled.set(false) }
+            }
+            """.trimIndent(),
+        )
+        subDir("src/main/java/com/example")
+        File(projectDir, "src/main/java/com/example/Hello.java")
+            .writeText("package com.example;\npublic class Hello { public String greet() { return \"hi\"; } }\n")
+
+        val result = runner("check").buildAndFail()
+        assertEquals(TaskOutcome.FAILED, result.task(":validatePublications")?.outcome)
+        assertTrue(
+            result.output.contains("Maven Central publication validation failed"),
+            "Expected validatePublications to enforce by default; got: ${result.output}",
+        )
     }
 }

--- a/gradle-quality-plugin/src/test/kotlin/org/octopusden/octopus/quality/OctopusQualityPluginFunctionalTest.kt
+++ b/gradle-quality-plugin/src/test/kotlin/org/octopusden/octopus/quality/OctopusQualityPluginFunctionalTest.kt
@@ -1,5 +1,6 @@
 package org.octopusden.octopus.quality
 
+import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -39,6 +40,8 @@ class OctopusQualityPluginFunctionalTest {
             }
         }
         """.trimIndent()
+
+    private val ansiEscape = Regex("\\u001B\\[[0-9;]*m")
 
     private fun settingsFile(content: String) {
         File(projectDir, "settings.gradle.kts").writeText(content)
@@ -85,6 +88,39 @@ class OctopusQualityPluginFunctionalTest {
         rootProject.name = "$projectName"
         $extraIncludes
         """.trimIndent()
+
+    /**
+     * All ktlint report files (PLAIN + CHECKSTYLE), ANSI-stripped, concatenated.
+     *
+     * ktlint writes its findings under `build/reports/ktlint/<task>/` deterministically before the
+     * task fails the build, whereas the same findings reaching the GradleRunner console
+     * (`result.output`) races with worker-output flushing and is intermittently absent on CI. So
+     * ktlint-content assertions read the report file as the authoritative source. The report is
+     * colorized, so escape codes are stripped.
+     */
+    private fun ktlintFindings(): String {
+        val dir = File(projectDir, "build/reports/ktlint")
+        if (!dir.exists()) return ""
+        return dir
+            .walkTopDown()
+            .filter { it.isFile }
+            .joinToString("\n") { it.readText() }
+            .replace(ansiEscape, "")
+    }
+
+    /** Assert each needle appears in the ktlint findings (console output OR the report files). */
+    private fun assertKtlintReported(
+        result: BuildResult,
+        vararg needles: String,
+    ) {
+        val findings = result.output + "\n" + ktlintFindings()
+        needles.forEach { needle ->
+            assertTrue(
+                findings.contains(needle),
+                "Expected ktlint findings to contain \"$needle\"; console+report was:\n$findings",
+            )
+        }
+    }
 
     // ---------------------------------------------------------------
     // 1. Single-module Kotlin: qualityStatic registers and runs
@@ -762,10 +798,7 @@ class OctopusQualityPluginFunctionalTest {
         )
 
         val result = runner("clean", "ktlintCheck").buildAndFail()
-        assertTrue(
-            result.output.contains("Bad.kt"),
-            "Expected ktlint failure output to mention Bad.kt; got: ${result.output}",
-        )
+        assertKtlintReported(result, "Bad.kt")
     }
 
     // ---------------------------------------------------------------
@@ -800,17 +833,10 @@ class OctopusQualityPluginFunctionalTest {
         )
 
         val result = runner("clean", "ktlintCheck").buildAndFail()
-        assertTrue(
-            result.output.contains("build.gradle.kts"),
-            "Expected ktlintCheck failure to mention build.gradle.kts; got: ${result.output}",
-        )
-        // Rule-message assertion guards against false positives where "build.gradle.kts"
-        // appears in unrelated error output (deprecation warnings, stack traces).
-        // ktlint's PLAIN reporter prints the human message, not the rule id.
-        assertTrue(
-            result.output.contains("Wildcard import"),
-            "Expected ktlintCheck failure to fire the wildcard-import rule; got: ${result.output}",
-        )
+        // "build.gradle.kts" proves the .kts file was scanned; the rule-message assertion guards
+        // against a false positive where the filename appears in unrelated output (deprecation
+        // warnings, stack traces). ktlint's PLAIN reporter prints the human message, not the rule id.
+        assertKtlintReported(result, "build.gradle.kts", "Wildcard import")
     }
 
     // ---------------------------------------------------------------
@@ -845,10 +871,7 @@ class OctopusQualityPluginFunctionalTest {
         )
 
         val result = runner("ktlintCheck").buildAndFail()
-        assertTrue(
-            result.output.contains("Exceeded max line length (140)"),
-            "Expected ktlint violation against bundled max_line_length=140; got: ${result.output}",
-        )
+        assertKtlintReported(result, "Exceeded max line length (140)")
     }
 
     // ---------------------------------------------------------------
@@ -970,10 +993,7 @@ class OctopusQualityPluginFunctionalTest {
         )
 
         val result = runner("ktlintCheck").buildAndFail()
-        assertTrue(
-            result.output.contains("max line length"),
-            "Expected ktlint violation against consumer override; got: ${result.output}",
-        )
+        assertKtlintReported(result, "max line length")
     }
 
     // ---------------------------------------------------------------
@@ -1040,10 +1060,7 @@ class OctopusQualityPluginFunctionalTest {
         )
 
         val result = runner("ktlintCheck").buildAndFail()
-        assertTrue(
-            result.output.contains("Bad.kt") && result.output.contains("Wildcard import"),
-            "Expected ktlint to scan the file under a 'build' package segment; got: ${result.output}",
-        )
+        assertKtlintReported(result, "Bad.kt", "Wildcard import")
     }
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
Part of the post-2.4.0 adoption-feedback follow-ups for the `gradle-quality-plugin` convention plugin. Targets a future **2.4.1**.

## Changes

### 1. `validatePublications` opt-out (main blocker)
Previously `validatePublications` was wired into `check` for any `maven-publish` project with no way to opt out — repos that don't publish to Maven Central were forced to provide sources/javadoc JARs and full POM metadata.

- New nested extension: `octopusQuality { publication { validateForMavenCentral = true } }` (default `true`), mirroring the existing `CoverageExtension` pattern.
- `PublicationValidator.register(...)` now captures the `Property<Boolean>` and adds a lazy `onlyIf { validateForMavenCentral.get() }` so the task is **SKIPPED** (not enforced on `check`) when a repo opts out. The existing lazy `check` wiring is unchanged.
- `PublicationExtension` added to the plugin's own Kover class-exclusion list (extension classes are uninstrumentable; the 80% `koverVerify` gate would otherwise fail).
- Opt-out is root-level / per-repo / all-or-nothing by design.

### 2. checkstyle/PMD gated to `hasJava` (Java-only tools)
checkstyle and PMD analyse `.java` source, so applying them to Kotlin-only / Groovy-only modules only added no-op, misleadingly-named tasks to the graph.

- Plugin-apply (`SubprojectConfigurer.configure`) and the `qualityStatic` wiring (`TaskRegistrar.registerQualityStatic`) are now gated to `hasJava`.
- The `classes`/`testClasses` wiring is **kept** under the broad `hasJava || hasKotlin || hasGroovy` condition — compilation is still needed for detekt/codenarc modules, so it is deliberately not narrowed to `hasJava`.
- Docs table corrected: Kotlin-only → detekt + ktlint; Groovy-only → codenarc; only Java gets checkstyle + pmd.

### 3. `excludeTasks` KDoc clarification
Clarified that `excludeTasks` prunes only the `qualityStatic` / `qualityCoverage` aggregate tasks (and transitively `qualityCheck`), NOT the standard `check` → `test` graph.

## Tests
New TestKit functional tests (dry-run, task-path-anchored):
- Kotlin-only and Groovy-only modules get no `:checkstyleMain`/`:pmdMain`, but still get `:classes` + `:detekt` / `:codenarcMain`.
- A Java module still wires `:checkstyleMain` + `:pmdMain`.
- Opt-out: `validatePublications` is SKIPPED on `check` when `validateForMavenCentral=false`; default (true) still fails an incomplete publication.
- Fixed the stale "codenarc + checkstyle + pmd applied" comment in the groovy-only test.

`./gradlew check` (in `gradle-quality-plugin`): **BUILD SUCCESSFUL** (ktlint, detekt, all functional tests, koverVerify, validatePublications).

🤖 Generated with [Claude Code](https://claude.com/claude-code)