### PR TITLE
ci(release): diagnose & classify Sonatype publish failures (retry triage)

### DIFF
--- a/.github/workflows/common-java-gradle-release.yml
+++ b/.github/workflows/common-java-gradle-release.yml
@@ -348,7 +348,7 @@ jobs:
                 echo "  (no errors parsed; raw status body):"; head -c 2000 "$stf"; echo
               fi
             else
-              echo "  (no portal_deployment_id for $repo; raw search body):"; head -c 2000 "$sf"; echo
+              echo "  No Portal deployment mapped for $repo — the close/release step did not hand the repository off to the Portal (typical for compat close/release failures), so there are no Portal validation errors to inspect."
             fi
             echo "::endgroup::"
           else

--- a/.github/workflows/common-java-gradle-release.yml
+++ b/.github/workflows/common-java-gradle-release.yml
@@ -327,14 +327,18 @@ jobs:
           if [ -n "$repo" ]; then
             echo "::group::Deployment status & validation errors for $repo"
             sf="$RUNNER_TEMP/diag-search.json"
-            scode=$(curl -sS -o "$sf" -w '%{http_code}' "${auth[@]}" "$host/manual/search/repositories" 2>/dev/null)
+            scode=$(curl -sS -o "$sf" -w '%{http_code}' "${net[@]}" -H "$bearer" -H 'Accept: application/json' "$host/manual/search/repositories" 2>/dev/null)
             echo "GET /manual/search/repositories -> HTTP ${scode:-?}"
             did=$(jq -r --arg k "$repo" '.repositories[]? | select(.key==$k) | .portal_deployment_id' "$sf" 2>/dev/null | head -1)
             if [ -n "$did" ] && [ "$did" != "null" ]; then
               stf="$RUNNER_TEMP/diag-status.json"
-              pcode=$(curl -sS -o "$stf" -w '%{http_code}' "${net[@]}" -X POST -H "$bearer" -H 'Accept: application/json' "$portal/status?id=$did" 2>/dev/null)
-              echo "POST /api/v1/publisher/status?id=$did -> HTTP ${pcode:-?}"
-              echo "  deploymentState=$(jq -r '.deploymentState // "?"' "$stf" 2>/dev/null)"
+              # Poll while the deployment is still validating; .errors appear only once FAILED.
+              for i in 1 2 3 4 5; do
+                pcode=$(curl -sS -o "$stf" -w '%{http_code}' "${net[@]}" -X POST -H "$bearer" -H 'Accept: application/json' "$portal/status?id=$did" 2>/dev/null)
+                dstate=$(jq -r '.deploymentState // "?"' "$stf" 2>/dev/null)
+                echo "POST /api/v1/publisher/status?id=$did (try $i) -> HTTP ${pcode:-?}  deploymentState=${dstate}"
+                case "$dstate" in PENDING|VALIDATING|PUBLISHING) sleep 5 ;; *) break ;; esac
+              done
               errs=$(jq -r 'if (.errors|type)=="object" then (.errors|to_entries[]|"  - \(.key): \(.value|tostring)") elif (.errors|type)=="array" then (.errors[]|"  - \(.|tostring)") else empty end' "$stf" 2>/dev/null)
               if [ -n "$errs" ]; then
                 echo "  errors:"; echo "$errs"; portal_errors="$errs"

--- a/.github/workflows/common-java-gradle-release.yml
+++ b/.github/workflows/common-java-gradle-release.yml
@@ -267,14 +267,72 @@ jobs:
 
       # publish to nexus
       - name: Publish to Sonatype Nexus
+        id: publish-sonatype
         if: ${{ !inputs.dry-run }}
