### PR TITLE
ci(teamcity): civilize release polling — watch the run, fail fast, report problem

### DIFF
--- a/.github/workflows/kts-compile-check.yml
+++ b/.github/workflows/kts-compile-check.yml
@@ -1,0 +1,58 @@
+name: KTS Compile Check
+
+# Compiles the TeamCity Kotlin scripts on the exact toolchain they run on
+# (kotlin-compiler 1.5.32), so a compile error (e.g. a .main.kts-only smart-cast
+# failure) is caught in CI instead of at release time on the TeamCity agent.
+on:
+  pull_request:
+    paths:
+      - 'teamcity/scripts/**.main.kts'
+      - '.github/workflows/kts-compile-check.yml'
+  workflow_dispatch: {}
+
+jobs:
+  compile-kts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '11'
+
+      - name: Install Kotlin compiler 1.5.32
+        run: |
+          set -euo pipefail
+          curl -sSL -o /tmp/kotlin.zip \
+            https://github.com/JetBrains/kotlin/releases/download/v1.5.32/kotlin-compiler-1.5.32.zip
+          unzip -q /tmp/kotlin.zip -d "$HOME"
+
+      - name: Compile teamcity/scripts/*.main.kts
+        run: |
+          set -uo pipefail
+          KOTLINC="$HOME/kotlinc/bin/kotlinc"
+          MAIN_KTS_JAR="$HOME/kotlinc/lib/kotlin-main-kts.jar"
+          shopt -s nullglob
+          scripts=(teamcity/scripts/*.main.kts)
+          if [ ${#scripts[@]} -eq 0 ]; then
+            echo "No teamcity/scripts/*.main.kts found; nothing to check."
+            exit 0
+          fi
+          rc=0
+          for s in "${scripts[@]}"; do
+            echo "::group::compile $s"
+            # kotlinc compiles the whole script before running; with no arguments
+            # the script's own argument guard exits before any side effect, so this
+            # is a safe compile check. We fail only on a compiler 'error:' line.
+            out="$("$KOTLINC" -cp "$MAIN_KTS_JAR" -script "$s" 2>&1 || true)"
+            echo "$out"
+            echo "::endgroup::"
+            if printf '%s\n' "$out" | grep -q "error:"; then
+              echo "::error file=$s::Kotlin compile error in $s"
+              rc=1
+            else
+              echo "OK: $s compiles"
+            fi
+          done
+          exit $rc

--- a/teamcity/scripts/CallGitHubRelease.main.kts
+++ b/teamcity/scripts/CallGitHubRelease.main.kts
@@ -63,9 +63,18 @@ fun listDispatchRunIds(): Pair<Boolean, Set<Long>> {
 }
 
 // Snapshot existing runs BEFORE dispatching so we only ever lock onto a NEW run
-// afterwards — never a prior release's (possibly failed) run.
-val (preOk, preExisting) = listDispatchRunIds()
-if (!preOk) println("Warning: could not snapshot existing runs before dispatch; new-run detection is best-effort.")
+// afterwards — never a prior release's (possibly failed) run. A reliable baseline is
+// mandatory: retry, and ABORT BEFORE dispatch if it can't be obtained (dispatching
+// blind could make us mistake a historical run for this release).
+var preExistingTmp: Set<Long>? = null
+for (i in 1..3) {
+    val (ok, ids) = listDispatchRunIds()
+    if (ok) { preExistingTmp = ids; break }
+    println("Could not snapshot existing runs (attempt $i/3); retrying...")
+    TimeUnit.SECONDS.sleep(5L)
+}
+val preExisting: Set<Long> = preExistingTmp
+    ?: fail("Could not snapshot existing workflow runs before dispatching (GitHub API unavailable). Aborting before dispatch to avoid mis-tracking a prior run; please retry the release.")
 
 // 1) Trigger the release. Build the body with org.json so special characters in
 //    the arguments can't break the JSON.
@@ -135,13 +144,22 @@ while (true) {
     if (status == "completed") {
         if (conclusion == "success") {
             println("Release run succeeded: $runUrl")
-            // Belt-and-braces: confirm the expected release tag actually exists.
-            val tag = get("$api/releases/tags/v$versionToRelease", headers = ghHeaders)
-            if (tag.statusCode / 100 == 2) {
-                println("Release tag v$versionToRelease is present.")
-                System.exit(0)
+            // Belt-and-braces: confirm the release tag exists, retrying within the
+            // remaining time budget so one transient tag GET (404 propagation delay /
+            // 5xx) doesn't turn a real success into a false failure.
+            while (true) {
+                val tag = get("$api/releases/tags/v$versionToRelease", headers = ghHeaders)
+                if (tag.statusCode / 100 == 2) {
+                    println("Release tag v$versionToRelease is present.")
+                    System.exit(0)
+                }
+                attempt++
+                if (attempt > timeoutMinutes) {
+                    fail("Release run for $repo succeeded but release tag v$versionToRelease was not confirmed within the timeout (last HTTP ${tag.statusCode}). See $runUrl")
+                }
+                println("Tag v$versionToRelease not confirmed yet (HTTP ${tag.statusCode}); retrying...")
+                TimeUnit.MINUTES.sleep(1L)
             }
-            fail("Release run for $repo succeeded but release tag v$versionToRelease was not found (HTTP ${tag.statusCode}). See $runUrl")
         } else {
             fail(
                 "Release run for $repo $versionToRelease concluded '$conclusion'. See $runUrl " +

--- a/teamcity/scripts/CallGitHubRelease.main.kts
+++ b/teamcity/scripts/CallGitHubRelease.main.kts
@@ -47,6 +47,22 @@ fun fail(description: String): Nothing {
     throw IllegalStateException() // unreachable; satisfies Nothing
 }
 
+// List current repository_dispatch run IDs. Returns (ok, ids): ok=false means the
+// listing call itself failed (so the snapshot is unreliable).
+fun listDispatchRunIds(): Pair<Boolean, Set<Long>> {
+    val resp = get("$api/actions/runs?event=repository_dispatch&per_page=50", headers = ghHeaders)
+    if (resp.statusCode / 100 != 2) return Pair(false, emptySet())
+    val arr = resp.jsonObject.optJSONArray("workflow_runs") ?: return Pair(true, emptySet())
+    val ids = HashSet<Long>()
+    for (i in 0 until arr.length()) ids.add(arr.getJSONObject(i).getLong("id"))
+    return Pair(true, ids)
+}
+
+// Snapshot existing runs BEFORE dispatching so we only ever lock onto a NEW run
+// afterwards — never a prior release's (possibly failed) run.
+val (preOk, preExisting) = listDispatchRunIds()
+if (!preOk) println("Warning: could not snapshot existing runs before dispatch; new-run detection is best-effort.")
+
 // 1) Trigger the release.
 val respCreate = post(
     "$api/dispatches",
@@ -56,40 +72,54 @@ val respCreate = post(
 if (respCreate.statusCode / 100 != 2) {
     fail("Failed to trigger release dispatch for $repo (HTTP ${respCreate.statusCode}): ${respCreate.text}")
 }
-println("Release dispatched for $repo version $versionToRelease. Watching the workflow run...")
+println("Release dispatched for $repo version $versionToRelease. Watching for the new workflow run...")
 
-// 2) Watch the triggered workflow run: lock onto the newest repository_dispatch
-//    run (releases are serial), then poll its conclusion. Fail fast on failure.
+// 2) Watch the run triggered by THIS dispatch: pick the newest repository_dispatch
+//    run whose id was not present before the dispatch, then poll its conclusion and
+//    fail fast on failure. (repository_dispatch client_payload is not exposed in the
+//    runs API, so a "new id not seen before" match is used; concurrent dispatches of
+//    the same repo are not disambiguated — releases are expected to be serial.)
 var runId: Long? = null
 var runUrl: String? = null
 var attempt = 0
 while (true) {
     attempt++
     if (attempt > timeoutMinutes) {
-        val seen = runUrl?.let { " Last observed run: $it" } ?: " No matching run was observed."
+        val seen = runUrl?.let { " Last observed run: $it" } ?: " No new workflow run appeared."
         fail("Release for $repo $versionToRelease did not complete within $timeoutMinutes minute(s).$seen")
     }
     TimeUnit.MINUTES.sleep(1L)
 
     if (runId == null) {
-        val runs = get("$api/actions/runs?event=repository_dispatch&per_page=10", headers = ghHeaders)
-        if (runs.statusCode / 100 == 2) {
-            val arr = runs.jsonObject.optJSONArray("workflow_runs")
-            if (arr != null && arr.length() > 0) {
-                val chosen = arr.getJSONObject(0) // newest first
-                runId = chosen.getLong("id")
-                runUrl = chosen.optString("html_url")
-                println("Watching run: $runUrl")
-            } else {
-                println("Attempt $attempt: no repository_dispatch run visible yet...")
-            }
-        } else {
+        val runs = get("$api/actions/runs?event=repository_dispatch&per_page=50", headers = ghHeaders)
+        if (runs.statusCode / 100 != 2) {
             println("Attempt $attempt: could not list runs (HTTP ${runs.statusCode}); retrying...")
+            continue
         }
+        val arr = runs.jsonObject.optJSONArray("workflow_runs")
+        var chosen: JSONObject? = null
+        if (arr != null) {
+            for (i in 0 until arr.length()) { // newest first
+                val r = arr.getJSONObject(i)
+                if (!preExisting.contains(r.getLong("id"))) { chosen = r; break }
+            }
+        }
+        if (chosen == null) {
+            println("Attempt $attempt: new release run not visible yet...")
+            continue
+        }
+        runId = chosen.getLong("id")
+        runUrl = chosen.optString("html_url")
+        println("Watching new run: $runUrl")
         continue
     }
 
-    val run: JSONObject = get("$api/actions/runs/$runId", headers = ghHeaders).jsonObject
+    val runResp = get("$api/actions/runs/$runId", headers = ghHeaders)
+    if (runResp.statusCode / 100 != 2) {
+        println("Attempt $attempt: could not read run $runId (HTTP ${runResp.statusCode}); retrying...")
+        continue
+    }
+    val run: JSONObject = runResp.jsonObject
     val status = run.optString("status")
     val conclusion = run.optString("conclusion")
     println("Attempt $attempt: run status=$status conclusion=$conclusion")

--- a/teamcity/scripts/CallGitHubRelease.main.kts
+++ b/teamcity/scripts/CallGitHubRelease.main.kts
@@ -2,8 +2,15 @@
 
 import khttp.get
 import khttp.post
+import org.json.JSONObject
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.TimeoutException
+
+// Triggers a GitHub release (repository_dispatch) and watches the resulting
+// workflow run. Fails FAST with an actionable TeamCity build problem when the
+// run concludes in failure — instead of blindly polling the release tag until a
+// bare timeout — and links to the run, where the reusable workflow's
+// "Diagnose & classify" step reports the cause and RELEASE_PUBLISH_RETRYABLE.
+// Arguments are unchanged for backward compatibility.
 
 if (args.size != 6) {
     System.err.println("Arguments: octopusModule githubToken currentCommit versionToRelease timeoutInMinutes eventType")
@@ -14,27 +21,87 @@ val octopusModule = args[0]
 val githubToken = args[1]
 val currentCommit = args[2]
 val versionToRelease = args[3]
-val timeoutMinutes = args[4]
+val timeoutMinutes = Integer.valueOf(args[4])
 val eventType = args[5]
 
-val respCreate = post("https://api.github.com/repos/octopusden/$octopusModule/dispatches", mapOf("Authorization" to "Bearer $githubToken"), emptyMap(), """{
-        "event_type": "$eventType",
-        "client_payload": {
-        "commit": "$currentCommit",
-        "project_version": "$versionToRelease"
-    }""")
-if (respCreate.statusCode / 100 != 2) {
-    throw Exception(respCreate.text)
+val repo = "octopusden/$octopusModule"
+val api = "https://api.github.com/repos/$repo"
+val ghHeaders = mapOf(
+    "Authorization" to "Bearer $githubToken",
+    "Accept" to "application/vnd.github+json"
+)
+
+// Emit a TeamCity build problem (escaped per TeamCity service-message rules).
+fun buildProblem(description: String) {
+    val escaped = description
+        .replace("|", "||").replace("'", "|'")
+        .replace("\n", "|n").replace("\r", "|r")
+        .replace("[", "|[").replace("]", "|]")
+    println("##teamcity[buildProblem description='$escaped' identity='github-release']")
 }
-println("Waiting for release to complete...")
-var attempt = 1
-var limit = Integer.valueOf(timeoutMinutes)
-do {
-    println("Attempt: " + attempt)
-    if (attempt > limit) {
-        throw TimeoutException("Number of attempts exceeded($attempt)")
+
+fun fail(description: String): Nothing {
+    buildProblem(description)
+    System.err.println(description)
+    System.exit(3)
+    throw IllegalStateException() // unreachable; satisfies Nothing
+}
+
+// 1) Trigger the release.
+val respCreate = post(
+    "$api/dispatches",
+    headers = ghHeaders,
+    data = """{"event_type":"$eventType","client_payload":{"commit":"$currentCommit","project_version":"$versionToRelease"}}"""
+)
+if (respCreate.statusCode / 100 != 2) {
+    fail("Failed to trigger release dispatch for $repo (HTTP ${respCreate.statusCode}): ${respCreate.text}")
+}
+println("Release dispatched for $repo version $versionToRelease. Watching the workflow run...")
+
+// 2) Watch the triggered workflow run: lock onto the newest repository_dispatch
+//    run (releases are serial), then poll its conclusion. Fail fast on failure.
+var runId: Long? = null
+var runUrl: String? = null
+var attempt = 0
+while (true) {
+    attempt++
+    if (attempt > timeoutMinutes) {
+        val seen = runUrl?.let { " Last observed run: $it" } ?: " No matching run was observed."
+        fail("Release for $repo $versionToRelease did not complete within $timeoutMinutes minute(s).$seen")
     }
     TimeUnit.MINUTES.sleep(1L)
-    val respCheck = get(url = "https://api.github.com/repos/octopusden/$octopusModule/releases/tags/v$versionToRelease")
-    attempt++
-} while (respCheck.statusCode / 100 != 2)
+
+    if (runId == null) {
+        val runs = get("$api/actions/runs?event=repository_dispatch&per_page=10", headers = ghHeaders)
+        if (runs.statusCode / 100 == 2) {
+            val arr = runs.jsonObject.optJSONArray("workflow_runs")
+            if (arr != null && arr.length() > 0) {
+                val chosen = arr.getJSONObject(0) // newest first
+                runId = chosen.getLong("id")
+                runUrl = chosen.optString("html_url")
+                println("Watching run: $runUrl")
+            } else {
+                println("Attempt $attempt: no repository_dispatch run visible yet...")
+            }
+        } else {
+            println("Attempt $attempt: could not list runs (HTTP ${runs.statusCode}); retrying...")
+        }
+        continue
+    }
+
+    val run: JSONObject = get("$api/actions/runs/$runId", headers = ghHeaders).jsonObject
+    val status = run.optString("status")
+    val conclusion = run.optString("conclusion")
+    println("Attempt $attempt: run status=$status conclusion=$conclusion")
+    if (status == "completed") {
+        if (conclusion == "success") {
+            println("Release run succeeded: $runUrl")
+            System.exit(0)
+        }
+        fail(
+            "Release run for $repo $versionToRelease concluded '$conclusion'. See $runUrl " +
+            "(open the 'Diagnose & classify Sonatype publish failure' step for the cause and " +
+            "RELEASE_PUBLISH_RETRYABLE: deterministic => do not re-dispatch; transient => a re-dispatch may help)."
+        )
+    }
+}

--- a/teamcity/scripts/CallGitHubRelease.main.kts
+++ b/teamcity/scripts/CallGitHubRelease.main.kts
@@ -126,8 +126,11 @@ while (true) {
             println("Attempt $attempt: new release run not visible yet...")
             continue
         }
-        runId = chosen.getLong("id")
-        runUrl = chosen.optString("html_url")
+        // !! is safe: the null-check above `continue`s when chosen is null. A plain
+        // smart-cast doesn't compile here — in a .main.kts the script body is a
+        // closure, so the captured `var chosen` cannot be smart-cast.
+        runId = chosen!!.getLong("id")
+        runUrl = chosen!!.optString("html_url")
         println("Watching new run: $runUrl")
         continue
     }

--- a/teamcity/scripts/CallGitHubRelease.main.kts
+++ b/teamcity/scripts/CallGitHubRelease.main.kts
@@ -21,7 +21,11 @@ val octopusModule = args[0]
 val githubToken = args[1]
 val currentCommit = args[2]
 val versionToRelease = args[3]
-val timeoutMinutes = Integer.valueOf(args[4])
+val timeoutMinutes = args[4].toIntOrNull() ?: -1
+if (timeoutMinutes < 0) {
+    System.err.println("timeoutInMinutes must be a non-negative integer, got: ${args[4]}")
+    System.exit(-1)
+}
 val eventType = args[5]
 
 val repo = "octopusden/$octopusModule"
@@ -37,7 +41,7 @@ fun buildProblem(description: String) {
         .replace("|", "||").replace("'", "|'")
         .replace("\n", "|n").replace("\r", "|r")
         .replace("[", "|[").replace("]", "|]")
-    println("##teamcity[buildProblem description='$escaped' identity='github-release']")
+    println("##teamcity[buildProblem description='$escaped' identity='github-release-$octopusModule']")
 }
 
 fun fail(description: String): Nothing {
@@ -63,11 +67,16 @@ fun listDispatchRunIds(): Pair<Boolean, Set<Long>> {
 val (preOk, preExisting) = listDispatchRunIds()
 if (!preOk) println("Warning: could not snapshot existing runs before dispatch; new-run detection is best-effort.")
 
-// 1) Trigger the release.
+// 1) Trigger the release. Build the body with org.json so special characters in
+//    the arguments can't break the JSON.
+val dispatchBody = JSONObject()
+    .put("event_type", eventType)
+    .put("client_payload", JSONObject().put("commit", currentCommit).put("project_version", versionToRelease))
+    .toString()
 val respCreate = post(
     "$api/dispatches",
-    headers = ghHeaders,
-    data = """{"event_type":"$eventType","client_payload":{"commit":"$currentCommit","project_version":"$versionToRelease"}}"""
+    headers = ghHeaders + ("Content-Type" to "application/json"),
+    data = dispatchBody
 )
 if (respCreate.statusCode / 100 != 2) {
     fail("Failed to trigger release dispatch for $repo (HTTP ${respCreate.statusCode}): ${respCreate.text}")
@@ -126,12 +135,19 @@ while (true) {
     if (status == "completed") {
         if (conclusion == "success") {
             println("Release run succeeded: $runUrl")
-            System.exit(0)
+            // Belt-and-braces: confirm the expected release tag actually exists.
+            val tag = get("$api/releases/tags/v$versionToRelease", headers = ghHeaders)
+            if (tag.statusCode / 100 == 2) {
+                println("Release tag v$versionToRelease is present.")
+                System.exit(0)
+            }
+            fail("Release run for $repo succeeded but release tag v$versionToRelease was not found (HTTP ${tag.statusCode}). See $runUrl")
+        } else {
+            fail(
+                "Release run for $repo $versionToRelease concluded '$conclusion'. See $runUrl " +
+                "(open the 'Diagnose & classify Sonatype publish failure' step for the cause and " +
+                "RELEASE_PUBLISH_RETRYABLE: deterministic => do not re-dispatch; transient => a re-dispatch may help)."
+            )
         }
-        fail(
-            "Release run for $repo $versionToRelease concluded '$conclusion'. See $runUrl " +
-            "(open the 'Diagnose & classify Sonatype publish failure' step for the cause and " +
-            "RELEASE_PUBLISH_RETRYABLE: deterministic => do not re-dispatch; transient => a re-dispatch may help)."
-        )
     }
 }


### PR DESCRIPTION
**Merge after #161** (independent branch off `main`, but its `##teamcity[buildProblem]` message points at the `Diagnose & classify` step that #161 adds).

Makes TeamCity release failures readable instead of a bare timeout.

## Problem
`teamcity/scripts/CallGitHubRelease.main.kts` dispatched the release then polled **only** the release tag; when the GA run failed, it ran all ~11 attempts and threw a bare `TimeoutException` (exit 3) — no cause, no link.

## Change
The script now watches the run triggered by THIS dispatch and reports clearly:
- Snapshots existing `repository_dispatch` run IDs **before** the dispatch (with retries; **aborts before dispatch** if the snapshot can't be taken) and locks onto the newest run **not** in that snapshot — never a prior release's run.
- On failure conclusion → **fail fast** with `##teamcity[buildProblem]` (escaped, per-module identity) linking the run, pointing at #161's `Diagnose & classify` step (cause + `RELEASE_PUBLISH_RETRYABLE`).
- On success → confirms the release tag exists, **retrying within the remaining timeout** so a transient 404/5xx doesn't become a false failure.
- Run-status GETs are HTTP-status-guarded (retry, never an unhandled exception that bypasses reporting); dispatch body built with `org.json` (escaped) + `Content-Type`; invalid `timeoutInMinutes` fails clearly.
- Arguments unchanged (backward compatible). Documented limitation: concurrent dispatches of the same repo aren't disambiguated (safe under serial TeamCity releases; the `client_payload` correlation id isn't exposed by the runs API).

## Also in this PR: a CI compile check
Adds `.github/workflows/kts-compile-check.yml` — compiles `teamcity/scripts/*.main.kts` on the exact toolchain (**kotlin-compiler 1.5.32**) on PRs touching them, failing on any compiler `error:`. This catches `.main.kts`-only compile failures (like the smart-cast error fixed here) in CI instead of at release time. The check is green on this PR.

## Testing
Compile-verified on kotlin 1.5.32 / JDK 11 (locally in Docker and by the new CI check). No unit tests: it's a khttp `.main.kts` doing live GitHub-API I/O; the real functional check is a live TeamCity release run.

## Out of scope
The red **detached-HEAD git advice** in the `Clone scripts from GitHub` step comes from a TeamCity server-side Command Line step (not in this repo); fix it there with `git -c advice.detachedHead=false checkout …`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
