### PR TITLE
feat(release): add publish-to-nexus toggle to gradle release workflow

### DIFF
--- a/.github/workflows/common-java-gradle-release.yml
+++ b/.github/workflows/common-java-gradle-release.yml
@@ -50,6 +50,11 @@ on:
         required: false
         type: string
         default: 'org.octopusden'
+      publish-to-nexus:
+        description: 'Publish Maven artifacts to Sonatype Central. Set false for deployable-only repos (app/UI) that nobody consumes as a Maven dependency.'
+        required: false
+        type: boolean
+        default: true
     secrets:
       OSSRH_USERNAME:
         required: false
@@ -137,7 +142,7 @@ jobs:
           echo "- Release log registration will be skipped"
 
       - name: Fail if release secrets are not set for non-dry-run
-        if: ${{ !inputs.dry-run }}
+        if: ${{ !inputs.dry-run && inputs.publish-to-nexus }}
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
@@ -250,7 +255,7 @@ jobs:
       # change. Bypasses the flaky OSSRH-compat staging-profile auto-lookup. No-op
       # when staging-profile-id is blank (falls back to auto-lookup).
       - name: Prepare staging-profile init script
-        if: ${{ !inputs.dry-run }}
+        if: ${{ !inputs.dry-run && inputs.publish-to-nexus }}
         run: |
           cat > "$RUNNER_TEMP/staging-profile.init.gradle" <<'GRADLE'
           allprojects { proj ->
@@ -268,7 +273,7 @@ jobs:
       # publish to nexus
       - name: Publish to Sonatype Nexus
         id: publish-sonatype
-        if: ${{ !inputs.dry-run }}
+        if: ${{ !inputs.dry-run && inputs.publish-to-nexus }}
         run: |
           set -o pipefail
           ./gradlew -Pnexus=true -PstagingProfileId="$STAGING_PROFILE_ID" --init-script "$RUNNER_TEMP/staging-profile.init.gradle" publishToSonatype closeAndReleaseSonatypeStagingRepository -PbuildVersion=${{ env.BUILD_VERSION }} -Pversion=${{ env.BUILD_VERSION }} --info -s 2>&1 | tee "$RUNNER_TEMP/publish.log"

--- a/docs/Octopus Developer Guide.md
+++ b/docs/Octopus Developer Guide.md
@@ -164,3 +164,30 @@ jobs:
       flow-type: hybrid
       java-version: '21'
 ```
+
+## Skipping Maven Central publishing (`publish-to-nexus`)
+
+`common-java-gradle-release` publishes the module's Maven artifacts to Sonatype
+Central by default (`publish-to-nexus: true`). Set it to `false` for
+**deployable-only** repositories — an application or UI that ships as a docker
+image and is never consumed by anyone as a Maven dependency. Skipping the
+upload keeps the org under Maven Central's monthly publishing limits (a Spring
+Boot fat-jar can be tens of MB per release).
+
+When `publish-to-nexus: false`, the release still builds, pushes the docker
+image, and creates the GitHub release — only the Sonatype publish (and its
+secret check) are skipped. Pair it with `register-release-immediately: true`
+so the release is logged directly instead of waiting for a Maven Central
+artifact that will never appear.
+
+```yaml
+jobs:
+  build:
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@<tag>
+    with:
+      flow-type: hybrid
+      java-version: '21'
+      docker-image: my-app
+      publish-to-nexus: false
+      register-release-immediately: true
+```


### PR DESCRIPTION
## Why

Our org is **over the Maven Central monthly publishing limits** (Release Size 1.21 GB vs 80 MB, File Count 10 094 vs 1 000). The single biggest contributor is deployable-only repos publishing their full Spring Boot **fat-jar** to Sonatype Central every release — e.g. the `components-management-portal` ships a ~67 MB boot-jar (~461 MB/month at current cadence) that **nobody consumes as a Maven dependency**; it runs as a docker image on ghcr.

There was no way to tell the shared release workflow "build + push the docker image and cut the GitHub release, but don't publish to Central."

## What

Add a `publish-to-nexus` input (**boolean, default `true`**) to `common-java-gradle-release.yml`. When `false`, the three nexus-only steps are skipped:

- `Fail if release secrets are not set for non-dry-run` (OSSRH/GPG check)
- `Prepare staging-profile init script`
- `Publish to Sonatype Nexus` (`publishToSonatype closeAndReleaseSonatypeStagingRepository`)

Docker build/push and the GitHub release step are untouched.

## Backward compatibility

`default: true` ⇒ for all 22 current consumers `!inputs.dry-run && inputs.publish-to-nexus` reduces to `!inputs.dry-run` — **byte-identical** to today. Opt-in only.

## Follow-up

Consumed by the portal PR (octopusden/octopus-components-management-portal) which sets `publish-to-nexus: false`. **That PR requires a new octopus-base release tag** carrying this input. A repo that skips nexus should also register its release directly (`register-release-immediately: true`) rather than via the Maven-Central artifact poll — handled in the portal PR.

Reviewed independently (Sonnet): no blockers, backward-compat confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to control whether Maven artifacts are published to Sonatype Central during releases.
  * Releases can now skip Nexus publishing and staging steps when this option is disabled.
  * Existing release and dry-run behavior remains unchanged by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->