-        run: ./gradlew -Pnexus=true -PstagingProfileId="$STAGING_PROFILE_ID" --init-script "$RUNNER_TEMP/staging-profile.init.gradle" publishToSonatype closeAndReleaseSonatypeStagingRepository -PbuildVersion=${{ env.BUILD_VERSION }} -Pversion=${{ env.BUILD_VERSION }} --info -s
+        run: |
+          set -o pipefail
+          ./gradlew -Pnexus=true -PstagingProfileId="$STAGING_PROFILE_ID" --init-script "$RUNNER_TEMP/staging-profile.init.gradle" publishToSonatype closeAndReleaseSonatypeStagingRepository -PbuildVersion=${{ env.BUILD_VERSION }} -Pversion=${{ env.BUILD_VERSION }} --info -s 2>&1 | tee "$RUNNER_TEMP/publish.log"
         env:
           STAGING_PROFILE_ID: ${{ inputs.staging-profile-id }}
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_PRIVATE_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_PASSPHRASE }}
+
+      # On a Sonatype publish failure, surface WHY and whether a retry can help.
+      # Dumps: (1) the staging profiles the account sees (profile-lookup issues),
+      # (2) the created staging repo's state + activity events (close/release
+      # validation-rule reasons), and classifies the failure as deterministic
+      # (do not retry) vs transient (a re-dispatch may help). Emits a machine
+      # marker (RELEASE_PUBLISH_RETRYABLE + step output) so the caller/TeamCity
+      # can stop re-dispatching on deterministic failures.
+      - name: Diagnose & classify Sonatype publish failure
+        id: diagnose-sonatype
+        if: ${{ failure() && steps.publish-sonatype.outcome == 'failure' && !inputs.dry-run }}
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+        run: |
+          set +e
+          base="https://ossrh-staging-api.central.sonatype.com/service/local"
+          log="$RUNNER_TEMP/publish.log"
+          auth=(-u "${MAVEN_USERNAME}:${MAVEN_PASSWORD}" -H 'Accept: application/json')
+
+          echo "::group::Staging profiles visible to this account"
+          curl -s "${auth[@]}" "$base/staging/profiles" \
+            | (jq -r '.data[]? | "  name=\(.name)  id=\(.id)"' 2>/dev/null || cat)
+          echo "::endgroup::"
+
+          # If a staging repo was created, dump its state + activity — this is where
+          # close/release validation-rule failures are reported.
+          repo=$(grep -oE 'org\.octopusden--[0-9a-f-]+' "$log" 2>/dev/null | head -1)
+          if [ -n "$repo" ]; then
+            echo "::group::Staging repository $repo — state & activity"
+            curl -s "${auth[@]}" "$base/staging/repository/$repo" \
+              | (jq -r '"  type=\(.type)  transitioning=\(.transitioning)  notifications=\(.notifications // 0)"' 2>/dev/null || cat)
+            curl -s "${auth[@]}" "$base/staging/repository/$repo/activity" \
+              | (jq -r '.[]?.events[]? | select((.name // "")|test("fail|error|rule|broken";"i")) | "  event=\(.name) " + ([.properties[]? | "\(.name)=\(.value)"] | join(" "))' 2>/dev/null \
+                 || echo "  (could not parse activity)")
+            echo "::endgroup::"
+          else
+            echo "No staging repository id found in publish log (failure before repo creation)."
+          fi
+
+          # Classify the failure for retry decisions.
+          retryable=true; reason="unknown"
+          if grep -qiE 'Failed to find staging profile|status code 401|401 Unauthorized|Content validation failed|Invalid POM|missing .*signature|No public key|Invalid signature' "$log" 2>/dev/null; then
+            retryable=false; reason="deterministic (profile / auth / artifact validation)"
+          elif grep -qiE 'No objects found|status code 5[0-9][0-9]|timed out|Connection reset|Read timed out|not in desired state' "$log" 2>/dev/null; then
+            retryable=true; reason="transient (OSSRH-compat instability)"
+          fi
+          echo "RELEASE_PUBLISH_FAILURE_CLASS=${reason}"
+          echo "RELEASE_PUBLISH_RETRYABLE=${retryable}"
+          echo "retryable=${retryable}" >> "$GITHUB_OUTPUT"
+          if [ "$retryable" = "false" ]; then
+            echo "::error title=Deterministic publish failure::${reason} — retrying will NOT help. Fix config/credentials/artifact; do not re-dispatch."
+          else
+            echo "::warning title=Transient publish failure::${reason} — a re-dispatch may succeed."
+          fi
 
       # github release
       - name: Create release

--- a/.github/workflows/common-java-gradle-release.yml
+++ b/.github/workflows/common-java-gradle-release.yml
@@ -279,15 +279,17 @@ jobs:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_PRIVATE_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_PASSPHRASE }}
 
