### PR TITLE
fix(release): fix broken Sonatype publishing — pin stagingProfileId via init script

### DIFF
--- a/.github/workflows/common-java-gradle-release.yml
+++ b/.github/workflows/common-java-gradle-release.yml
@@ -245,10 +245,30 @@ jobs:
         if: inputs.docker-image && !inputs.dry-run
         run: docker push ghcr.io/octopusden/${{ inputs.docker-image }}:${{ env.BUILD_VERSION }}
 
+      # Bind -PstagingProfileId to the gradle-nexus publish-plugin extension for
+      # every project that applies it, without requiring any consumer build-script
+      # change. Bypasses the flaky OSSRH-compat staging-profile auto-lookup. No-op
+      # when staging-profile-id is blank (falls back to auto-lookup).
+      - name: Prepare staging-profile init script
+        if: ${{ !inputs.dry-run }}
+        run: |
+          cat > "$RUNNER_TEMP/staging-profile.init.gradle" <<'GRADLE'
+          allprojects { proj ->
+              proj.plugins.withId('io.github.gradle-nexus.publish-plugin') {
+                  def spid = proj.findProperty('stagingProfileId')?.toString()?.trim()
+                  if (spid) {
+                      proj.extensions.getByName('nexusPublishing')
+                          .repositories.all { repo -> repo.stagingProfileId.set(spid) }
+                  }
+              }
+          }
+          GRADLE
+          echo "Wrote $RUNNER_TEMP/staging-profile.init.gradle"
+
       # publish to nexus
       - name: Publish to Sonatype Nexus
         if: ${{ !inputs.dry-run }}
-        run: ./gradlew -Pnexus=true -PstagingProfileId=${{ inputs.staging-profile-id }} publishToSonatype closeAndReleaseSonatypeStagingRepository -PbuildVersion=${{ env.BUILD_VERSION }} -Pversion=${{ env.BUILD_VERSION }} --info -s
+        run: ./gradlew -Pnexus=true -PstagingProfileId=${{ inputs.staging-profile-id }} --init-script "$RUNNER_TEMP/staging-profile.init.gradle" publishToSonatype closeAndReleaseSonatypeStagingRepository -PbuildVersion=${{ env.BUILD_VERSION }} -Pversion=${{ env.BUILD_VERSION }} --info -s
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}

--- a/.github/workflows/common-java-gradle-release.yml
+++ b/.github/workflows/common-java-gradle-release.yml
@@ -46,7 +46,7 @@ on:
         type: string
         default: ''
       staging-profile-id:
-        description: 'Sonatype staging profile id (Central Portal namespace, e.g. org.octopusden). Passed as -PstagingProfileId; consumers must read it in their nexusPublishing.sonatype block. Bypasses the OSSRH-compat auto-lookup that fails for new/uncached package groups.'
+        description: 'Sonatype staging profile id (Central Portal namespace, e.g. org.octopusden). Bound to the gradle-nexus sonatype repository automatically via an injected init script — consumers need NO build-script change. Bypasses the flaky OSSRH-compat staging-profile auto-lookup. Blank = keep auto-lookup.'
         required: false
         type: string
         default: 'org.octopusden'
@@ -258,7 +258,7 @@ jobs:
                   def spid = proj.findProperty('stagingProfileId')?.toString()?.trim()
                   if (spid) {
                       proj.extensions.getByName('nexusPublishing')
-                          .repositories.all { repo -> repo.stagingProfileId.set(spid) }
+                          .repositories.all { repo -> if (repo.name == 'sonatype') repo.stagingProfileId.set(spid) }
                   }
               }
           }
@@ -267,9 +267,11 @@ jobs:
 
       # publish to nexus
       - name: Publish to Sonatype Nexus
+        id: publish-sonatype
         if: ${{ !inputs.dry-run }}
-        run: ./gradlew -Pnexus=true -PstagingProfileId=${{ inputs.staging-profile-id }} --init-script "$RUNNER_TEMP/staging-profile.init.gradle" publishToSonatype closeAndReleaseSonatypeStagingRepository -PbuildVersion=${{ env.BUILD_VERSION }} -Pversion=${{ env.BUILD_VERSION }} --info -s
+        run: ./gradlew -Pnexus=true -PstagingProfileId="$STAGING_PROFILE_ID" --init-script "$RUNNER_TEMP/staging-profile.init.gradle" publishToSonatype closeAndReleaseSonatypeStagingRepository -PbuildVersion=${{ env.BUILD_VERSION }} -Pversion=${{ env.BUILD_VERSION }} --info -s
         env:
+          STAGING_PROFILE_ID: ${{ inputs.staging-profile-id }}
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_PRIVATE_KEY }}
@@ -281,7 +283,7 @@ jobs:
       # credentials (401 => bad token; list without org.octopusden => the
       # server-side profile regression; present but unmatched => prefix issue).
       - name: Diagnose Sonatype staging (on failure)
