### PR TITLE
fix(release): pin stagingProfileId in octopus-base self-release (unblocks tag cut)

### DIFF
--- a/.github/workflows/release-octopus-base.yml
+++ b/.github/workflows/release-octopus-base.yml
@@ -201,6 +201,24 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      # Bind stagingProfileId to the gradle-nexus sonatype repository so publishing
+      # bypasses the flaky OSSRH-compat staging-profile auto-lookup (same fix as the
+      # reusable release workflow). Consumer build needs no change.
+      - name: Prepare staging-profile init script
+        run: |
+          cat > "$RUNNER_TEMP/staging-profile.init.gradle" <<'GRADLE'
+          allprojects { proj ->
+              proj.plugins.withId('io.github.gradle-nexus.publish-plugin') {
+                  def spid = proj.findProperty('stagingProfileId')?.toString()?.trim()
+                  if (spid) {
+                      proj.extensions.getByName('nexusPublishing')
+                          .repositories.all { repo -> if (repo.name == 'sonatype') repo.stagingProfileId.set(spid) }
+                  }
+              }
+          }
+          GRADLE
+          echo "Wrote $RUNNER_TEMP/staging-profile.init.gradle"
+
       - name: Build and publish plugin
         working-directory: gradle-quality-plugin
         env:
@@ -212,6 +230,8 @@ jobs:
           ./gradlew build publishToSonatype closeAndReleaseSonatypeStagingRepository \
             -Pversion=${{ needs.calculate-version.outputs.release_version }} \
             -Pnexus=true \
+            -PstagingProfileId=org.octopusden \
+            --init-script "$RUNNER_TEMP/staging-profile.init.gradle" \
             --no-daemon --info -s
 
   create-release:


### PR DESCRIPTION
Last piece of the release-reliability fix. #160 (reusable-workflow fix), #161 (diagnostics), #162 (TeamCity poll) are **merged**; this closes the gap they didn't cover — octopus-base's own release — which currently blocks cutting the tag.

## Problem

The **Release octopus-base** workflow (`release-octopus-base.yml`) fails at `:initializeSonatypeStagingRepository`:

```
> Failed to find staging profile for package group: org.octopusden
```

([failed run](https://github.com/octopusden/octopus-base/actions/runs/30104696925/job/89520077300)) — the flaky OSSRH-compat staging-profile auto-lookup.

**Why #160 didn't fix it:** this workflow publishes the quality convention plugin (group `org.octopusden.octopus`) via its **own** `Build and publish plugin` step (`./gradlew build publishToSonatype closeAndReleaseSonatypeStagingRepository`), not the reusable `common-java-gradle-release.yml`. It also **blocks cutting the octopus-base release tag** (the self-release publishes the plugin and creates the tag).

## Fix

Same mechanism as #160, applied to this workflow:
- a `Prepare staging-profile init script` step generates the init script that binds `stagingProfileId` to the gradle-nexus `sonatype` repository;
- the publish command passes `-PstagingProfileId=org.octopusden --init-script …`.

No change to `gradle-quality-plugin`'s build. Bypasses the auto-lookup entirely.

## Verification

- YAML valid; the generated `init.gradle` is valid Groovy (identical script proven live on the octopus-test canary in #161).
- Not run live here (the self-release is the live check — it's the very run that was failing).

## Related
- #160/#161/#162 (merged), #163 (Central publishing limits — separate owner action).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