-      # On a Sonatype publish failure, surface WHY and whether a retry can help.
-      # Dumps: (1) the staging profiles the account sees (profile-lookup issues),
-      # (2) the created staging repo's state + activity events (close/release
-      # validation-rule reasons), and classifies the failure as deterministic
-      # (do not retry) vs transient (a re-dispatch may help). Emits a machine
-      # marker (RELEASE_PUBLISH_RETRYABLE + step output) so the caller/TeamCity
-      # can stop re-dispatching on deterministic failures.
+      # On a Sonatype publish failure, surface WHY (and whether a retry can help):
+      #  (1) HTTP status + body of the account's staging profiles,
+      #  (2) the created staging repo's state + activity (close/release validation
+      #      reasons), printing the raw body when the response can't be parsed,
+      #  (3) a classification — deterministic (do not retry) / transient (re-dispatch
+      #      may help) / unknown — emitted as log markers RELEASE_PUBLISH_CLASS and
+      #      RELEASE_PUBLISH_RETRYABLE for the caller/TeamCity to scrape. (Reusable-
+      #      workflow step outputs are unreliable on failed runs, so we use log
+      #      markers, not a step output.) Classification reads only the Gradle
+      #      failure section to avoid false matches from --info chatter.
       - name: Diagnose & classify Sonatype publish failure
-        id: diagnose-sonatype
         if: ${{ failure() && steps.publish-sonatype.outcome == 'failure' && !inputs.dry-run }}
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
@@ -298,41 +300,49 @@ jobs:
           log="$RUNNER_TEMP/publish.log"
           auth=(-u "${MAVEN_USERNAME}:${MAVEN_PASSWORD}" -H 'Accept: application/json')
 
+          # Helper: GET into a file, print HTTP status, then jq; on empty/parse
+          # failure print the raw body so 401/non-JSON responses are visible.
+          dump() { # $1=label $2=url $3=jq-filter
+            local f; f="$RUNNER_TEMP/diag-$(echo "$1" | tr -c 'a-zA-Z0-9' _).json"
+            local code; code=$(curl -sS -o "$f" -w '%{http_code}' "${auth[@]}" "$2" 2>/dev/null)
+            echo "GET $2 -> HTTP ${code:-?}"
+            local out; out=$(jq -r "$3" "$f" 2>/dev/null)
+            if [ -n "$out" ]; then echo "$out"; else echo "  (unparsed body):"; head -c 2000 "$f"; echo; fi
+          }
+
           echo "::group::Staging profiles visible to this account"
-          curl -s "${auth[@]}" "$base/staging/profiles" \
-            | (jq -r '.data[]? | "  name=\(.name)  id=\(.id)"' 2>/dev/null || cat)
+          dump "profiles" "$base/staging/profiles" '.data[]? | "  name=\(.name)  id=\(.id)"'
           echo "::endgroup::"
 
-          # If a staging repo was created, dump its state + activity — this is where
-          # close/release validation-rule failures are reported.
-          repo=$(grep -oE 'org\.octopusden--[0-9a-f-]+' "$log" 2>/dev/null | head -1)
+          # Extract the staging repo id from the authoritative "Created staging
+          # repository '<id>'" log line — namespace-agnostic (honours staging-profile-id).
+          repo=$(grep -oE "Created staging repository '[^']+'" "$log" 2>/dev/null | head -1 | sed -E "s/^.*'([^']+)'.*$/\1/")
           if [ -n "$repo" ]; then
-            echo "::group::Staging repository $repo — state & activity"
-            curl -s "${auth[@]}" "$base/staging/repository/$repo" \
-              | (jq -r '"  type=\(.type)  transitioning=\(.transitioning)  notifications=\(.notifications // 0)"' 2>/dev/null || cat)
-            curl -s "${auth[@]}" "$base/staging/repository/$repo/activity" \
-              | (jq -r '.[]?.events[]? | select((.name // "")|test("fail|error|rule|broken";"i")) | "  event=\(.name) " + ([.properties[]? | "\(.name)=\(.value)"] | join(" "))' 2>/dev/null \
-                 || echo "  (could not parse activity)")
+            echo "::group::Staging repository $repo — state & activity (close/release validation)"
+            dump "repo-state" "$base/staging/repository/$repo" '"  type=\(.type)  transitioning=\(.transitioning)  notifications=\(.notifications // 0)"'
+            dump "repo-activity" "$base/staging/repository/$repo/activity" '.[]?.events[]? | select((.name // "")|test("fail|broken|error";"i")) | "  event=\(.name) " + ([.properties[]? | "\(.name)=\(.value)"] | join(" "))'
             echo "::endgroup::"
           else