-        if: ${{ failure() && !inputs.dry-run }}
+        if: ${{ failure() && steps.publish-sonatype.outcome == 'failure' && !inputs.dry-run }}
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
@@ -306,8 +308,8 @@ jobs:
           echo "  - HTTP 401                    -> credentials/token problem (OSSRH_USERNAME/OSSRH_TOKEN)."
           echo "  - 200 but org.octopusden absent -> server-side staging-profile regression (Sonatype)."
           echo "  - 200 with org.octopusden but group unmatched -> pass -PstagingProfileId explicitly."
-          echo "Workaround: set the reusable-workflow input staging-profile-id (default 'org.octopusden')"
-          echo "and read -PstagingProfileId in your nexusPublishing.sonatype block."
+          echo "This workflow already sets staging-profile-id (default 'org.octopusden') and binds it via the"
+          echo "injected init script, so a present-but-unmatched profile should not occur with the default."
 
       # github release
       - name: Create release

--- a/.github/workflows/common-java-gradle-release.yml
+++ b/.github/workflows/common-java-gradle-release.yml
@@ -255,6 +255,40 @@ jobs:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_PRIVATE_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_PASSPHRASE }}
 
+      # On publish failure, dump what the account actually sees so that
+      # "Failed to find staging profile for package group" is diagnosable:
+      # which staging profiles the OSSRH-compat service returns for these
+      # credentials (401 => bad token; list without org.octopusden => the
+      # server-side profile regression; present but unmatched => prefix issue).
+      - name: Diagnose Sonatype staging (on failure)
+        if: ${{ failure() && !inputs.dry-run }}
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+        run: |
+          set +e
+          endpoint="https://ossrh-staging-api.central.sonatype.com/service/local/staging/profiles"
+          echo "::group::Sonatype staging profiles visible to this account"
+          echo "GET ${endpoint}"
+          code=$(curl -s -o /tmp/staging-profiles.json -w '%{http_code}' \
+            -u "${MAVEN_USERNAME}:${MAVEN_PASSWORD}" \
+            -H 'Accept: application/json' \
+            "${endpoint}")
+          echo "HTTP ${code}"
+          if command -v jq >/dev/null 2>&1; then
+            jq -r '.data[]? | "  name=\(.name)  id=\(.id)  mode=\(.mode // "n/a")"' /tmp/staging-profiles.json 2>/dev/null \
+              || { echo "(non-JSON body)"; cat /tmp/staging-profiles.json; }
+          else
+            cat /tmp/staging-profiles.json
+          fi
+          echo "::endgroup::"
+          echo "Auto-lookup picks a profile whose name is a dot-boundary prefix of the package group."
+          echo "  - HTTP 401                    -> credentials/token problem (OSSRH_USERNAME/OSSRH_TOKEN)."
+          echo "  - 200 but org.octopusden absent -> server-side staging-profile regression (Sonatype)."
+          echo "  - 200 with org.octopusden but group unmatched -> pass -PstagingProfileId explicitly."
+          echo "Workaround: set the reusable-workflow input staging-profile-id (default 'org.octopusden')"
+          echo "and read -PstagingProfileId in your nexusPublishing.sonatype block."
+
       # github release
       - name: Create release
         if: ${{ !inputs.dry-run }}

--- a/.github/workflows/common-java-gradle-release.yml
+++ b/.github/workflows/common-java-gradle-release.yml
@@ -267,7 +267,6 @@ jobs:
 
       # publish to nexus
       - name: Publish to Sonatype Nexus
-        id: publish-sonatype
         if: ${{ !inputs.dry-run }}
         run: ./gradlew -Pnexus=true -PstagingProfileId="$STAGING_PROFILE_ID" --init-script "$RUNNER_TEMP/staging-profile.init.gradle" publishToSonatype closeAndReleaseSonatypeStagingRepository -PbuildVersion=${{ env.BUILD_VERSION }} -Pversion=${{ env.BUILD_VERSION }} --info -s
         env:
@@ -276,40 +275,6 @@ jobs:
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_PRIVATE_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_PASSPHRASE }}
-
-      # On publish failure, dump what the account actually sees so that
-      # "Failed to find staging profile for package group" is diagnosable:
-      # which staging profiles the OSSRH-compat service returns for these
-      # credentials (401 => bad token; list without org.octopusden => the
-      # server-side profile regression; present but unmatched => prefix issue).
-      - name: Diagnose Sonatype staging (on failure)
-        if: ${{ failure() && steps.publish-sonatype.outcome == 'failure' && !inputs.dry-run }}
-        env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
-        run: |
-          set +e
-          endpoint="https://ossrh-staging-api.central.sonatype.com/service/local/staging/profiles"
-          echo "::group::Sonatype staging profiles visible to this account"
-          echo "GET ${endpoint}"
-          code=$(curl -s -o /tmp/staging-profiles.json -w '%{http_code}' \
-            -u "${MAVEN_USERNAME}:${MAVEN_PASSWORD}" \
-            -H 'Accept: application/json' \
-            "${endpoint}")
-          echo "HTTP ${code}"
-          if command -v jq >/dev/null 2>&1; then
-            jq -r '.data[]? | "  name=\(.name)  id=\(.id)  mode=\(.mode // "n/a")"' /tmp/staging-profiles.json 2>/dev/null \
-              || { echo "(non-JSON body)"; cat /tmp/staging-profiles.json; }
-          else
-            cat /tmp/staging-profiles.json
-          fi
-          echo "::endgroup::"
-          echo "Auto-lookup picks a profile whose name is a dot-boundary prefix of the package group."
-          echo "  - HTTP 401                    -> credentials/token problem (OSSRH_USERNAME/OSSRH_TOKEN)."
-          echo "  - 200 but org.octopusden absent -> server-side staging-profile regression (Sonatype)."
-          echo "  - 200 with org.octopusden but group unmatched -> pass -PstagingProfileId explicitly."
-          echo "This workflow already sets staging-profile-id (default 'org.octopusden') and binds it via the"
-          echo "injected init script, so a present-but-unmatched profile should not occur with the default."
 
       # github release
       - name: Create release

