### PR TITLE
feat(quality): coverage report/verify-on-check semantics (verifyInCheck)

### DIFF
--- a/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/OctopusQualityExtension.kt
+++ b/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/OctopusQualityExtension.kt
@@ -55,8 +55,24 @@ open class CoverageExtension
     ) {
         enum class Tool { AUTO, JACOCO, KOVER }
 
-        /** Enable coverage verification. Set to false for repos without tests. */
+        /**
+         * Enable coverage. Governs BOTH the coverage report and verification on `check`/`build`:
+         * when `false`, neither the report nor the verify task runs on `check` and no coverage rule is
+         * configured (for Kover and JaCoCo alike); when `true` (default) the report runs on `check` while
+         * floor enforcement is gated by [verifyInCheck] (or the `qualityCoverage` aggregate).
+         * Set to `false` for repos without tests.
+         */
         val enabled = objects.property(Boolean::class.java).convention(true)
+
+        /**
+         * Enforce the per-module line-coverage floor on `check`/`build`.
+         *
+         * Default `false`: with coverage `enabled` (the default) the report still runs on `check`,
+         * but the floor is NOT enforced there — enforce it via the `qualityCoverage` aggregate task.
+         * Set to `true` to additionally gate `check` on `koverVerify` / `jacocoTestCoverageVerification`.
+         * Has no effect when `enabled` is `false` (no report and no verify run on `check`).
+         */
+        val verifyInCheck = objects.property(Boolean::class.java).convention(false)
 
         /** Coverage tool selection. AUTO detects based on project languages. */
         val tool = objects.property(Tool::class.java).convention(Tool.AUTO)

--- a/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/SubprojectConfigurer.kt
+++ b/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/SubprojectConfigurer.kt
@@ -309,9 +309,29 @@ internal object SubprojectConfigurer {
         val defaultReportTask = reportTasks.matching { it.name == "jacocoTestReport" }
         val defaultVerifyTask = verifyTasks.matching { it.name == "jacocoTestCoverageVerification" }
 
-        defaultTestTask.configureEach { task -> task.finalizedBy(defaultReportTask) }
+        // Coverage semantics (read eagerly — this runs from the subproject afterEvaluate, so the
+        // consumer's octopusQuality { } block has already been processed). These are structural
+        // task-graph decisions, so they cannot be deferred to a lazy Provider.
+        val coverageEnabled = extension.coverage.enabled.get()
+        val verifyInCheck = extension.coverage.verifyInCheck.get()
+
+        // Report-on-check follows `enabled`: the jacoco plugin ties the report to `check` only
+        // through this `test.finalizedBy(jacocoTestReport)` edge, so gating it here removes the
+        // report from `check` when coverage is disabled.
+        if (coverageEnabled) {
+            defaultTestTask.configureEach { task -> task.finalizedBy(defaultReportTask) }
+        }
         defaultReportTask.configureEach { task -> task.dependsOn(defaultTestTask) }
         defaultVerifyTask.configureEach { task -> task.dependsOn(defaultTestTask) }
+
+        // Unlike Kover, Gradle's jacoco plugin does NOT put verification on `check` by default, so
+        // there is no pre-existing floor to remove. Add the opt-in edge only when the consumer asks
+        // for it. Wired lazily via `matching` so it is safe regardless of plugin application order.
+        if (coverageEnabled && verifyInCheck) {
+            project.tasks.matching { it.name == "check" }.configureEach { task ->
+                task.dependsOn(defaultVerifyTask)
+            }
+        }
 
         reportTasks.configureEach { task ->
             task.reports.xml.required
@@ -319,13 +339,17 @@ internal object SubprojectConfigurer {
             task.reports.html.required
                 .set(true)
         }
-        verifyTasks.configureEach { task ->
-            task.violationRules.rule { rule ->
-                rule.element = "BUNDLE"
-                rule.limit { limit ->
-                    limit.counter = "LINE"
-                    limit.value = "COVEREDRATIO"
-                    limit.minimum = extension.coverage.minimumLineCoverage.get()
+        // Configure the violation rule only when coverage is enabled — an enabled=false project has
+        // no floor at all, so a direct `jacocoTestCoverageVerification` invocation passes vacuously.
+        if (coverageEnabled) {
+            verifyTasks.configureEach { task ->
+                task.violationRules.rule { rule ->
+                    rule.element = "BUNDLE"
+                    rule.limit { limit ->
+                        limit.counter = "LINE"
+                        limit.value = "COVEREDRATIO"
+                        limit.minimum = extension.coverage.minimumLineCoverage.get()
+                    }
                 }
             }
         }
@@ -341,20 +365,40 @@ internal object SubprojectConfigurer {
         // same per-module line-coverage floor the JaCoCo path enforces. Previously this was a no-op,
         // so `koverVerify` passed with NO threshold — a coverage gate that measured nothing.
         project.plugins.withId("org.jetbrains.kotlinx.kover") {
+            val coverage = extension.coverage
             val minPercent =
-                extension.coverage.minimumLineCoverage
+                coverage.minimumLineCoverage
                     .get()
                     .movePointRight(2)
                     .toInt()
                     .coerceIn(0, 100)
+            // Structural gate for the rule (read eagerly — runs from the subproject afterEvaluate,
+            // so the consumer's octopusQuality { } block is already processed). The onCheck flags
+            // below are wired lazily as Providers.
+            val coverageEnabled = coverage.enabled.get()
             project.extensions.configure(kotlinx.kover.gradle.plugin.dsl.KoverProjectExtension::class.java) { kover ->
                 kover.reports { reports ->
-                    reports.verify { verify ->
-                        verify.rule { rule ->
-                            rule.minBound(
-                                minValue = minPercent,
-                                coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE,
-                            )
+                    // Report-on-check follows `enabled`. Verify-on-check is opt-in: Kover binds
+                    // `koverVerify` into `check` by default via `total.verify.onCheck.convention(true)`,
+                    // so we ACTIVELY set it to false unless the consumer asked for `verifyInCheck` —
+                    // this is the loosening relative to #147, which always enforced the floor on check.
+                    reports.total { total ->
+                        total.xml.onCheck.set(coverage.enabled)
+                        total.html.onCheck.set(coverage.enabled)
+                        total.verify.onCheck.set(
+                            coverage.enabled.zip(coverage.verifyInCheck) { enabled, verify -> enabled && verify },
+                        )
+                    }
+                    // Configure the floor rule only when coverage is enabled — an enabled=false
+                    // project has no rule at all, so a direct `koverVerify` invocation passes vacuously.
+                    if (coverageEnabled) {
+                        reports.verify { verify ->
+                            verify.rule { rule ->
+                                rule.minBound(
+                                    minValue = minPercent,
+                                    coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE,
+                                )
+                            }
                         }
                     }
                 }

--- a/gradle-quality-plugin/src/test/kotlin/org/octopusden/octopus/quality/OctopusQualityPluginFunctionalTest.kt
+++ b/gradle-quality-plugin/src/test/kotlin/org/octopusden/octopus/quality/OctopusQualityPluginFunctionalTest.kt
@@ -41,6 +41,17 @@ class OctopusQualityPluginFunctionalTest {
         }
         """.trimIndent()
 
+    // JUnit 5 wiring for coverage fixtures that actually execute `test` (and thus produce
+    // coverage data). Gradle 8.9 needs the platform launcher explicitly on the runtime classpath.
+    private val junitDeps =
+        """
+        dependencies {
+            testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
+            testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.10.2")
+        }
+        tasks.withType<Test> { useJUnitPlatform() }
+        """.trimIndent()
+
     private val ansiEscape = Regex("\\u001B\\[[0-9;]*m")
 
     private fun settingsFile(content: String) {
@@ -1301,5 +1312,398 @@ class OctopusQualityPluginFunctionalTest {
             result.output.contains("Maven Central publication validation failed"),
             "Expected validatePublications to enforce by default; got: ${result.output}",
         )
+    }
+
+    /** Kotlin `Calc` with four methods; the paired test covers only `add` → ~40% line coverage. */
+    private fun writeKotlinCalc() {
+        writeKotlinFile(
+            "src/main/kotlin/com/example/Calc.kt",
+            """
+            package com.example
+            class Calc {
+                fun add(a: Int, b: Int): Int = a + b
+                fun sub(a: Int, b: Int): Int = a - b
+                fun mul(a: Int, b: Int): Int = a * b
+                fun div(a: Int, b: Int): Int = a / b
+            }
+            """.trimIndent() + "\n",
+        )
+        writeKotlinFile(
+            "src/test/kotlin/com/example/CalcTest.kt",
+            """
+            package com.example
+            import org.junit.jupiter.api.Test
+            import org.junit.jupiter.api.Assertions.assertEquals
+            class CalcTest {
+                @Test fun t() { assertEquals(3, Calc().add(1, 2)) }
+            }
+            """.trimIndent() + "\n",
+        )
+    }
+
+    /** Java `Calc` with four methods; the paired test covers only `add` → ~40% line coverage. */
+    private fun writeJavaCalc() {
+        subDir("src/main/java/com/example")
+        File(projectDir, "src/main/java/com/example/Calc.java").writeText(
+            """
+            package com.example;
+            public class Calc {
+                public int add(int a, int b) { return a + b; }
+                public int sub(int a, int b) { return a - b; }
+                public int mul(int a, int b) { return a * b; }
+                public int div(int a, int b) { return a / b; }
+            }
+            """.trimIndent() + "\n",
+        )
+        subDir("src/test/java/com/example")
+        File(projectDir, "src/test/java/com/example/CalcTest.java").writeText(
+            """
+            package com.example;
+            import org.junit.jupiter.api.Test;
+            import static org.junit.jupiter.api.Assertions.assertEquals;
+            class CalcTest {
+                @Test void t() { assertEquals(3, new Calc().add(1, 2)); }
+            }
+            """.trimIndent() + "\n",
+        )
+    }
+
+    // ===============================================================
+    // Coverage-on-check semantics (#150)
+    //
+    // Kover binds `koverVerify` into `check` by default (`total.verify.onCheck` convention is
+    // true); JaCoCo never puts verification on `check`. The plugin normalises both: with coverage
+    // enabled (default) the REPORT runs on `check` but the floor is NOT enforced there unless the
+    // consumer opts in with `verifyInCheck = true`. Anchored on task PATHS via `--dry-run`.
+    // ===============================================================
+
+    // ---------------------------------------------------------------
+    // Kover (a): enabled (default) — report on check, but verify actively OFF.
+    // LOAD-BEARING: proves we overrode Kover's `total.verify.onCheck.convention(true)`.
+    // ---------------------------------------------------------------
+    @Test
+    fun `kover enabled default - check runs report but not koverVerify`() {
+        settingsFile(kotlinSettings("test-kover-report-on-check"))
+        buildFile(
+            """
+            plugins {
+                kotlin("jvm") version "1.9.25"
+                id("org.jetbrains.kotlinx.kover") version "0.9.4"
+                id("org.octopusden.octopus-quality")
+            }
+            repositories { mavenCentral() }
+            octopusQuality {
+                kotlin { failOnViolation.set(false) }
+            }
+            """.trimIndent(),
+        )
+        writeKotlinFile("src/main/kotlin/com/example/Hello.kt", "package com.example\nfun hello() = 1\n")
+
+        val result = runner("check", "--dry-run").build()
+        assertTrue(
+            result.output.contains(":koverXmlReport"),
+            "Kover report must run on check when coverage is enabled; got: ${result.output}",
+        )
+        assertFalse(
+            result.output.contains(":koverVerify"),
+            "koverVerify must NOT run on check by default — Kover's onCheck convention must be disabled; got: ${result.output}",
+        )
+    }
+
+    // ---------------------------------------------------------------
+    // Kover (b): verifyInCheck=true — koverVerify wired onto check.
+    // ---------------------------------------------------------------
+    @Test
+    fun `kover verifyInCheck true - koverVerify runs on check`() {
+        settingsFile(kotlinSettings("test-kover-verify-on-check"))
+        buildFile(
+            """
+            plugins {
+                kotlin("jvm") version "1.9.25"
+                id("org.jetbrains.kotlinx.kover") version "0.9.4"
+                id("org.octopusden.octopus-quality")
+            }
+            repositories { mavenCentral() }
+            octopusQuality {
+                kotlin { failOnViolation.set(false) }
+                coverage { verifyInCheck.set(true) }
+            }
+            """.trimIndent(),
+        )
+        writeKotlinFile("src/main/kotlin/com/example/Hello.kt", "package com.example\nfun hello() = 1\n")
+
+        val result = runner("check", "--dry-run").build()
+        assertTrue(
+            result.output.contains(":koverVerify"),
+            "koverVerify must run on check when verifyInCheck=true; got: ${result.output}",
+        )
+    }
+
+    // ---------------------------------------------------------------
+    // Kover (c): enabled=false — no report and no verify on check; a direct koverVerify
+    // invocation PASSES because no rule was configured at all (green check alone can't prove this).
+    // ---------------------------------------------------------------
+    @Test
+    fun `kover disabled - no report or verify on check and direct koverVerify passes`() {
+        settingsFile(kotlinSettings("test-kover-disabled"))
+        buildFile(
+            """
+            plugins {
+                kotlin("jvm") version "1.9.25"
+                id("org.jetbrains.kotlinx.kover") version "0.9.4"
+                id("org.octopusden.octopus-quality")
+            }
+            repositories { mavenCentral() }
+            octopusQuality {
+                kotlin { failOnViolation.set(false) }
+                coverage { enabled.set(false) }
+            }
+            """.trimIndent(),
+        )
+        writeKotlinFile("src/main/kotlin/com/example/Hello.kt", "package com.example\nfun hello() = 1\n")
+
+        val dryRun = runner("check", "--dry-run").build()
+        assertFalse(
+            dryRun.output.contains(":koverXmlReport"),
+            "No Kover report on check when disabled; got: ${dryRun.output}",
+        )
+        assertFalse(
+            dryRun.output.contains(":koverVerify"),
+            "No koverVerify on check when disabled; got: ${dryRun.output}",
+        )
+
+        // No rule configured → koverVerify passes vacuously (0% coverage, no bound).
+        val direct = runner("koverVerify").build()
+        assertEquals(TaskOutcome.SUCCESS, direct.task(":koverVerify")?.outcome)
+    }
+
+    // ---------------------------------------------------------------
+    // Kover (d): a below-floor project fails `check` with verifyInCheck=true, but passes
+    // `check` when coverage is disabled (no rule enforced anywhere).
+    // ---------------------------------------------------------------
+    @Test
+    fun `kover below floor - check fails with verifyInCheck and passes when disabled`() {
+        settingsFile(kotlinSettings("test-kover-below-floor"))
+
+        fun script(coverageBlock: String) =
+            """
+            import java.math.BigDecimal
+            plugins {
+                kotlin("jvm") version "1.9.25"
+                id("org.jetbrains.kotlinx.kover") version "0.9.4"
+                id("org.octopusden.octopus-quality")
+            }
+            repositories { mavenCentral() }
+            $junitDeps
+            octopusQuality {
+                kotlin { failOnViolation.set(false) }
+                coverage { $coverageBlock }
+            }
+            """.trimIndent()
+        writeKotlinCalc()
+
+        // ~40% covered, floor 99% + verifyInCheck → check FAILS on koverVerify.
+        buildFile(script("""enabled.set(true); verifyInCheck.set(true); minimumLineCoverage.set(BigDecimal("0.99"))"""))
+        val failed = runner("check").buildAndFail()
+        assertEquals(TaskOutcome.FAILED, failed.task(":koverVerify")?.outcome)
+
+        // Same project, coverage disabled → no rule, koverVerify not on check → check PASSES.
+        buildFile(script("""enabled.set(false); minimumLineCoverage.set(BigDecimal("0.99"))"""))
+        val passed = runner("check").build()
+        assertTrue(passed.task(":koverVerify") == null, "koverVerify must not run under check when disabled")
+    }
+
+    // ---------------------------------------------------------------
+    // JaCoCo (a): enabled (default) — report on check, verification NOT on check.
+    // ---------------------------------------------------------------
+    @Test
+    fun `jacoco enabled default - check runs report but not verification`() {
+        settingsFile(kotlinSettings("test-jacoco-report-on-check"))
+        buildFile(
+            """
+            plugins {
+                java
+                id("org.octopusden.octopus-quality")
+            }
+            repositories { mavenCentral() }
+            octopusQuality {
+                java { failOnViolation.set(false) }
+            }
+            """.trimIndent(),
+        )
+        writeJavaCalc()
+
+        val result = runner("check", "--dry-run").build()
+        assertTrue(
+            result.output.contains(":jacocoTestReport"),
+            "JaCoCo report must run on check when coverage is enabled; got: ${result.output}",
+        )
+        assertFalse(
+            result.output.contains(":jacocoTestCoverageVerification"),
+            "jacocoTestCoverageVerification must NOT run on check by default; got: ${result.output}",
+        )
+    }
+
+    // ---------------------------------------------------------------
+    // JaCoCo (b): verifyInCheck=true — verification wired onto check.
+    // ---------------------------------------------------------------
+    @Test
+    fun `jacoco verifyInCheck true - verification runs on check`() {
+        settingsFile(kotlinSettings("test-jacoco-verify-on-check"))
+        buildFile(
+            """
+            plugins {
+                java
+                id("org.octopusden.octopus-quality")
+            }
+            repositories { mavenCentral() }
+            octopusQuality {
+                java { failOnViolation.set(false) }
+                coverage { verifyInCheck.set(true) }
+            }
+            """.trimIndent(),
+        )
+        writeJavaCalc()
+
+        val result = runner("check", "--dry-run").build()
+        assertTrue(
+            result.output.contains(":jacocoTestCoverageVerification"),
+            "jacocoTestCoverageVerification must run on check when verifyInCheck=true; got: ${result.output}",
+        )
+    }
+
+    // ---------------------------------------------------------------
+    // JaCoCo (c): enabled=false — no report and no verification on check; a direct
+    // jacocoTestCoverageVerification invocation PASSES because no rule was configured.
+    // ---------------------------------------------------------------
+    @Test
+    fun `jacoco disabled - no report or verification on check and direct verification passes`() {
+        settingsFile(kotlinSettings("test-jacoco-disabled"))
+        buildFile(
+            """
+            plugins {
+                java
+                id("org.octopusden.octopus-quality")
+            }
+            repositories { mavenCentral() }
+            $junitDeps
+            octopusQuality {
+                java { failOnViolation.set(false) }
+                coverage { enabled.set(false) }
+            }
+            """.trimIndent(),
+        )
+        writeJavaCalc()
+
+        val dryRun = runner("check", "--dry-run").build()
+        assertFalse(
+            dryRun.output.contains(":jacocoTestReport"),
+            "No JaCoCo report on check when disabled; got: ${dryRun.output}",
+        )
+        assertFalse(
+            dryRun.output.contains(":jacocoTestCoverageVerification"),
+            "No jacocoTestCoverageVerification on check when disabled; got: ${dryRun.output}",
+        )
+
+        // No rule configured → verification passes vacuously.
+        val direct = runner("jacocoTestCoverageVerification").build()
+        assertEquals(TaskOutcome.SUCCESS, direct.task(":jacocoTestCoverageVerification")?.outcome)
+    }
+
+    // ---------------------------------------------------------------
+    // JaCoCo (d): a below-floor project fails `check` with verifyInCheck=true, but passes
+    // `check` when coverage is disabled (no rule enforced anywhere).
+    // ---------------------------------------------------------------
+    @Test
+    fun `jacoco below floor - check fails with verifyInCheck and passes when disabled`() {
+        settingsFile(kotlinSettings("test-jacoco-below-floor"))
+
+        fun script(coverageBlock: String) =
+            """
+            import java.math.BigDecimal
+            plugins {
+                java
+                id("org.octopusden.octopus-quality")
+            }
+            repositories { mavenCentral() }
+            $junitDeps
+            octopusQuality {
+                java { failOnViolation.set(false) }
+                coverage { $coverageBlock }
+            }
+            """.trimIndent()
+        writeJavaCalc()
+
+        // ~40% covered, floor 99% + verifyInCheck → check FAILS on the verification task.
+        buildFile(script("""enabled.set(true); verifyInCheck.set(true); minimumLineCoverage.set(BigDecimal("0.99"))"""))
+        val failed = runner("check").buildAndFail()
+        assertEquals(TaskOutcome.FAILED, failed.task(":jacocoTestCoverageVerification")?.outcome)
+
+        // Same project, coverage disabled → no rule, verification not on check → check PASSES.
+        buildFile(script("""enabled.set(false); minimumLineCoverage.set(BigDecimal("0.99"))"""))
+        val passed = runner("check").build()
+        assertTrue(
+            passed.task(":jacocoTestCoverageVerification") == null,
+            "jacocoTestCoverageVerification must not run under check when disabled",
+        )
+    }
+
+    // ---------------------------------------------------------------
+    // qualityCoverage is the enforcement path with the new default (verifyInCheck=false): the
+    // verifyInCheck KDoc directs consumers to it. A below-floor project therefore PASSES `check`
+    // (no verify on check) yet FAILS `qualityCoverage` — proving the floor is still enforced
+    // somewhere and the gate is not hollow. Kover and JaCoCo, both at default verifyInCheck.
+    // ---------------------------------------------------------------
+    @Test
+    fun `kover below floor - qualityCoverage enforces floor even when verifyInCheck is false`() {
+        settingsFile(kotlinSettings("test-kover-qualitycoverage-floor"))
+        buildFile(
+            """
+            import java.math.BigDecimal
+            plugins {
+                kotlin("jvm") version "1.9.25"
+                id("org.jetbrains.kotlinx.kover") version "0.9.4"
+                id("org.octopusden.octopus-quality")
+            }
+            repositories { mavenCentral() }
+            $junitDeps
+            octopusQuality {
+                kotlin { failOnViolation.set(false) }
+                coverage { enabled.set(true); minimumLineCoverage.set(BigDecimal("0.99")) }
+            }
+            """.trimIndent(),
+        )
+        writeKotlinCalc()
+
+        // Default verifyInCheck=false → check does not enforce the floor (build() would throw otherwise).
+        runner("check").build()
+        // ...but qualityCoverage does: ~40% covered vs a 99% floor → koverVerify FAILS.
+        val failed = runner("qualityCoverage").buildAndFail()
+        assertEquals(TaskOutcome.FAILED, failed.task(":koverVerify")?.outcome)
+    }
+
+    @Test
+    fun `jacoco below floor - qualityCoverage enforces floor even when verifyInCheck is false`() {
+        settingsFile(kotlinSettings("test-jacoco-qualitycoverage-floor"))
+        buildFile(
+            """
+            import java.math.BigDecimal
+            plugins {
+                java
+                id("org.octopusden.octopus-quality")
+            }
+            repositories { mavenCentral() }
+            $junitDeps
+            octopusQuality {
+                java { failOnViolation.set(false) }
+                coverage { enabled.set(true); minimumLineCoverage.set(BigDecimal("0.99")) }
+            }
+            """.trimIndent(),
+        )
+        writeJavaCalc()
+
+        runner("check").build()
+        val failed = runner("qualityCoverage").buildAndFail()
+        assertEquals(TaskOutcome.FAILED, failed.task(":jacocoTestCoverageVerification")?.outcome)
     }
 }


### PR DESCRIPTION
## Summary

Introduces coverage-on-check semantics so `check`/`build` reports coverage by default but only enforces the per-module floor when the consumer opts in. Adds a new `coverage.verifyInCheck` property (`Property<Boolean>`, default `false`) and rewires both coverage tools in `SubprojectConfigurer`.

Stacked on PR-1 (`fix/quality-optout-and-checkstyle-gating`); base is set to that branch so this diff shows only PR-2's changes. GitHub will auto-retarget to `main` once PR-1 merges.

## The Kover-loosens / JaCoCo-never-on-check asymmetry

The two tools start from opposite defaults, so the code is deliberately asymmetric:

- **Kover (0.9.4)** already binds `koverVerify` into `check` by default via the per-variant `reports.total.verify.onCheck.convention(true)`. Combined with the `minBound` floor added in #147, every Kover consumer currently enforces the floor on `check`. This PR is therefore a **loosening**: we actively set `reports.total.verify.onCheck` to `coverage.enabled && verifyInCheck`, overriding Kover's `true` convention. Report-on-check follows `coverage.enabled` via `reports.total.xml.onCheck` / `reports.total.html.onCheck`. The floor rule (in the global `reports.verify {}` rules container — which has no `onCheck` of its own) is configured only when `coverage.enabled`.
- **JaCoCo** never puts verification on `check` by default (Gradle's jacoco plugin only wires `test.finalizedBy(jacocoTestReport)` and the plugin's own `jacocoTestCoverageVerification.dependsOn(test)`). There is no pre-existing floor to remove, so this PR **keeps** report-on-check (now gated on `coverage.enabled`) and **adds** a new opt-in `check.dependsOn(jacocoTestCoverageVerification)` only when `coverage.enabled && verifyInCheck`. The violation rule is configured only when `coverage.enabled`.

## Net behaviour

- `enabled = false` → no report and no verify on `check`; no rule configured at all (both tools). A direct `koverVerify` / `jacocoTestCoverageVerification` passes vacuously.
- `enabled = true` (default) → report on `check`, but **no floor enforcement on `check`**. Enforcement moves to the `qualityCoverage` aggregate task, or opt back into `check` with `coverage { verifyInCheck.set(true) }`.

## Tests

Symmetric TestKit coverage for both tools, anchored on task paths via `--dry-run`:

- default (`enabled=true`): `check --dry-run` lists the report task (`:koverXmlReport` / `:jacocoTestReport`) but **not** the verify task — load-bearing proof that Kover's default `onCheck` was disabled;
- `verifyInCheck=true`: the verify task is present on `check --dry-run`;
- `enabled=false`: no report and no verify on `check --dry-run`, **and** a direct verify invocation passes (proving no rule was configured);
- below-floor project: `check` fails under `verifyInCheck=true` yet passes when `enabled=false`.

`./gradlew check` is green (ktlint, detekt, all TestKit tests, koverVerify, validatePublications).

Part of the post-2.4.0 follow-ups → 2.4.1. References #150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to enforce minimum line coverage during standard `check` and `build` tasks.
  * Coverage verification can now be enabled independently of coverage reporting.
  * Coverage checks remain available through the aggregate quality coverage task.

* **Bug Fixes**
  * Disabled coverage no longer adds reports or verification tasks to standard checks.
  * Coverage thresholds are now applied consistently for both Kover and JaCoCo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->