-            echo "No staging repository id found in publish log (failure before repo creation)."
+            echo "No staging repository was created (failure before repo creation)."
           fi
 
-          # Classify the failure for retry decisions.
-          retryable=true; reason="unknown"
-          if grep -qiE 'Failed to find staging profile|status code 401|401 Unauthorized|Content validation failed|Invalid POM|missing .*signature|No public key|Invalid signature' "$log" 2>/dev/null; then
-            retryable=false; reason="deterministic (profile / auth / artifact validation)"
-          elif grep -qiE 'No objects found|status code 5[0-9][0-9]|timed out|Connection reset|Read timed out|not in desired state' "$log" 2>/dev/null; then
-            retryable=true; reason="transient (OSSRH-compat instability)"
+          # Classify using ONLY the Gradle failure section (after "FAILURE: Build failed"),
+          # falling back to the log tail, to avoid false matches from --info chatter.
+          sec=$(awk '/FAILURE: Build failed/{f=1} f{print}' "$log" 2>/dev/null)
+          [ -z "$sec" ] && sec=$(tail -n 400 "$log" 2>/dev/null)
+          cls="unknown"; retryable="unknown"
+          if printf '%s' "$sec" | grep -qiE 'responded with status code 40[13]|401 Unauthorized|403 Forbidden|Content validation failed|Invalid POM|No public key|invalid signature|missing .*signature'; then
+            cls="deterministic"; retryable="false"
+          elif printf '%s' "$sec" | grep -qiE 'Failed to find staging profile|Failed to (close|release) staging repository|No objects found|responded with status code 400|responded with status code 5[0-9][0-9]|timed out|Connection reset|Read timed out|not in desired state'; then
+            cls="transient"; retryable="true"
           fi
-          echo "RELEASE_PUBLISH_FAILURE_CLASS=${reason}"
+          echo "RELEASE_PUBLISH_CLASS=${cls}"
           echo "RELEASE_PUBLISH_RETRYABLE=${retryable}"
-          echo "retryable=${retryable}" >> "$GITHUB_OUTPUT"
-          if [ "$retryable" = "false" ]; then
-            echo "::error title=Deterministic publish failure::${reason} — retrying will NOT help. Fix config/credentials/artifact; do not re-dispatch."
-          else
-            echo "::warning title=Transient publish failure::${reason} — a re-dispatch may succeed."
-          fi
+          case "$cls" in
+            deterministic) echo "::error title=Deterministic publish failure::Auth / permissions / artifact validation — retrying will NOT help. Fix config/credentials/artifact; do not re-dispatch." ;;
+            transient)     echo "::warning title=Transient publish failure::OSSRH-compat instability — a re-dispatch may succeed." ;;
+            *)             echo "::warning title=Unclassified publish failure::Could not classify from the failure section — inspect the log and staging activity above before deciding whether to re-dispatch." ;;
+          esac
 
       # github release
       - name: Create release

--- a/.github/workflows/common-java-gradle-release.yml
+++ b/.github/workflows/common-java-gradle-release.yml
@@ -329,7 +329,9 @@ jobs:
             sf="$RUNNER_TEMP/diag-search.json"
             scode=$(curl -sS -o "$sf" -w '%{http_code}' "${net[@]}" -H "$bearer" -H 'Accept: application/json' "$host/manual/search/repositories" 2>/dev/null)
             echo "GET /manual/search/repositories -> HTTP ${scode:-?}"
-            did=$(jq -r --arg k "$repo" '.repositories[]? | select(.key==$k) | .portal_deployment_id' "$sf" 2>/dev/null | head -1)
+            # The search 'key' is prefixed (e.g. "<user>/any/org.octopusden--<uuid>"),
+            # so match on the repo id as a suffix rather than exact equality.
+            did=$(jq -r --arg k "$repo" '.repositories[]? | select(.key | endswith($k)) | .portal_deployment_id' "$sf" 2>/dev/null | head -1)
             if [ -n "$did" ] && [ "$did" != "null" ]; then
               stf="$RUNNER_TEMP/diag-status.json"
               # Poll while the deployment is still validating; .errors appear only once FAILED.

--- a/.github/workflows/common-java-gradle-release.yml
+++ b/.github/workflows/common-java-gradle-release.yml
@@ -280,14 +280,17 @@ jobs:
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_PASSPHRASE }}
 
       # On a Sonatype publish failure, surface WHY (and whether a retry can help):