--- a/.github/workflows/common-java-gradle-release.yml
+++ b/.github/workflows/common-java-gradle-release.yml
@@ -45,6 +45,11 @@ on:
         required: false
         type: string
         default: ''
+      staging-profile-id:
+        description: 'Sonatype staging profile id (Central Portal namespace, e.g. org.octopusden). Passed as -PstagingProfileId; consumers must read it in their nexusPublishing.sonatype block. Bypasses the OSSRH-compat auto-lookup that fails for new/uncached package groups.'
+        required: false
+        type: string
+        default: 'org.octopusden'
     secrets:
       OSSRH_USERNAME:
         required: false
@@ -243,7 +248,7 @@ jobs:
       # publish to nexus
       - name: Publish to Sonatype Nexus
         if: ${{ !inputs.dry-run }}
-        run: ./gradlew -Pnexus=true publishToSonatype closeAndReleaseSonatypeStagingRepository -PbuildVersion=${{ env.BUILD_VERSION }} -Pversion=${{ env.BUILD_VERSION }} --info -s
+        run: ./gradlew -Pnexus=true -PstagingProfileId=${{ inputs.staging-profile-id }} publishToSonatype closeAndReleaseSonatypeStagingRepository -PbuildVersion=${{ env.BUILD_VERSION }} -Pversion=${{ env.BUILD_VERSION }} --info -s
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}


### PR DESCRIPTION
## Summary

**Fixes broken releases.** Component releases fail at `:initializeSonatypeStagingRepository` with `Failed to find staging profile for package group: <group>` and never publish to Maven Central. This pins the Sonatype staging profile explicitly so publishing works again.

Affected (observed): `octopus-api-gateway`, `octopus-cve-automation`, `octopus-platform-gradle-plugin`, `octopus-test` — across different `octopus-base` refs (2.3.4 / 2.4.1), so it is **not** a version regression on our side.

## Root cause

The OSSRH-compat staging service (`ossrh-staging-api.central.sonatype.com`) has a **flaky `/staging/profiles` auto-lookup**. The org account has exactly one verified profile — `org.octopusden` (name = id, confirmed in the Central Portal and via the API). The same groups/token/command that published days earlier now intermittently get an empty profile list → the failure above. (Same instability class as #140, hitting the lookup stage.)

## Fix

Bypass the flaky auto-lookup by pinning the profile:

1. New reusable-workflow input `staging-profile-id` (default `org.octopusden`).
2. Passed to Gradle as `-PstagingProfileId` (via a quoted env var).
3. A generated Gradle **init script** (`--init-script`) binds it into the `gradle-nexus` `sonatype` repository for any project applying the plugin — so **consumers need no build-script change**. No-op when blank (auto-lookup preserved).

## Validation

Canary on `octopus-test` (`test/staging-profile-id`, fresh group, **no** consumer wiring), run against the final commit:
`Created staging repository 'org.octopusden--…'` at `:initializeSonatypeStagingRepository`, with **no** `No stagingProfileId set, querying…` line — profile bound purely by the injected init script. (The later `close/release` failure is the separate #158/#140 stage + synthetic-artifact validation, out of scope.)

Reviewed by a separate agent (no blockers; should-fixes applied: quote input, bind only the `sonatype` repo). All merge-gate checks green.

## Rollout

Consumers adopt by bumping the `common-java-gradle-release.yml` ref — **one-line change, no build.gradle edit**. Laggards on older refs (e.g. platform `@v2.3.4`) also pull intermediate changes; sequence accordingly.

## Assumptions / scope

- **Shared-account assumption:** default `org.octopusden` is correct because all consumers publish via the org's shared OSSRH account (single profile `org.octopusden`). A consumer publishing under its own account without an explicit `stagingProfileId` would override the input; consumers that already set it in their build win (init script does not clobber explicit values).
- **Out of scope (follow-ups):** publish-failure diagnostics + retry classification (dedicated diagnostics PR); #158 (`user_managed` release / manual Publish); the maven release workflow (different publish mechanism).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