-      #  (1) HTTP status + body of the account's staging profiles,
-      #  (2) the created staging repo's state + activity (close/release validation
-      #      reasons), printing the raw body when the response can't be parsed,
-      #  (3) a classification — deterministic (do not retry) / transient (re-dispatch
-      #      may help) / unknown — emitted as log markers RELEASE_PUBLISH_CLASS and
-      #      RELEASE_PUBLISH_RETRYABLE for the caller/TeamCity to scrape. (Reusable-
-      #      workflow step outputs are unreliable on failed runs, so we use log
-      #      markers, not a step output.) Classification reads only the Gradle
+      #  (1) HTTP status + body of the account's staging profiles;
+      #  (2) the deployment's validation errors via the SUPPORTED path
+      #      (/manual/search/repositories -> portal_deployment_id -> Portal
+      #      /api/v1/publisher/status .errors); the compat /activity endpoint is
+      #      unsupported (HTTP 400) so it is not used;
+      #  (3) an evidence-based classification emitted as log markers
+      #      RELEASE_PUBLISH_CLASS / RELEASE_PUBLISH_RETRYABLE for the caller /
+      #      TeamCity to scrape (reusable-workflow step outputs are unreliable on
+      #      failed runs). retryable=true is asserted ONLY on unambiguous infra
+      #      signals (5xx / timeout / reset); Portal validation errors are
+      #      deterministic; everything else stays 'unknown'. Reads only the Gradle
       #      failure section to avoid false matches from --info chatter.
       - name: Diagnose & classify Sonatype publish failure
         if: ${{ failure() && steps.publish-sonatype.outcome == 'failure' && !inputs.dry-run }}
@@ -296,13 +299,15 @@ jobs:
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
         run: |
           set +e
-          base="https://ossrh-staging-api.central.sonatype.com/service/local"
+          compat="https://ossrh-staging-api.central.sonatype.com/service/local"
+          portal="https://central.sonatype.com/api/v1/publisher"
           log="$RUNNER_TEMP/publish.log"
-          auth=(-u "${MAVEN_USERNAME}:${MAVEN_PASSWORD}" -H 'Accept: application/json')
+          net=(--connect-timeout 15 --max-time 60)
+          auth=("${net[@]}" -u "${MAVEN_USERNAME}:${MAVEN_PASSWORD}" -H 'Accept: application/json')
+          bearer="Authorization: Bearer $(printf '%s:%s' "${MAVEN_USERNAME}" "${MAVEN_PASSWORD}" | base64 | tr -d '\n')"
 
-          # Helper: GET into a file, print HTTP status, then jq; on empty/parse
-          # failure print the raw body so 401/non-JSON responses are visible.
-          dump() { # $1=label $2=url $3=jq-filter
+          # GET (basic auth) into a file, print HTTP status, jq; raw body on parse-fail.
+          dump() { # label url jq-filter
             local f; f="$RUNNER_TEMP/diag-$(echo "$1" | tr -c 'a-zA-Z0-9' _).json"
             local code; code=$(curl -sS -o "$f" -w '%{http_code}' "${auth[@]}" "$2" 2>/dev/null)
             echo "GET $2 -> HTTP ${code:-?}"
@@ -311,37 +316,55 @@ jobs:
           }
 
           echo "::group::Staging profiles visible to this account"
-          dump "profiles" "$base/staging/profiles" '.data[]? | "  name=\(.name)  id=\(.id)"'
+          dump "profiles" "$compat/staging/profiles" '.data[]? | "  name=\(.name)  id=\(.id)"'
           echo "::endgroup::"
 
-          # Extract the staging repo id from the authoritative "Created staging
-          # repository '<id>'" log line — namespace-agnostic (honours staging-profile-id).
+          # Validation reason: the compat /activity endpoint is unsupported (HTTP 400),
+          # so map the staging repo -> Portal deployment and read its .errors.
+          portal_errors=""
           repo=$(grep -oE "Created staging repository '[^']+'" "$log" 2>/dev/null | head -1 | sed -E "s/^.*'([^']+)'.*$/\1/")
           if [ -n "$repo" ]; then
-            echo "::group::Staging repository $repo — state & activity (close/release validation)"
-            dump "repo-state" "$base/staging/repository/$repo" '"  type=\(.type)  transitioning=\(.transitioning)  notifications=\(.notifications // 0)"'
-            dump "repo-activity" "$base/staging/repository/$repo/activity" '.[]?.events[]? | select((.name // "")|test("fail|broken|error";"i")) | "  event=\(.name) " + ([.properties[]? | "\(.name)=\(.value)"] | join(" "))'
+            echo "::group::Deployment status & validation errors for $repo"
+            sf="$RUNNER_TEMP/diag-search.json"
+            scode=$(curl -sS -o "$sf" -w '%{http_code}' "${auth[@]}" "$compat/manual/search/repositories" 2>/dev/null)
+            echo "GET /manual/search/repositories -> HTTP ${scode:-?}"
+            did=$(jq -r --arg k "$repo" '.repositories[]? | select(.key==$k) | .portal_deployment_id' "$sf" 2>/dev/null | head -1)
+            if [ -n "$did" ] && [ "$did" != "null" ]; then
+              stf="$RUNNER_TEMP/diag-status.json"
+              pcode=$(curl -sS -o "$stf" -w '%{http_code}' "${net[@]}" -X POST -H "$bearer" -H 'Accept: application/json' "$portal/status?id=$did" 2>/dev/null)
+              echo "POST /api/v1/publisher/status?id=$did -> HTTP ${pcode:-?}"
+              echo "  deploymentState=$(jq -r '.deploymentState // "?"' "$stf" 2>/dev/null)"
+              errs=$(jq -r 'if (.errors|type)=="object" then (.errors|to_entries[]|"  - \(.key): \(.value|tostring)") elif (.errors|type)=="array" then (.errors[]|"  - \(.|tostring)") else empty end' "$stf" 2>/dev/null)
+              if [ -n "$errs" ]; then
+                echo "  errors:"; echo "$errs"; portal_errors="$errs"
+              else
+                echo "  (no errors parsed; raw status body):"; head -c 2000 "$stf"; echo
+              fi
+            else
+              echo "  (no portal_deployment_id for $repo; raw search body):"; head -c 2000 "$sf"; echo
+            fi
             echo "::endgroup::"
           else
             echo "No staging repository was created (failure before repo creation)."
           fi
 
-          # Classify using ONLY the Gradle failure section (after "FAILURE: Build failed"),
-          # falling back to the log tail, to avoid false matches from --info chatter.
+          # Classify. Deterministic = Portal reported validation errors, or an explicit
+          # auth failure. Transient = ONLY unambiguous infra signals. Everything else is
+          # unknown (do NOT assert a retry will help). Reads only the Gradle failure section.
           sec=$(awk '/FAILURE: Build failed/{f=1} f{print}' "$log" 2>/dev/null)
           [ -z "$sec" ] && sec=$(tail -n 400 "$log" 2>/dev/null)
           cls="unknown"; retryable="unknown"
-          if printf '%s' "$sec" | grep -qiE 'responded with status code 40[13]|401 Unauthorized|403 Forbidden|Content validation failed|Invalid POM|No public key|invalid signature|missing .*signature'; then
+          if [ -n "$portal_errors" ] || printf '%s' "$sec" | grep -qiE 'responded with status code 40[13]|401 Unauthorized|403 Forbidden'; then
             cls="deterministic"; retryable="false"
-          elif printf '%s' "$sec" | grep -qiE 'Failed to find staging profile|Failed to (close|release) staging repository|No objects found|responded with status code 400|responded with status code 5[0-9][0-9]|timed out|Connection reset|Read timed out|not in desired state'; then
+          elif printf '%s' "$sec" | grep -qiE 'responded with status code 5[0-9][0-9]|status code 5[0-9][0-9]|timed out|Read timed out|Connection reset|Connection refused'; then
             cls="transient"; retryable="true"
           fi
           echo "RELEASE_PUBLISH_CLASS=${cls}"
           echo "RELEASE_PUBLISH_RETRYABLE=${retryable}"
           case "$cls" in
-            deterministic) echo "::error title=Deterministic publish failure::Auth / permissions / artifact validation — retrying will NOT help. Fix config/credentials/artifact; do not re-dispatch." ;;
-            transient)     echo "::warning title=Transient publish failure::OSSRH-compat instability — a re-dispatch may succeed." ;;
-            *)             echo "::warning title=Unclassified publish failure::Could not classify from the failure section — inspect the log and staging activity above before deciding whether to re-dispatch." ;;
+            deterministic) echo "::error title=Deterministic publish failure::Validation / auth error (see deployment errors above) — retrying will NOT help. Fix the artifact/credentials; do not re-dispatch." ;;
+            transient)     echo "::warning title=Transient publish failure::Infrastructure instability (5xx/timeout) — a re-dispatch may succeed." ;;
+            *)             echo "::warning title=Unclassified publish failure::Could not classify — inspect the deployment errors and log above; there is no evidence a retry will help." ;;
           esac
 
       # github release

--- a/.github/workflows/common-java-gradle-release.yml
+++ b/.github/workflows/common-java-gradle-release.yml
@@ -299,7 +299,8 @@ jobs:
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
         run: |
           set +e
-          compat="https://ossrh-staging-api.central.sonatype.com/service/local"
+          host="https://ossrh-staging-api.central.sonatype.com"
+          compat="$host/service/local"
           portal="https://central.sonatype.com/api/v1/publisher"
           log="$RUNNER_TEMP/publish.log"
           net=(--connect-timeout 15 --max-time 60)
@@ -326,7 +327,7 @@ jobs:
           if [ -n "$repo" ]; then
             echo "::group::Deployment status & validation errors for $repo"
             sf="$RUNNER_TEMP/diag-search.json"
-            scode=$(curl -sS -o "$sf" -w '%{http_code}' "${auth[@]}" "$compat/manual/search/repositories" 2>/dev/null)
+            scode=$(curl -sS -o "$sf" -w '%{http_code}' "${auth[@]}" "$host/manual/search/repositories" 2>/dev/null)
             echo "GET /manual/search/repositories -> HTTP ${scode:-?}"
             did=$(jq -r --arg k "$repo" '.repositories[]? | select(.key==$k) | .portal_deployment_id' "$sf" 2>/dev/null | head -1)
             if [ -n "$did" ] && [ "$did" != "null" ]; then


### PR DESCRIPTION
**Merge after #160** (stacked on `fix/staging-profile-id`; retarget to `main` once #160 merges). Follow-up that makes Sonatype publish failures diagnosable and correctly classified.

## What it adds (on publish-step failure only, not dry-run)

A `Diagnose & classify Sonatype publish failure` step:
1. **Profiles** — dumps `/staging/profiles` with HTTP status (401/empty visible).
2. **Validation reason** — the compat `/activity` endpoint is unsupported (HTTP 400), so it uses the supported path: `/manual/search/repositories` (**Bearer** auth, host root) → `portal_deployment_id` (matched by key suffix, namespace-agnostic) → `POST /api/v1/publisher/status?id=…` (polled while `PENDING`/`VALIDATING`/`PUBLISHING`) → `.errors` + `deploymentState`.
3. **Classification** (emitted as log markers `RELEASE_PUBLISH_CLASS` / `RELEASE_PUBLISH_RETRYABLE` — reusable-workflow step outputs are unreliable on failed runs):
   - **deterministic** (retryable=false) — Portal reported validation `errors`, or an explicit `401/403`;
   - **transient** (retryable=true) — **only** unambiguous infra signals (`5xx` / timeout / connection reset);
   - **unknown** (retryable=unknown) — everything else (close/release `400`, `not in desired state`, `No objects found`, profile-not-found). Not asserted retryable, because the same messages also occur on deterministic validation-rule violations and we don't guess without Portal `errors`.

## Robustness
- All diagnostic HTTP calls use `--connect-timeout`/`--max-time` (can't hang during the instability it diagnoses).
- Every call prints HTTP status and falls back to the raw body on parse failure.
- Publish log captured via `tee` under `set -o pipefail` (exit code preserved); classification reads only the Gradle failure section (after `FAILURE: Build failed`) to avoid false matches from `--info` chatter.
- Clear message when a repo has no Portal deployment (close/release didn't hand off — nothing to inspect).

## Validation
- Classifier unit-tested against synthetic logs (close-400 ±Portal errors, 5xx, 401/403, timeout, profile-not-found, not-in-desired-state, scoped-401).
- Exercised on the `octopus-test` canary against live Sonatype: `/staging/profiles` 200, `/manual/search` 200 (Bearer, host root), key-suffix match; close-400 honestly classified `unknown`. The deterministic (Portal `errors`) path is validated by unit tests + the documented API shape (a live validation failure can't be forced on the canary).

## Out of scope / follow-ups
- TeamCity-side release polling (`CallGitHubRelease.main.kts`) → #162.
- Central publishing limits → #163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
