### PR TITLE
fix(release): publish via Central Portal API instead of the broken compat release

### DIFF
--- a/.github/scripts/portal-publish.sh
+++ b/.github/scripts/portal-publish.sh
@@ -1,0 +1,298 @@
+#!/usr/bin/env bash
+#
+# Finish a Sonatype release through the Central Portal Publisher API.
+#
+# The OSSRH-compat Nexus2 `release` transition is unreliable (it leaves the
+# deployment `closed`, so nothing reaches Maven Central). This script replaces it:
+# after Gradle has uploaded + closed the staging repository, it maps that repo to
+# its Portal deployment, waits for VALIDATED, publishes explicitly, waits for
+# PUBLISHED, and finally verifies the artifacts are resolvable on Maven Central.
+#
+# Inputs (env):
+#   MAVEN_USERNAME, MAVEN_PASSWORD  Portal/OSSRH token pair (required)
+#   BUILD_VERSION                   expected release version (required)
+#   STAGING_PROFILE_ID              namespace, e.g. org.octopusden (required)
+#   PUBLISH_LOG                     Gradle publish log, to read the compat repo key
+#   RESUME_DEPLOYMENT_ID            optional: skip the search, use this deployment
+#   REQUIRE_COORDS                  optional: "group:artifact ..." that must be present
+#
+# On failure it emits classification markers for the caller / TeamCity to scrape:
+#   RELEASE_PUBLISH_CLASS=deterministic|transient|resumable
+#   RELEASE_PUBLISH_RETRYABLE=false|true
+#   RELEASE_PUBLISH_RESUME_DEPLOYMENT_ID=<id>   (when the run can be resumed)
+
+set -uo pipefail
+
+: "${MAVEN_USERNAME:?MAVEN_USERNAME is required}"
+: "${MAVEN_PASSWORD:?MAVEN_PASSWORD is required}"
+: "${BUILD_VERSION:?BUILD_VERSION is required}"
+: "${STAGING_PROFILE_ID:?STAGING_PROFILE_ID is required}"
+PUBLISH_LOG="${PUBLISH_LOG:-}"
+RESUME_DEPLOYMENT_ID="${RESUME_DEPLOYMENT_ID:-}"
+REQUIRE_COORDS="${REQUIRE_COORDS:-}"
+TMP="${RUNNER_TEMP:-/tmp}"
+
+HOST="https://ossrh-staging-api.central.sonatype.com"
+PORTAL="https://central.sonatype.com/api/v1/publisher"
+REPO1="https://repo1.maven.org/maven2"
+# Bearer must be base64 of "user:token" with no trailing newline and no line wrap.
+AUTH="Authorization: Bearer $(printf '%s' "${MAVEN_USERNAME}:${MAVEN_PASSWORD}" | base64 | tr -d '\n')"
+NET=(-sS --connect-timeout 15 --max-time 120)
+
+# Deadlines (seconds) — overridable for the canary.
+SEARCH_DEADLINE="${SEARCH_DEADLINE:-600}"
+VALIDATE_DEADLINE="${VALIDATE_DEADLINE:-1800}"
+PUBLISH_DEADLINE="${PUBLISH_DEADLINE:-1800}"
+CENTRAL_DEADLINE="${CENTRAL_DEADLINE:-1800}"
+
+DID="${RESUME_DEPLOYMENT_ID}"
+REPO_KEY=""
+STATUS_JSON="$TMP/portal-status.json"
+
+classify() { # class retryable
+  echo "RELEASE_PUBLISH_CLASS=$1"
+  echo "RELEASE_PUBLISH_RETRYABLE=$2"
+  : > "$TMP/publish-classified"
+}
+
+fail_deterministic() { classify deterministic false; echo "::error title=Deterministic publish failure::$*"; exit 1; }
+fail_transient()     { classify transient true;      echo "::error title=Transient publish failure::$*"; exit 1; }
+# After a deployment exists, a blind re-dispatch would upload the version twice.
+fail_resumable() {
+  classify resumable false
+  [ -n "$DID" ] && echo "RELEASE_PUBLISH_RESUME_DEPLOYMENT_ID=$DID"
+  [ -n "$REPO_KEY" ] && echo "RELEASE_PUBLISH_COMPAT_KEY=$REPO_KEY"
+  echo "::error title=Resumable publish failure::$* Re-dispatch with resume-deployment-id=${DID:-<unknown>} instead of a plain re-run (a plain re-run would create a second deployment of ${BUILD_VERSION})."
+  exit 1
+}
+
+# http METHOD URL OUTFILE -> prints HTTP status (000 on transport error)
+http() {
+  local method="$1" url="$2" out="$3" code
+  code=$(curl "${NET[@]}" -o "$out" -w '%{http_code}' -X "$method" -H "$AUTH" -H 'Accept: application/json' "$url" 2>/dev/null)
+  if [ -z "$code" ]; then echo "000"; else echo "$code"; fi
+}
+
+now() { date +%s; }
+
+# ---------------------------------------------------------------------------
+# 1. Locate the Portal deployment
+# ---------------------------------------------------------------------------
+if [ -n "$DID" ]; then
+  echo "Resuming deployment $DID (upload skipped)."
+else
+  [ -n "$PUBLISH_LOG" ] && [ -f "$PUBLISH_LOG" ] \
+    || fail_deterministic "PUBLISH_LOG is required when RESUME_DEPLOYMENT_ID is not set."
+  REPO_KEY=$(grep -oE "Created staging repository '[^']+'" "$PUBLISH_LOG" 2>/dev/null | head -1 | sed -E "s/^.*'([^']+)'.*$/\1/")
+  [ -n "$REPO_KEY" ] \
+    || fail_deterministic "No 'Created staging repository' line in the publish log — nothing was staged."
+  echo "Compat staging repository: $REPO_KEY"
+
+  # The search key is prefixed ("<user>/<ip>/<repo-id>"), so match by suffix.
+  sf="$TMP/portal-search.json"
+  deadline=$(( $(now) + SEARCH_DEADLINE ))
+  while :; do
+    code=$(http GET "$HOST/manual/search/repositories?ip=any&profile_id=${STAGING_PROFILE_ID}" "$sf")
+    if [ "$code" = "200" ]; then
+      DID=$(jq -r --arg k "$REPO_KEY" '.repositories[]? | select(.key | endswith($k)) | .portal_deployment_id // empty' "$sf" 2>/dev/null | head -1)
+      [ -n "$DID" ] && [ "$DID" != "null" ] && break
+      echo "Portal deployment id not published yet for $REPO_KEY; waiting..."
+    elif [ "$code" = "401" ] || [ "$code" = "403" ]; then
+      fail_deterministic "GET /manual/search/repositories -> HTTP $code (credentials/permissions)."
+    else
+      echo "GET /manual/search/repositories -> HTTP $code; retrying..."
+    fi
+    if [ "$(now)" -ge "$deadline" ]; then
+      echo "  (last search body):"; head -c 2000 "$sf" 2>/dev/null; echo
+      REPO_KEY="$REPO_KEY" fail_resumable "The staging repository was created but never appeared as a Portal deployment within ${SEARCH_DEADLINE}s."
+    fi
+    sleep 15
+  done
+fi
+echo "Portal deployment id: $DID"
+echo "RELEASE_PUBLISH_DEPLOYMENT_ID=$DID"
+[ -n "$REPO_KEY" ] && echo "RELEASE_PUBLISH_COMPAT_KEY=$REPO_KEY"
+
+# ---------------------------------------------------------------------------
+# 2. Wait for VALIDATED (or notice it already moved on)
+# ---------------------------------------------------------------------------
+dump_errors() {
+  jq -r 'if (.errors|type)=="object" then (.errors|to_entries[]|"  - \(.key): \(.value|tostring)")
+         elif (.errors|type)=="array" then (.errors[]|"  - \(.|tostring)")
+         else empty end' "$STATUS_JSON" 2>/dev/null \
+    || { echo "  (raw status body):"; head -c 2000 "$STATUS_JSON"; echo; }
+}
+
+poll_state() { jq -r '.deploymentState // empty' "$STATUS_JSON" 2>/dev/null; }
+
+state=""
+deadline=$(( $(now) + VALIDATE_DEADLINE ))
+while :; do
+  code=$(http POST "$PORTAL/status?id=$DID" "$STATUS_JSON")
+  state=$(poll_state)
+  echo "POST /status?id=$DID -> HTTP $code state=${state:-?}"
+  case "$code" in
+    200) : ;;
+    401|403) fail_deterministic "POST /status -> HTTP $code (credentials/permissions)." ;;
+    404)
+      # Right after the hand-off the deployment may not be queryable yet.
+      echo "  status 404 — treating as propagation delay, still waiting..."
+      ;;
+    *) echo "  transient HTTP $code, retrying..." ;;
+  esac
+  case "$state" in
+    VALIDATED)            break ;;
+    PUBLISHING|PUBLISHED) echo "Deployment already $state — skipping the publish call."; break ;;
+    FAILED)
+      echo "::group::Deployment validation errors"; dump_errors; echo "::endgroup::"
+      fail_deterministic "Deployment $DID is FAILED (validation). Fix the cause; a FAILED deployment cannot be published or resumed."
+      ;;
+    *) : ;;  # PENDING / VALIDATING / empty
+  esac
+  if [ "$(now)" -ge "$deadline" ]; then
+    fail_resumable "Deployment $DID did not reach VALIDATED within ${VALIDATE_DEADLINE}s (last state=${state:-unknown})."
+  fi
+  sleep 15
+done
+
+# ---------------------------------------------------------------------------
+# 3. Guard: the deployment must be the one we just built
+#    (protects against a wrong resume-deployment-id publishing someone else's work)
+# ---------------------------------------------------------------------------
+mapfile -t PURLS < <(jq -r '.purls[]? // empty' "$STATUS_JSON" 2>/dev/null | sed 's/?.*$//')
+MAVEN_COORDS=()
+for p in "${PURLS[@]:-}"; do
+  [ -n "$p" ] || continue
+  case "$p" in pkg:maven/*) : ;; *) continue ;; esac
+  rest="${p#pkg:maven/}"
+  ga="${rest%@*}"; ver="${rest##*@}"
+  grp="${ga%/*}"; art="${ga##*/}"
+  [ -n "$grp" ] && [ -n "$art" ] && [ -n "$ver" ] || continue
+  MAVEN_COORDS+=("$grp:$art:$ver")
+done
+
+if [ "${#MAVEN_COORDS[@]}" -eq 0 ]; then
+  echo "  (raw status body):"; head -c 2000 "$STATUS_JSON"; echo
+  fail_deterministic "No Maven coordinates (purls) reported for deployment $DID — cannot verify what would be published."
+fi
+
+echo "::group::Deployment coordinates"
+printf '  %s\n' "${MAVEN_COORDS[@]}"
+echo "::endgroup::"
+
+for c in "${MAVEN_COORDS[@]}"; do
+  grp="${c%%:*}"; ver="${c##*:}"
+  [ "$ver" = "$BUILD_VERSION" ] \
+    || fail_deterministic "Deployment $DID contains version '$ver' but this release is '$BUILD_VERSION' — refusing to publish (wrong resume-deployment-id?)."
+  case "$grp" in
+    "$STAGING_PROFILE_ID"|"$STAGING_PROFILE_ID".*) : ;;
+    *) fail_deterministic "Deployment $DID contains group '$grp' outside namespace '$STAGING_PROFILE_ID' — refusing to publish." ;;
+  esac
+done
+
+for want in $REQUIRE_COORDS; do
+  found=false
+  for c in "${MAVEN_COORDS[@]}"; do
+    [ "${c%:*}" = "$want" ] && found=true && break
+  done
+  $found || fail_deterministic "Deployment $DID does not contain the required coordinate '$want:$BUILD_VERSION'."
+done
+
+# ---------------------------------------------------------------------------
+# 4. Publish (irreversible)
+# ---------------------------------------------------------------------------
+if [ "$state" = "VALIDATED" ]; then
+  resp="$TMP/portal-publish-resp"
+  attempt=0
+  while :; do
+    attempt=$(( attempt + 1 ))
+    code=$(http POST "$PORTAL/deployment/$DID" "$resp")
+    echo "POST /deployment/$DID (attempt $attempt) -> HTTP $code"
+    case "$code" in
+      204|200) echo "Publish accepted."; break ;;
+      401|403|400|404|409|422)
+        echo "  (response body):"; head -c 2000 "$resp" 2>/dev/null; echo
+        fail_deterministic "POST /deployment/$DID -> HTTP $code."
+        ;;
+      429)
+        ra=$(awk 'tolower($0) ~ /^retry-after:/ {print $2}' "$resp" 2>/dev/null | tr -d '\r')
+        sleep "${ra:-30}"
+        ;;
+      *)
+        # Ambiguous: the publish may have been accepted. Never blindly re-POST —
+        # settle, then decide from the deployment state.
+        echo "  ambiguous response ($code); settling before re-checking status..."
+        sleep 45
+        http POST "$PORTAL/status?id=$DID" "$STATUS_JSON" >/dev/null
+        state=$(poll_state)
+        echo "  post-settle state=${state:-unknown}"
+        case "$state" in
+          PUBLISHING|PUBLISHED) break ;;
+          VALIDATED)            : ;;  # genuinely not accepted -> retry the POST
+          FAILED) echo "::group::Errors"; dump_errors; echo "::endgroup::"
+                  fail_deterministic "Deployment $DID became FAILED during publish." ;;
+          *) fail_resumable "Deployment $DID is in state '${state:-unknown}' after an ambiguous publish call." ;;
+        esac
+        ;;
+    esac
+    [ "$attempt" -ge 5 ] && fail_resumable "Publish call for $DID did not succeed after $attempt attempts."
+  done
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Wait for PUBLISHED
+# ---------------------------------------------------------------------------
+deadline=$(( $(now) + PUBLISH_DEADLINE ))
+while :; do
+  code=$(http POST "$PORTAL/status?id=$DID" "$STATUS_JSON")
+  state=$(poll_state)
+  echo "POST /status?id=$DID -> HTTP $code state=${state:-?}"
+  case "$state" in
+    PUBLISHED) echo "Deployment $DID is PUBLISHED."; break ;;
+    FAILED)
+      echo "::group::Deployment errors"; dump_errors; echo "::endgroup::"
+      fail_deterministic "Deployment $DID became FAILED while publishing."
+      ;;
+    *) : ;;
+  esac
+  if [ "$(now)" -ge "$deadline" ]; then
+    fail_resumable "Deployment $DID did not reach PUBLISHED within ${PUBLISH_DEADLINE}s (last state=${state:-unknown})."
+  fi
+  sleep 20
+done
+
+# ---------------------------------------------------------------------------
+# 6. Verify the artifacts are actually resolvable on Maven Central
+#    (a green publish alone is not "done" — consumers resolve from repo1)
+# ---------------------------------------------------------------------------
+echo "::group::Verifying artifacts on Maven Central"
+deadline=$(( $(now) + CENTRAL_DEADLINE ))
+pending=("${MAVEN_COORDS[@]}")
+while [ "${#pending[@]}" -gt 0 ]; do
+  still=()
+  for c in "${pending[@]}"; do
+    grp="${c%%:*}"; rest="${c#*:}"; art="${rest%%:*}"; ver="${rest##*:}"
+    url="$REPO1/${grp//./\/}/$art/$ver/$art-$ver.pom"
+    code=$(curl "${NET[@]}" -o /dev/null -w '%{http_code}' "$url" 2>/dev/null)
+    if [ "$code" = "200" ]; then
+      echo "  OK   $c"
+    else
+      echo "  wait $c (HTTP ${code:-?})"
+      still+=("$c")
+    fi
+  done
+  pending=("${still[@]:-}")
+  # `still` may contain a single empty element after expansion of an empty array.
+  [ "${#pending[@]}" -eq 1 ] && [ -z "${pending[0]}" ] && pending=()
+  [ "${#pending[@]}" -eq 0 ] && break
+  if [ "$(now)" -ge "$deadline" ]; then
+    echo "::endgroup::"
+    fail_resumable "Published, but ${#pending[@]} artifact(s) were not resolvable on Maven Central within ${CENTRAL_DEADLINE}s: ${pending[*]}."
+  fi
+  sleep 30
+done
+echo "::endgroup::"
+
+echo "RELEASE_PUBLISH_CLASS=published"
+echo "RELEASE_PUBLISH_RETRYABLE=false"
+echo "All ${#MAVEN_COORDS[@]} artifact(s) of $BUILD_VERSION are published and resolvable on Maven Central."

--- a/.github/scripts/portal-publish.sh
+++ b/.github/scripts/portal-publish.sh
@@ -11,22 +11,26 @@
 # Inputs (env):
 #   MAVEN_USERNAME, MAVEN_PASSWORD  Portal/OSSRH token pair (required)
 #   BUILD_VERSION                   expected release version (required)
-#   STAGING_PROFILE_ID              namespace, e.g. org.octopusden (required)
+#   STAGING_PROFILE_ID              namespace, e.g. org.octopusden (optional; when
+#                                   blank the search is unfiltered and the namespace
+#                                   check is skipped — matches "blank = auto-lookup")
 #   PUBLISH_LOG                     Gradle publish log, to read the compat repo key
 #   RESUME_DEPLOYMENT_ID            optional: skip the search, use this deployment
 #   REQUIRE_COORDS                  optional: "group:artifact ..." that must be present
 #
-# On failure it emits classification markers for the caller / TeamCity to scrape:
+# Emits classification markers for the caller / TeamCity to scrape:
+#   RELEASE_PUBLISH_CLASS=published                  (success)
 #   RELEASE_PUBLISH_CLASS=deterministic|transient|resumable
 #   RELEASE_PUBLISH_RETRYABLE=false|true
-#   RELEASE_PUBLISH_RESUME_DEPLOYMENT_ID=<id>   (when the run can be resumed)
+#   RELEASE_PUBLISH_RESUME_DEPLOYMENT_ID=<id>        (resumable, deployment known)
+#   RELEASE_PUBLISH_COMPAT_KEY=<key>                 (staging repo, for manual triage)
 
 set -uo pipefail
 
 : "${MAVEN_USERNAME:?MAVEN_USERNAME is required}"
 : "${MAVEN_PASSWORD:?MAVEN_PASSWORD is required}"
 : "${BUILD_VERSION:?BUILD_VERSION is required}"
-: "${STAGING_PROFILE_ID:?STAGING_PROFILE_ID is required}"
+STAGING_PROFILE_ID="${STAGING_PROFILE_ID:-}"
 PUBLISH_LOG="${PUBLISH_LOG:-}"
 RESUME_DEPLOYMENT_ID="${RESUME_DEPLOYMENT_ID:-}"
 REQUIRE_COORDS="${REQUIRE_COORDS:-}"
@@ -44,6 +48,8 @@ SEARCH_DEADLINE="${SEARCH_DEADLINE:-600}"
 VALIDATE_DEADLINE="${VALIDATE_DEADLINE:-1800}"
 PUBLISH_DEADLINE="${PUBLISH_DEADLINE:-1800}"
 CENTRAL_DEADLINE="${CENTRAL_DEADLINE:-1800}"
+# Settling window before re-reading state after an inconclusive publish response.
+SETTLE_SECONDS="${SETTLE_SECONDS:-45}"
 
 DID="${RESUME_DEPLOYMENT_ID}"
 REPO_KEY=""
@@ -52,6 +58,8 @@ STATUS_JSON="$TMP/portal-status.json"
 classify() { # class retryable
   echo "RELEASE_PUBLISH_CLASS=$1"
   echo "RELEASE_PUBLISH_RETRYABLE=$2"
+  [ -n "$DID" ] && echo "RELEASE_PUBLISH_DEPLOYMENT_ID=$DID"
+  [ -n "$REPO_KEY" ] && echo "RELEASE_PUBLISH_COMPAT_KEY=$REPO_KEY"
   : > "$TMP/publish-classified"
 }
 
@@ -60,16 +68,20 @@ fail_transient()     { classify transient true;      echo "::error title=Transie
 # After a deployment exists, a blind re-dispatch would upload the version twice.
 fail_resumable() {
   classify resumable false
-  [ -n "$DID" ] && echo "RELEASE_PUBLISH_RESUME_DEPLOYMENT_ID=$DID"
-  [ -n "$REPO_KEY" ] && echo "RELEASE_PUBLISH_COMPAT_KEY=$REPO_KEY"
-  echo "::error title=Resumable publish failure::$* Re-dispatch with resume-deployment-id=${DID:-<unknown>} instead of a plain re-run (a plain re-run would create a second deployment of ${BUILD_VERSION})."
+  if [ -n "$DID" ]; then
+    echo "RELEASE_PUBLISH_RESUME_DEPLOYMENT_ID=$DID"
+    echo "::error title=Resumable publish failure::$* Re-dispatch with resume-deployment-id=${DID} — a plain re-run would upload ${BUILD_VERSION} a second time."
+  else
+    echo "::error title=Resumable publish failure::$* The artifacts are staged but no Portal deployment id is known yet. Do NOT plainly re-run (that uploads ${BUILD_VERSION} again): look it up with the compat key above via GET ${HOST}/manual/search/repositories?ip=any (Bearer auth) and re-dispatch with resume-deployment-id, or drop that staging repository first."
+  fi
   exit 1
 }
 
-# http METHOD URL OUTFILE -> prints HTTP status (000 on transport error)
+# http METHOD URL OUTFILE -> prints HTTP status (000 on transport error).
+# Response headers land in <OUTFILE>.headers (needed for Retry-After).
 http() {
   local method="$1" url="$2" out="$3" code
-  code=$(curl "${NET[@]}" -o "$out" -w '%{http_code}' -X "$method" -H "$AUTH" -H 'Accept: application/json' "$url" 2>/dev/null)
+  code=$(curl "${NET[@]}" -o "$out" -D "${out}.headers" -w '%{http_code}' -X "$method" -H "$AUTH" -H 'Accept: application/json' "$url" 2>/dev/null)
   if [ -z "$code" ]; then echo "000"; else echo "$code"; fi
 }
 
@@ -83,16 +95,25 @@ if [ -n "$DID" ]; then
 else
   [ -n "$PUBLISH_LOG" ] && [ -f "$PUBLISH_LOG" ] \
     || fail_deterministic "PUBLISH_LOG is required when RESUME_DEPLOYMENT_ID is not set."
-  REPO_KEY=$(grep -oE "Created staging repository '[^']+'" "$PUBLISH_LOG" 2>/dev/null | head -1 | sed -E "s/^.*'([^']+)'.*$/\1/")
-  [ -n "$REPO_KEY" ] \
-    || fail_deterministic "No 'Created staging repository' line in the publish log — nothing was staged."
+  mapfile -t created < <(grep -oE "Created staging repository '[^']+'" "$PUBLISH_LOG" 2>/dev/null | sed -E "s/^.*'([^']+)'.*$/\1/" | sort -u)
+  if [ "${#created[@]}" -eq 0 ]; then
+    fail_deterministic "No 'Created staging repository' line in the publish log — nothing was staged."
+  elif [ "${#created[@]}" -gt 1 ]; then
+    printf 'Staged repositories: %s\n' "${created[*]}"
+    fail_deterministic "The build created ${#created[@]} staging repositories; this flow publishes exactly one. Publish them manually or split the release."
+  fi
+  REPO_KEY="${created[0]}"
   echo "Compat staging repository: $REPO_KEY"
+  echo "RELEASE_PUBLISH_COMPAT_KEY=$REPO_KEY"
 
   # The search key is prefixed ("<user>/<ip>/<repo-id>"), so match by suffix.
+  # Without a namespace the search is unfiltered — the key-suffix match still pins it.
+  search_url="$HOST/manual/search/repositories?ip=any"
+  [ -n "$STAGING_PROFILE_ID" ] && search_url="${search_url}&profile_id=${STAGING_PROFILE_ID}"
   sf="$TMP/portal-search.json"
   deadline=$(( $(now) + SEARCH_DEADLINE ))
   while :; do
-    code=$(http GET "$HOST/manual/search/repositories?ip=any&profile_id=${STAGING_PROFILE_ID}" "$sf")
+    code=$(http GET "$search_url" "$sf")
     if [ "$code" = "200" ]; then
       DID=$(jq -r --arg k "$REPO_KEY" '.repositories[]? | select(.key | endswith($k)) | .portal_deployment_id // empty' "$sf" 2>/dev/null | head -1)
       [ -n "$DID" ] && [ "$DID" != "null" ] && break
@@ -104,23 +125,23 @@ else
     fi
     if [ "$(now)" -ge "$deadline" ]; then
       echo "  (last search body):"; head -c 2000 "$sf" 2>/dev/null; echo
-      REPO_KEY="$REPO_KEY" fail_resumable "The staging repository was created but never appeared as a Portal deployment within ${SEARCH_DEADLINE}s."
+      fail_resumable "The staging repository was created but never appeared as a Portal deployment within ${SEARCH_DEADLINE}s."
     fi
     sleep 15
   done
 fi
 echo "Portal deployment id: $DID"
 echo "RELEASE_PUBLISH_DEPLOYMENT_ID=$DID"
-[ -n "$REPO_KEY" ] && echo "RELEASE_PUBLISH_COMPAT_KEY=$REPO_KEY"
 
 # ---------------------------------------------------------------------------
 # 2. Wait for VALIDATED (or notice it already moved on)
 # ---------------------------------------------------------------------------
 dump_errors() {
-  jq -r 'if (.errors|type)=="object" then (.errors|to_entries[]|"  - \(.key): \(.value|tostring)")
-         elif (.errors|type)=="array" then (.errors[]|"  - \(.|tostring)")
-         else empty end' "$STATUS_JSON" 2>/dev/null \
-    || { echo "  (raw status body):"; head -c 2000 "$STATUS_JSON"; echo; }
+  local out
+  out=$(jq -r 'if (.errors|type)=="object" then (.errors|to_entries[]|"  - \(.key): \(.value|tostring)")
+               elif (.errors|type)=="array" then (.errors[]|"  - \(.|tostring)")
+               else empty end' "$STATUS_JSON" 2>/dev/null)
+  if [ -n "$out" ]; then echo "$out"; else echo "  (no .errors field; raw status body):"; head -c 2000 "$STATUS_JSON"; echo; fi
 }
 
 poll_state() { jq -r '.deploymentState // empty' "$STATUS_JSON" 2>/dev/null; }
@@ -136,7 +157,7 @@ while :; do
     401|403) fail_deterministic "POST /status -> HTTP $code (credentials/permissions)." ;;
     404)
       # Right after the hand-off the deployment may not be queryable yet.
-      echo "  status 404 — treating as propagation delay, still waiting..."
+      echo "  status 404 — treating as propagation delay, still waiting (verify the id if this persists)..."
       ;;
     *) echo "  transient HTTP $code, retrying..." ;;
   esac
@@ -160,7 +181,7 @@ done
 #    (protects against a wrong resume-deployment-id publishing someone else's work)
 # ---------------------------------------------------------------------------
 mapfile -t PURLS < <(jq -r '.purls[]? // empty' "$STATUS_JSON" 2>/dev/null | sed 's/?.*$//')
-MAVEN_COORDS=()
+declare -a MAVEN_COORDS=()
 for p in "${PURLS[@]:-}"; do
   [ -n "$p" ] || continue
   case "$p" in pkg:maven/*) : ;; *) continue ;; esac
@@ -170,6 +191,11 @@ for p in "${PURLS[@]:-}"; do
   [ -n "$grp" ] && [ -n "$art" ] && [ -n "$ver" ] || continue
   MAVEN_COORDS+=("$grp:$art:$ver")
 done
+
+# Classifier-stripped purls (sources/javadoc) collapse into duplicates.
+if [ "${#MAVEN_COORDS[@]}" -gt 0 ]; then
+  mapfile -t MAVEN_COORDS < <(printf '%s\n' "${MAVEN_COORDS[@]}" | sort -u)
+fi
 
 if [ "${#MAVEN_COORDS[@]}" -eq 0 ]; then
   echo "  (raw status body):"; head -c 2000 "$STATUS_JSON"; echo
@@ -184,11 +210,15 @@ for c in "${MAVEN_COORDS[@]}"; do
   grp="${c%%:*}"; ver="${c##*:}"
   [ "$ver" = "$BUILD_VERSION" ] \
     || fail_deterministic "Deployment $DID contains version '$ver' but this release is '$BUILD_VERSION' — refusing to publish (wrong resume-deployment-id?)."
-  case "$grp" in
-    "$STAGING_PROFILE_ID"|"$STAGING_PROFILE_ID".*) : ;;
-    *) fail_deterministic "Deployment $DID contains group '$grp' outside namespace '$STAGING_PROFILE_ID' — refusing to publish." ;;
-  esac
+  if [ -n "$STAGING_PROFILE_ID" ]; then
+    case "$grp" in
+      "$STAGING_PROFILE_ID"|"$STAGING_PROFILE_ID".*) : ;;
+      *) fail_deterministic "Deployment $DID contains group '$grp' outside namespace '$STAGING_PROFILE_ID' — refusing to publish." ;;
+    esac
+  fi
 done
+[ -n "$STAGING_PROFILE_ID" ] || echo "::warning::No staging-profile-id configured — namespace check skipped (the version was still verified)."
+
 
 for want in $REQUIRE_COORDS; do
   found=false
@@ -201,6 +231,26 @@ done
 # ---------------------------------------------------------------------------
 # 4. Publish (irreversible)
 # ---------------------------------------------------------------------------
+# Any inconclusive response is reconciled against the deployment state rather than
+# re-POSTed or declared fatal: the publish may have been accepted, and a late
+# 400/409 usually means "no longer VALIDATED", i.e. it already went through.
+reconcile_after_publish() { # $1 = context for the log
+  echo "  $1 — settling, then re-reading the deployment state..."
+  sleep "$SETTLE_SECONDS"
+  http POST "$PORTAL/status?id=$DID" "$STATUS_JSON" >/dev/null
+  state=$(poll_state)
+  echo "  post-settle state=${state:-unknown}"
+  case "$state" in
+    PUBLISHING|PUBLISHED) return 0 ;;
+    VALIDATED)            return 1 ;;
+    FAILED)
+      echo "::group::Deployment errors"; dump_errors; echo "::endgroup::"
+      fail_deterministic "Deployment $DID became FAILED during publish."
+      ;;
+    *) fail_resumable "Deployment $DID is in state '${state:-unknown}' after an inconclusive publish call." ;;
+  esac
+}
+
 if [ "$state" = "VALIDATED" ]; then
   resp="$TMP/portal-publish-resp"
   attempt=0
@@ -210,29 +260,23 @@ if [ "$state" = "VALIDATED" ]; then
     echo "POST /deployment/$DID (attempt $attempt) -> HTTP $code"
     case "$code" in
       204|200) echo "Publish accepted."; break ;;
-      401|403|400|404|409|422)
+      401|403)
         echo "  (response body):"; head -c 2000 "$resp" 2>/dev/null; echo
-        fail_deterministic "POST /deployment/$DID -> HTTP $code."
+        fail_deterministic "POST /deployment/$DID -> HTTP $code (credentials/permissions)."
+        ;;
+      400|404|409|422)
+        # May equally mean "already past VALIDATED" — check before condemning it.
+        echo "  (response body):"; head -c 2000 "$resp" 2>/dev/null; echo
+        if reconcile_after_publish "HTTP $code"; then break; fi
+        fail_deterministic "POST /deployment/$DID -> HTTP $code and the deployment is still VALIDATED."
         ;;
       429)
-        ra=$(awk 'tolower($0) ~ /^retry-after:/ {print $2}' "$resp" 2>/dev/null | tr -d '\r')
+        ra=$(awk 'BEGIN{IGNORECASE=1} /^retry-after:/ {gsub(/\r/,""); print $2}' "${resp}.headers" 2>/dev/null | head -1)
+        echo "  rate limited; sleeping ${ra:-30}s"
         sleep "${ra:-30}"
         ;;
       *)
-        # Ambiguous: the publish may have been accepted. Never blindly re-POST —
-        # settle, then decide from the deployment state.
-        echo "  ambiguous response ($code); settling before re-checking status..."
-        sleep 45
-        http POST "$PORTAL/status?id=$DID" "$STATUS_JSON" >/dev/null
-        state=$(poll_state)
-        echo "  post-settle state=${state:-unknown}"
-        case "$state" in
-          PUBLISHING|PUBLISHED) break ;;
-          VALIDATED)            : ;;  # genuinely not accepted -> retry the POST
-          FAILED) echo "::group::Errors"; dump_errors; echo "::endgroup::"
-                  fail_deterministic "Deployment $DID became FAILED during publish." ;;
-          *) fail_resumable "Deployment $DID is in state '${state:-unknown}' after an ambiguous publish call." ;;
-        esac
+        if reconcile_after_publish "inconclusive response ($code)"; then break; fi
         ;;
     esac
     [ "$attempt" -ge 5 ] && fail_resumable "Publish call for $DID did not succeed after $attempt attempts."
@@ -247,6 +291,10 @@ while :; do
   code=$(http POST "$PORTAL/status?id=$DID" "$STATUS_JSON")
   state=$(poll_state)
   echo "POST /status?id=$DID -> HTTP $code state=${state:-?}"
+  case "$code" in
+    401|403) fail_deterministic "POST /status -> HTTP $code while waiting for PUBLISHED (credentials/permissions)." ;;
+    *) : ;;
+  esac
   case "$state" in
     PUBLISHED) echo "Deployment $DID is PUBLISHED."; break ;;
     FAILED)

--- a/.github/scripts/test/curl
+++ b/.github/scripts/test/curl
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Fake curl for portal-publish.sh tests. Canned responses driven by env:
+#   SEARCH_CODE, SEARCH_DID, STATUS_STATES (space-separated, consumed per call),
+#   STATUS_VERSION, STATUS_GROUP, STATUS_ERRORS, PUBLISH_CODES, REPO1_CODES
+set -u
+out=/dev/null; url=""; method="GET"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -o) out="$2"; shift 2 ;;
+    -X) method="$2"; shift 2 ;;
+    -w|-H|--connect-timeout|--max-time) shift 2 ;;
+    -sS|-s|-S) shift ;;
+    -*) shift ;;
+    *) url="$1"; shift ;;
+  esac
+done
+S="${STATE_DIR:?}"
+next() { # counter-file list default
+  local f="$S/$1" list="$2" def="$3" i v
+  i=$(cat "$f" 2>/dev/null || echo 0); i=$((i+1)); echo "$i" > "$f"
+  v=$(echo "$list" | awk -v n="$i" '{ if (NF>=n) print $n; else print $NF }')
+  [ -n "$v" ] && echo "$v" || echo "$def"
+}
+echo "$method $url" >> "$S/calls.log"
+case "$url" in
+  *manual/search/repositories*)
+    code="${SEARCH_CODE:-200}"
+    did="$(next search_i "${SEARCH_DID:-dep-1}" dep-1)"
+    if [ "$did" = "-" ]; then did=null; else did="\"$did\""; fi
+    cat > "$out" <<EOF
+{"repositories":[{"key":"user/any/org.octopusden--abc","state":"closed","portal_deployment_id":$did}]}
+EOF
+    echo "$code" ;;
+  *publisher/status*)
+    st="$(next status_i "${STATUS_STATES:-VALIDATED}" VALIDATED)"
+    ver="${STATUS_VERSION:-2.5.0}"; grp="${STATUS_GROUP:-org.octopusden.octopus}"
+    err="${STATUS_ERRORS:-}"
+    if [ -n "$err" ]; then errj=",\"errors\":{\"pom\":\"$err\"}"; else errj=""; fi
+    cat > "$out" <<EOF
+{"deploymentId":"dep-1","deploymentState":"$st","purls":["pkg:maven/$grp/octopus-quality-plugin@$ver?type=jar","pkg:maven/org.octopusden.octopus-quality/org.octopusden.octopus-quality.gradle.plugin@$ver"]$errj}
+EOF
+    echo 200 ;;
+  *publisher/deployment/*)
+    echo "" > "$out"
+    next publish_i "${PUBLISH_CODES:-204}" 204 ;;
+  *repo1.maven.org*)
+    echo "" > "$out"
+    next repo1_i "${REPO1_CODES:-200}" 200 ;;
+  *) echo 000 ;;
+esac

--- a/.github/scripts/test/portal-publish-scenarios.sh
+++ b/.github/scripts/test/portal-publish-scenarios.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# Scenario tests for .github/scripts/portal-publish.sh.
+#
+# The Central Portal API is replaced by the stub `curl` next to this file (put on
+# PATH), so the whole publish state machine — including paths that are impossible
+# to trigger on demand against the live service (FAILED validation, ambiguous
+# publish responses, wrong deployment ids) — runs offline and deterministically.
+#
+# Usage: bash .github/scripts/test/portal-publish-scenarios.sh   (from the repo root)
+
+set -uo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$here/../portal-publish.sh"
+[ -f "$SCRIPT" ] || { echo "portal-publish.sh not found next to the test dir"; exit 1; }
+command -v jq >/dev/null || { echo "jq is required"; exit 1; }
+
+pass=0; fail=0
+# Short deadlines/settling so the suite runs in seconds.
+common_env=(SEARCH_DEADLINE=3 VALIDATE_DEADLINE=6 PUBLISH_DEADLINE=6 CENTRAL_DEADLINE=6 SETTLE_SECONDS=1
+            MAVEN_USERNAME=u MAVEN_PASSWORD=p)
+
+# run <name> <expected-rc> <must-match> [<must-not-match>]
+# Scenario knobs are passed by the caller as environment variables (see stub curl).
+run() {
+  local name="$1" erc="$2" want="$3" nowant="${4:-}"
+  export STATE_DIR RUNNER_TEMP
+  STATE_DIR="$(mktemp -d)"; RUNNER_TEMP="$(mktemp -d)"
+  if [ "${NO_LOG:-}" != "1" ]; then
+    printf "Created staging repository '%s' at https://x/content/\n" "${LOG_REPO:-org.octopusden--abc}" > "$RUNNER_TEMP/publish.log"
+  fi
+  local out="$STATE_DIR/out.txt" rc ok=true
+  PATH="$here:$PATH" env "${common_env[@]}" \
+    BUILD_VERSION="${VERSION:-2.5.0}" STAGING_PROFILE_ID="${SPI-org.octopusden}" \
+    PUBLISH_LOG="$RUNNER_TEMP/publish.log" \
+    RESUME_DEPLOYMENT_ID="${RESUME_ID:-}" REQUIRE_COORDS="${REQ_COORDS:-}" \
+    bash "$SCRIPT" >"$out" 2>&1
+  rc=$?
+  [ "$rc" = "$erc" ] || { ok=false; echo "  rc=$rc expected=$erc"; }
+  [ -n "$want" ] && ! grep -qE "$want" "$out" && { ok=false; echo "  missing: $want"; }
+  [ -n "$nowant" ] && grep -qE "$nowant" "$out" && { ok=false; echo "  unexpected: $nowant"; }
+  if $ok; then echo "PASS  $name"; pass=$((pass+1)); else
+    echo "FAIL  $name"; fail=$((fail+1)); sed 's/^/    | /' "$out"
+  fi
+}
+
+echo "-- happy path and guards -------------------------------------------------"
+STATUS_STATES="VALIDATING VALIDATED PUBLISHED" PUBLISH_CODES=204 REPO1_CODES=200 \
+  run "publishes and verifies on Central" 0 "RELEASE_PUBLISH_CLASS=published" "Deterministic|Resumable"
+STATUS_STATES="VALIDATED" STATUS_VERSION=9.9.9 \
+  run "refuses a deployment of another version" 1 "refusing to publish" "POST .*/publisher/deployment"
+STATUS_STATES="VALIDATED" STATUS_GROUP=com.evil \
+  run "refuses a group outside the namespace" 1 "outside namespace" "POST .*/publisher/deployment"
+STATUS_STATES="VALIDATED" REQ_COORDS="org.octopusden.octopus:absent" \
+  run "refuses when a required coordinate is missing" 1 "required coordinate" "POST .*/publisher/deployment"
+STATUS_STATES="VALIDATED PUBLISHED" PUBLISH_CODES=204 REPO1_CODES=200 \
+  REQ_COORDS="org.octopusden.octopus-quality:org.octopusden.octopus-quality.gradle.plugin" \
+  run "accepts the required marker coordinate" 0 "RELEASE_PUBLISH_CLASS=published"
+
+echo "-- validation and publish edge cases -------------------------------------"
+STATUS_STATES="VALIDATING FAILED" STATUS_ERRORS="missing signature" \
+  run "reports validation errors as deterministic" 1 "missing signature"
+STATUS_STATES="VALIDATED PUBLISHING PUBLISHED" PUBLISH_CODES="000" REPO1_CODES=200 \
+  run "reconciles an inconclusive publish without re-POSTing" 0 "inconclusive response"
+STATUS_STATES="VALIDATED PUBLISHING PUBLISHED" PUBLISH_CODES="409" REPO1_CODES=200 \
+  run "treats a late 409 as already-published" 0 "RELEASE_PUBLISH_CLASS=published"
+STATUS_STATES="VALIDATED VALIDATED VALIDATED VALIDATED VALIDATED" PUBLISH_CODES="409" \
+  run "keeps a still-VALIDATED 409 deterministic" 1 "still VALIDATED"
+STATUS_STATES="VALIDATED PUBLISHED" PUBLISH_CODES=204 REPO1_CODES="404" \
+  run "stays resumable when Central never serves the artifact" 1 "RELEASE_PUBLISH_CLASS=resumable"
+
+echo "-- resume, namespaces and staging bookkeeping ----------------------------"
+RESUME_ID=dep-42 NO_LOG=1 STATUS_STATES="VALIDATED PUBLISHED" PUBLISH_CODES=204 REPO1_CODES=200 \
+  run "resumes an existing deployment without uploading" 0 "Resuming deployment dep-42"
+SPI="" STATUS_STATES="VALIDATED PUBLISHED" PUBLISH_CODES=204 REPO1_CODES=200 \
+  run "works without a namespace (auto-lookup contract)" 0 "namespace check skipped" "outside namespace"
+SEARCH_DID="-" STATUS_STATES="VALIDATED" \
+  run "reports resumable when no Portal deployment appears" 1 "RELEASE_PUBLISH_COMPAT_KEY"
+NO_LOG=1 \
+  run "refuses when nothing was staged" 1 "PUBLISH_LOG is required|nothing was staged"
+
+# Two staged repositories in one build must not be silently truncated.
+export STATE_DIR RUNNER_TEMP; STATE_DIR="$(mktemp -d)"; RUNNER_TEMP="$(mktemp -d)"
+printf "Created staging repository 'org.octopusden--a'\nCreated staging repository 'org.octopusden--b'\n" > "$RUNNER_TEMP/publish.log"
+PATH="$here:$PATH" env "${common_env[@]}" BUILD_VERSION=2.5.0 STAGING_PROFILE_ID=org.octopusden \
+  PUBLISH_LOG="$RUNNER_TEMP/publish.log" bash "$SCRIPT" >"$STATE_DIR/out.txt" 2>&1
+if [ $? = 1 ] && grep -q "publishes exactly one" "$STATE_DIR/out.txt"; then
+  echo "PASS  refuses a build that staged two repositories"; pass=$((pass+1))
+else
+  echo "FAIL  refuses a build that staged two repositories"; fail=$((fail+1)); sed 's/^/    | /' "$STATE_DIR/out.txt"
+fi
+
+echo
+echo "RESULT: pass=$pass fail=$fail"
+[ "$fail" = 0 ]

--- a/.github/workflows/check-octopus-test-consumer.yml
+++ b/.github/workflows/check-octopus-test-consumer.yml
@@ -106,7 +106,7 @@ jobs:
               -ignore "shellcheck reported issue in this script: SC2034:" \
               -ignore "shellcheck reported issue in this script: SC2046:" \
               -ignore "shellcheck reported issue in this script: SC2086:" \
-              -ignore "property \"workflow_sha\" is not defined" \
+              -ignore "property \"workflow_sha\" is not defined in object type \{check_run_id" \
               $(find .github/workflows -type f \( -name "*.yml" -o -name "*.yaml" \) | sort)
           '
       - name: Validate helper scripts

--- a/.github/workflows/check-octopus-test-consumer.yml
+++ b/.github/workflows/check-octopus-test-consumer.yml
@@ -87,6 +87,11 @@ jobs:
       ACTIONLINT_IMAGE: ${{ inputs.actionlint_image || 'rhysd/actionlint:1.7.7' }}
     steps:
       - uses: actions/checkout@v4
+      # Note on the last -ignore: `github.job_workflow_sha` is a real, documented
+      # context property (the commit SHA of the reusable-workflow file), used by
+      # common-java-gradle-release.yml to fetch its helper script at exactly its own
+      # version. actionlint 1.7.7 still ships an older context type list and reports
+      # it as undefined, so that one message is filtered out.
       - name: actionlint
         shell: bash
         run: |
@@ -98,6 +103,7 @@ jobs:
               -ignore "shellcheck reported issue in this script: SC2034:" \
               -ignore "shellcheck reported issue in this script: SC2046:" \
               -ignore "shellcheck reported issue in this script: SC2086:" \
+              -ignore "property \"job_workflow_sha\" is not defined" \
               $(find .github/workflows -type f \( -name "*.yml" -o -name "*.yaml" \) | sort)
           '
       - name: Validate helper scripts

--- a/.github/workflows/check-octopus-test-consumer.yml
+++ b/.github/workflows/check-octopus-test-consumer.yml
@@ -91,8 +91,7 @@ jobs:
       # property (the commit SHA of the workflow file defining the current job).
       # common-java-gradle-release.yml uses it to pin its helper script to its own
       # version. actionlint — including the newest 1.7.12 — still ships an older
-      # job-context type list (container/services/status, plus check_run_id since
-      # 1.7.8) and
+      # job-context type list and
       # reports it as undefined, so that one message is filtered out. The workflow
       # additionally fails loudly if the value is ever empty, so the filter cannot
       # hide a real breakage.
@@ -107,7 +106,7 @@ jobs:
               -ignore "shellcheck reported issue in this script: SC2034:" \
               -ignore "shellcheck reported issue in this script: SC2046:" \
               -ignore "shellcheck reported issue in this script: SC2086:" \
-              -ignore "property \"workflow_sha\" is not defined in object type \{(check_run_id|container)" \
+              -ignore "property \"workflow_sha\" is not defined" \
               $(find .github/workflows -type f \( -name "*.yml" -o -name "*.yaml" \) | sort)
           '
       - name: Validate helper scripts
@@ -120,6 +119,12 @@ jobs:
       - name: Validate workflow naming convention
         shell: bash
         run: bash .github/scripts/validate-workflow-naming.sh .
+      # Exercises the Portal publish state machine against a stubbed Central API,
+      # covering paths that cannot be triggered on demand against the live service
+      # (FAILED validation, ambiguous publish responses, wrong deployment ids).
+      - name: Portal publish helper scenarios
+        shell: bash
+        run: bash .github/scripts/test/portal-publish-scenarios.sh
 
   security:
     name: security

--- a/.github/workflows/check-octopus-test-consumer.yml
+++ b/.github/workflows/check-octopus-test-consumer.yml
@@ -87,11 +87,14 @@ jobs:
       ACTIONLINT_IMAGE: ${{ inputs.actionlint_image || 'rhysd/actionlint:1.7.7' }}
     steps:
       - uses: actions/checkout@v4
-      # Note on the last -ignore: `github.job_workflow_sha` is a real, documented
-      # context property (the commit SHA of the reusable-workflow file), used by
-      # common-java-gradle-release.yml to fetch its helper script at exactly its own
-      # version. actionlint 1.7.7 still ships an older context type list and reports
-      # it as undefined, so that one message is filtered out.
+      # Note on the last -ignore: `job.workflow_sha` is a documented job-context
+      # property (the commit SHA of the workflow file defining the current job).
+      # common-java-gradle-release.yml uses it to pin its helper script to its own
+      # version. actionlint — including the newest 1.7.12 — still ships an older
+      # job-context type list (check_run_id/container/services/status only) and
+      # reports it as undefined, so that one message is filtered out. The workflow
+      # additionally fails loudly if the value is ever empty, so the filter cannot
+      # hide a real breakage.
       - name: actionlint
         shell: bash
         run: |
@@ -103,7 +106,7 @@ jobs:
               -ignore "shellcheck reported issue in this script: SC2034:" \
               -ignore "shellcheck reported issue in this script: SC2046:" \
               -ignore "shellcheck reported issue in this script: SC2086:" \
-              -ignore "property \"job_workflow_sha\" is not defined" \
+              -ignore "property \"workflow_sha\" is not defined" \
               $(find .github/workflows -type f \( -name "*.yml" -o -name "*.yaml" \) | sort)
           '
       - name: Validate helper scripts

--- a/.github/workflows/check-octopus-test-consumer.yml
+++ b/.github/workflows/check-octopus-test-consumer.yml
@@ -91,7 +91,8 @@ jobs:
       # property (the commit SHA of the workflow file defining the current job).
       # common-java-gradle-release.yml uses it to pin its helper script to its own
       # version. actionlint — including the newest 1.7.12 — still ships an older
-      # job-context type list (check_run_id/container/services/status only) and
+      # job-context type list (container/services/status, plus check_run_id since
+      # 1.7.8) and
       # reports it as undefined, so that one message is filtered out. The workflow
       # additionally fails loudly if the value is ever empty, so the filter cannot
       # hide a real breakage.
@@ -106,7 +107,7 @@ jobs:
               -ignore "shellcheck reported issue in this script: SC2034:" \
               -ignore "shellcheck reported issue in this script: SC2046:" \
               -ignore "shellcheck reported issue in this script: SC2086:" \
-              -ignore "property \"workflow_sha\" is not defined in object type \{check_run_id" \
+              -ignore "property \"workflow_sha\" is not defined in object type \{(check_run_id|container)" \
               $(find .github/workflows -type f \( -name "*.yml" -o -name "*.yaml" \) | sort)
           '
       - name: Validate helper scripts

--- a/.github/workflows/common-java-gradle-release.yml
+++ b/.github/workflows/common-java-gradle-release.yml
@@ -74,12 +74,17 @@ jobs:
   prepare-build-publish-release:
     runs-on: ubuntu-latest
     environment: Prod
-    # Two overlapping releases of the same repository would compute the same next
-    # version and upload it twice (one deployment then fails validation as a
-    # duplicate). Serialize per repository instead of cancelling: a cancelled run
-    # could leave an unpublished deployment behind.
+    # Serialize REAL releases per repository: two overlapping ones would compute the
+    # same next version and upload it twice. Dry runs must NOT share that group —
+    # a repository can run several release variants at once (octopus-test's
+    # release-smoke matrix), and since GitHub keeps only one pending member per
+    # group, the extra variants would be cancelled. So dry runs get a key that is
+    # unique per run and variant, real publishes get the shared per-repository one.
     concurrency:
-      group: release-${{ github.repository }}
+      group: >-
+        release-${{ github.repository }}-${{ inputs.dry-run
+          && format('dry-{0}-{1}-{2}-{3}', github.run_id, github.run_attempt, inputs.flow-type, inputs.docker-image)
+          || 'publish' }}
       cancel-in-progress: false
     env:
       SKIP_TESTS: ''
@@ -440,6 +445,12 @@ jobs:
           cls="unknown"; retryable="unknown"
           if [ -n "$portal_errors" ] || printf '%s' "$sec" | grep -qiE 'responded with status code 40[13]|401 Unauthorized|403 Forbidden'; then
             cls="deterministic"; retryable="false"
+          elif [ -n "$repo" ]; then
+            # Artifacts are already staged (and possibly handed off to the Portal):
+            # a plain re-dispatch would upload this version a second time.
+            cls="resumable"; retryable="false"
+            echo "RELEASE_PUBLISH_COMPAT_KEY=$repo"
+            [ -n "${did:-}" ] && [ "${did:-}" != "null" ] && echo "RELEASE_PUBLISH_RESUME_DEPLOYMENT_ID=$did"
           elif printf '%s' "$sec" | grep -qiE 'responded with status code 5[0-9][0-9]|status code 5[0-9][0-9]|timed out|Read timed out|Connection reset|Connection refused'; then
             cls="transient"; retryable="true"
           fi
@@ -453,7 +464,8 @@ jobs:
             echo "RELEASE_PUBLISH_RETRYABLE=${retryable}"
             case "$cls" in
               deterministic) echo "::error title=Deterministic publish failure::Validation / auth error (see deployment errors above) — retrying will NOT help. Fix the artifact/credentials; do not re-dispatch." ;;
-              transient)     echo "::warning title=Transient publish failure::Infrastructure instability (5xx/timeout) — a re-dispatch may succeed." ;;
+              transient)     echo "::warning title=Transient publish failure::Infrastructure instability (5xx/timeout) before anything was staged — a re-dispatch may succeed." ;;
+              resumable)     echo "::error title=Resumable publish failure::The version is already staged, so a plain re-dispatch would upload it twice. Finish it with resume-deployment-id (see the id/compat key above), or drop that staging repository first." ;;
               *)             echo "::warning title=Unclassified publish failure::Could not classify — inspect the deployment errors and log above; there is no evidence a retry will help." ;;
             esac
           fi

--- a/.github/workflows/common-java-gradle-release.yml
+++ b/.github/workflows/common-java-gradle-release.yml
@@ -56,7 +56,7 @@ on:
         type: boolean
         default: true
       resume-deployment-id:
-        description: 'Emergency re-run knob: Portal deployment id of a release whose artifacts were already uploaded (printed by the failed run as RELEASE_PUBLISH_RESUME_DEPLOYMENT_ID). When set, the Gradle upload is SKIPPED and the existing deployment is published instead — use this after a run died past the upload, so the version is not uploaded twice.'
+        description: 'Emergency re-run knob: Portal deployment id printed as RELEASE_PUBLISH_RESUME_DEPLOYMENT_ID by a failed run OF THIS SAME REPOSITORY. When set, the Gradle upload is SKIPPED and that existing deployment is published instead — use it after a run died past the upload, so the version is not uploaded twice. Callers must expose it in their own workflow_dispatch inputs to use it.'
         required: false
         type: string
         default: ''
@@ -262,6 +262,41 @@ jobs:
         if: inputs.docker-image && !inputs.dry-run
         run: docker push ghcr.io/octopusden/${{ inputs.docker-image }}:${{ env.BUILD_VERSION }}
 
+      # The publish helper lives in octopus-base, but this reusable workflow runs
+      # against the CONSUMER's checkout — so fetch the script from the very commit
+      # THIS workflow file comes from (`job.workflow_sha`), keeping script and
+      # workflow versions in lockstep.
+      #
+      # Both steps deliberately run BEFORE the upload: once artifacts are staged a
+      # failure here would leave an orphaned deployment that nothing can classify,
+      # and the operator's natural plain re-run would upload the version twice.
+      #
+      # The guard requires a full commit SHA: an empty or non-SHA ref would make
+      # actions/checkout silently resolve a branch/tag (its default branch), i.e. run
+      # a different script than the pinned workflow — the very skew this prevents.
+      - name: Resolve Portal publish helper ref
+        id: helper-ref
+        if: ${{ !inputs.dry-run && inputs.publish-to-nexus }}
+        env:
+          HELPER_SHA: ${{ job.workflow_sha }}
+        run: |
+          set -euo pipefail
+          if [[ ! "${HELPER_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error title=Cannot pin the publish helper::job.workflow_sha resolved to '${HELPER_SHA}', which is not a full commit SHA, so the helper script cannot be pinned to this workflow version. Refusing to publish with an unpinned helper."
+            exit 1
+          fi
+          echo "sha=${HELPER_SHA}" >> "$GITHUB_OUTPUT"
+          echo "Publish helper pinned to octopus-base@${HELPER_SHA}"
+
+      - name: Fetch Portal publish helper
+        if: ${{ !inputs.dry-run && inputs.publish-to-nexus }}
+        uses: actions/checkout@v4
+        with:
+          repository: octopusden/octopus-base
+          ref: ${{ steps.helper-ref.outputs.sha }}
+          path: .octopus-base-helper
+          sparse-checkout: .github/scripts
+
       # Bind -PstagingProfileId to the gradle-nexus publish-plugin extension for
       # every project that applies it, without requiring any consumer build-script
       # change. Bypasses the flaky OSSRH-compat staging-profile auto-lookup. No-op
@@ -300,38 +335,6 @@ jobs:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_PRIVATE_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_PASSPHRASE }}
 
-      # The publish helper lives in octopus-base, but this reusable workflow runs
-      # against the CONSUMER's checkout — so fetch the script from the very commit
-      # THIS workflow file comes from (`job.workflow_sha`), keeping script and
-      # workflow versions in lockstep. Both steps run before anything irreversible,
-      # so a failure here is a plain retry.
-      #
-      # Guard first: an empty ref would make actions/checkout silently fall back to
-      # octopus-base's default branch, i.e. run a newer script than the pinned
-      # workflow — exactly the version skew this is meant to prevent.
-      - name: Resolve Portal publish helper ref
-        id: helper-ref
-        if: ${{ !inputs.dry-run && inputs.publish-to-nexus }}
-        env:
-          HELPER_SHA: ${{ job.workflow_sha }}
-        run: |
-          set -euo pipefail
-          if [ -z "${HELPER_SHA}" ]; then
-            echo "::error title=Cannot pin the publish helper::job.workflow_sha is empty, so the helper script version cannot be pinned to this workflow. Refusing to publish with an unpinned helper."
-            exit 1
-          fi
-          echo "sha=${HELPER_SHA}" >> "$GITHUB_OUTPUT"
-          echo "Publish helper pinned to octopus-base@${HELPER_SHA}"
-
-      - name: Fetch Portal publish helper
-        if: ${{ !inputs.dry-run && inputs.publish-to-nexus }}
-        uses: actions/checkout@v4
-        with:
-          repository: octopusden/octopus-base
-          ref: ${{ steps.helper-ref.outputs.sha }}
-          path: .octopus-base-helper
-          sparse-checkout: .github/scripts
-
       # Explicit Central Portal publish: map the closed staging repository to its
       # Portal deployment, wait for VALIDATED, verify it is really OUR version and
       # namespace, publish, wait for PUBLISHED, and confirm every artifact is
@@ -366,6 +369,7 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          RESUME_ID: ${{ inputs.resume-deployment-id }}
         run: |
           set +e
           host="https://ossrh-staging-api.central.sonatype.com"
@@ -421,7 +425,11 @@ jobs:
             fi
             echo "::endgroup::"
           else
-            echo "No staging repository was created (failure before repo creation)."
+            if [ -n "${RESUME_ID:-}" ]; then
+              echo "Resume mode: no local publish log (the upload was skipped by design)."
+            else
+              echo "No staging repository was created (failure before repo creation)."
+            fi
           fi
 
           # Classify. Deterministic = Portal reported validation errors, or an explicit

--- a/.github/workflows/common-java-gradle-release.yml
+++ b/.github/workflows/common-java-gradle-release.yml
@@ -302,15 +302,33 @@ jobs:
 
       # The publish helper lives in octopus-base, but this reusable workflow runs
       # against the CONSUMER's checkout — so fetch the script from the very commit
-      # this workflow file comes from (job_workflow_sha), keeping script and
-      # workflow versions in lockstep. Runs before any irreversible step, so a
-      # failure here is a plain retry.
+      # THIS workflow file comes from (`job.workflow_sha`), keeping script and
+      # workflow versions in lockstep. Both steps run before anything irreversible,
+      # so a failure here is a plain retry.
+      #
+      # Guard first: an empty ref would make actions/checkout silently fall back to
+      # octopus-base's default branch, i.e. run a newer script than the pinned
+      # workflow — exactly the version skew this is meant to prevent.
+      - name: Resolve Portal publish helper ref
+        id: helper-ref
+        if: ${{ !inputs.dry-run && inputs.publish-to-nexus }}
+        env:
+          HELPER_SHA: ${{ job.workflow_sha }}
+        run: |
+          set -euo pipefail
+          if [ -z "${HELPER_SHA}" ]; then
+            echo "::error title=Cannot pin the publish helper::job.workflow_sha is empty, so the helper script version cannot be pinned to this workflow. Refusing to publish with an unpinned helper."
+            exit 1
+          fi
+          echo "sha=${HELPER_SHA}" >> "$GITHUB_OUTPUT"
+          echo "Publish helper pinned to octopus-base@${HELPER_SHA}"
+
       - name: Fetch Portal publish helper
         if: ${{ !inputs.dry-run && inputs.publish-to-nexus }}
         uses: actions/checkout@v4
         with:
           repository: octopusden/octopus-base
-          ref: ${{ github.job_workflow_sha }}
+          ref: ${{ steps.helper-ref.outputs.sha }}
           path: .octopus-base-helper
           sparse-checkout: .github/scripts
 

--- a/.github/workflows/common-java-gradle-release.yml
+++ b/.github/workflows/common-java-gradle-release.yml
@@ -55,6 +55,11 @@ on:
         required: false
         type: boolean
         default: true
+      resume-deployment-id:
+        description: 'Emergency re-run knob: Portal deployment id of a release whose artifacts were already uploaded (printed by the failed run as RELEASE_PUBLISH_RESUME_DEPLOYMENT_ID). When set, the Gradle upload is SKIPPED and the existing deployment is published instead — use this after a run died past the upload, so the version is not uploaded twice.'
+        required: false
+        type: string
+        default: ''
     secrets:
       OSSRH_USERNAME:
         required: false
@@ -69,6 +74,13 @@ jobs:
   prepare-build-publish-release:
     runs-on: ubuntu-latest
     environment: Prod
+    # Two overlapping releases of the same repository would compute the same next
+    # version and upload it twice (one deployment then fails validation as a
+    # duplicate). Serialize per repository instead of cancelling: a cancelled run
+    # could leave an unpublished deployment behind.
+    concurrency:
+      group: release-${{ github.repository }}
+      cancel-in-progress: false
     env:
       SKIP_TESTS: ''
       BUILD_VERSION: ''
@@ -255,7 +267,7 @@ jobs:
       # change. Bypasses the flaky OSSRH-compat staging-profile auto-lookup. No-op
       # when staging-profile-id is blank (falls back to auto-lookup).
       - name: Prepare staging-profile init script
-        if: ${{ !inputs.dry-run && inputs.publish-to-nexus }}
+        if: ${{ !inputs.dry-run && inputs.publish-to-nexus && inputs.resume-deployment-id == '' }}
         run: |
           cat > "$RUNNER_TEMP/staging-profile.init.gradle" <<'GRADLE'
           allprojects { proj ->
@@ -270,19 +282,53 @@ jobs:
           GRADLE
           echo "Wrote $RUNNER_TEMP/staging-profile.init.gradle"
 
-      # publish to nexus
+      # Upload + close the staging repository. The Nexus2-compat `release`
+      # transition is NOT used: it leaves the deployment `closed`, so nothing ever
+      # reaches Maven Central. The publish is driven explicitly through the Central
+      # Portal API in the next step. Skipped entirely when resuming an existing
+      # deployment (the artifacts are already uploaded).
       - name: Publish to Sonatype Nexus
         id: publish-sonatype
-        if: ${{ !inputs.dry-run && inputs.publish-to-nexus }}
+        if: ${{ !inputs.dry-run && inputs.publish-to-nexus && inputs.resume-deployment-id == '' }}
         run: |
           set -o pipefail
-          ./gradlew -Pnexus=true -PstagingProfileId="$STAGING_PROFILE_ID" --init-script "$RUNNER_TEMP/staging-profile.init.gradle" publishToSonatype closeAndReleaseSonatypeStagingRepository -PbuildVersion=${{ env.BUILD_VERSION }} -Pversion=${{ env.BUILD_VERSION }} --info -s 2>&1 | tee "$RUNNER_TEMP/publish.log"
+          ./gradlew -Pnexus=true -PstagingProfileId="$STAGING_PROFILE_ID" --init-script "$RUNNER_TEMP/staging-profile.init.gradle" publishToSonatype closeSonatypeStagingRepository -PbuildVersion=${{ env.BUILD_VERSION }} -Pversion=${{ env.BUILD_VERSION }} --info -s 2>&1 | tee "$RUNNER_TEMP/publish.log"
         env:
           STAGING_PROFILE_ID: ${{ inputs.staging-profile-id }}
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_PRIVATE_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_PASSPHRASE }}
+
+      # The publish helper lives in octopus-base, but this reusable workflow runs
+      # against the CONSUMER's checkout — so fetch the script from the very commit
+      # this workflow file comes from (job_workflow_sha), keeping script and
+      # workflow versions in lockstep. Runs before any irreversible step, so a
+      # failure here is a plain retry.
+      - name: Fetch Portal publish helper
+        if: ${{ !inputs.dry-run && inputs.publish-to-nexus }}
+        uses: actions/checkout@v4
+        with:
+          repository: octopusden/octopus-base
+          ref: ${{ github.job_workflow_sha }}
+          path: .octopus-base-helper
+          sparse-checkout: .github/scripts
+
+      # Explicit Central Portal publish: map the closed staging repository to its
+      # Portal deployment, wait for VALIDATED, verify it is really OUR version and
+      # namespace, publish, wait for PUBLISHED, and confirm every artifact is
+      # resolvable on Maven Central. Only then may the release/tag be created.
+      - name: Publish deployment via Central Portal
+        id: portal-publish
+        if: ${{ !inputs.dry-run && inputs.publish-to-nexus }}
+        run: bash .octopus-base-helper/.github/scripts/portal-publish.sh
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          BUILD_VERSION: ${{ env.BUILD_VERSION }}
+          STAGING_PROFILE_ID: ${{ inputs.staging-profile-id }}
+          PUBLISH_LOG: ${{ runner.temp }}/publish.log
+          RESUME_DEPLOYMENT_ID: ${{ inputs.resume-deployment-id }}
 
       # On a Sonatype publish failure, surface WHY (and whether a retry can help):
       #  (1) HTTP status + body of the account's staging profiles;
@@ -298,7 +344,7 @@ jobs:
       #      deterministic; everything else stays 'unknown'. Reads only the Gradle
       #      failure section to avoid false matches from --info chatter.
       - name: Diagnose & classify Sonatype publish failure
-        if: ${{ failure() && steps.publish-sonatype.outcome == 'failure' && !inputs.dry-run }}
+        if: ${{ failure() && (steps.publish-sonatype.outcome == 'failure' || steps.portal-publish.outcome == 'failure') && !inputs.dry-run }}
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
@@ -371,13 +417,20 @@ jobs:
           elif printf '%s' "$sec" | grep -qiE 'responded with status code 5[0-9][0-9]|status code 5[0-9][0-9]|timed out|Read timed out|Connection reset|Connection refused'; then
             cls="transient"; retryable="true"
           fi
-          echo "RELEASE_PUBLISH_CLASS=${cls}"
-          echo "RELEASE_PUBLISH_RETRYABLE=${retryable}"
-          case "$cls" in
-            deterministic) echo "::error title=Deterministic publish failure::Validation / auth error (see deployment errors above) — retrying will NOT help. Fix the artifact/credentials; do not re-dispatch." ;;
-            transient)     echo "::warning title=Transient publish failure::Infrastructure instability (5xx/timeout) — a re-dispatch may succeed." ;;
-            *)             echo "::warning title=Unclassified publish failure::Could not classify — inspect the deployment errors and log above; there is no evidence a retry will help." ;;
-          esac
+          # The Portal publish helper classifies its own failures precisely (it knows
+          # whether a deployment exists and is resumable). Only classify here when it
+          # did not, i.e. the failure happened in the Gradle upload/close stage.
+          if [ -f "$RUNNER_TEMP/publish-classified" ]; then
+            echo "Classification already emitted by the Portal publish step (see above)."
+          else
+            echo "RELEASE_PUBLISH_CLASS=${cls}"
+            echo "RELEASE_PUBLISH_RETRYABLE=${retryable}"
+            case "$cls" in
+              deterministic) echo "::error title=Deterministic publish failure::Validation / auth error (see deployment errors above) — retrying will NOT help. Fix the artifact/credentials; do not re-dispatch." ;;
+              transient)     echo "::warning title=Transient publish failure::Infrastructure instability (5xx/timeout) — a re-dispatch may succeed." ;;
+              *)             echo "::warning title=Unclassified publish failure::Could not classify — inspect the deployment errors and log above; there is no evidence a retry will help." ;;
+            esac
+          fi
 
       # github release
       - name: Create release

--- a/.github/workflows/release-octopus-base.yml
+++ b/.github/workflows/release-octopus-base.yml
@@ -27,9 +27,21 @@ on:
         required: true
         type: boolean
         default: false
+      resume-deployment-id:
+        description: 'Emergency re-run knob: Portal deployment id of a release whose artifacts were already uploaded (printed by the failed run as RELEASE_PUBLISH_RESUME_DEPLOYMENT_ID). When set, the Gradle upload is SKIPPED and that deployment is published instead — prevents uploading the same version twice.'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: write
+
+# Never let two self-releases overlap: both would compute the same version and
+# upload it twice. Queue instead of cancelling — a cancelled run can leave an
+# unpublished deployment behind.
+concurrency:
+  group: release-octopus-base
+  cancel-in-progress: false
 
 jobs:
   resolve-target:
@@ -205,6 +217,7 @@ jobs:
       # bypasses the flaky OSSRH-compat staging-profile auto-lookup (same fix as the
       # reusable release workflow). Consumer build needs no change.
       - name: Prepare staging-profile init script
+        if: ${{ inputs.resume-deployment-id == '' }}
         run: |
           cat > "$RUNNER_TEMP/staging-profile.init.gradle" <<'GRADLE'
           allprojects { proj ->
@@ -219,7 +232,12 @@ jobs:
           GRADLE
           echo "Wrote $RUNNER_TEMP/staging-profile.init.gradle"
 
+      # Upload + close only. The Nexus2-compat `release` transition leaves the
+      # deployment `closed` (nothing reaches Central), so the publish is driven
+      # explicitly through the Central Portal API in the next step.
       - name: Build and publish plugin
+        id: publish-sonatype
+        if: ${{ inputs.resume-deployment-id == '' }}
         working-directory: gradle-quality-plugin
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
@@ -227,12 +245,29 @@ jobs:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_PRIVATE_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_PASSPHRASE }}
         run: |
-          ./gradlew build publishToSonatype closeAndReleaseSonatypeStagingRepository \
+          set -o pipefail
+          ./gradlew build publishToSonatype closeSonatypeStagingRepository \
             -Pversion=${{ needs.calculate-version.outputs.release_version }} \
             -Pnexus=true \
             -PstagingProfileId=org.octopusden \
             --init-script "$RUNNER_TEMP/staging-profile.init.gradle" \
-            --no-daemon --info -s
+            --no-daemon --info -s 2>&1 | tee "$RUNNER_TEMP/publish.log"
+
+      # Explicit Central Portal publish + verification that the plugin is really
+      # resolvable on Maven Central. REQUIRE_COORDS pins the plugin marker POM —
+      # that is what every consumer's plugin resolution hits first, so the release
+      # must not be tagged unless the marker is live (see #158).
+      - name: Publish deployment via Central Portal
+        id: portal-publish
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          BUILD_VERSION: ${{ needs.calculate-version.outputs.release_version }}
+          STAGING_PROFILE_ID: org.octopusden
+          PUBLISH_LOG: ${{ runner.temp }}/publish.log
+          RESUME_DEPLOYMENT_ID: ${{ inputs.resume-deployment-id }}
+          REQUIRE_COORDS: 'org.octopusden.octopus-quality:org.octopusden.octopus-quality.gradle.plugin'
+        run: bash .github/scripts/portal-publish.sh
 
   create-release:
     name: Create GitHub release

--- a/.github/workflows/release-octopus-base.yml
+++ b/.github/workflows/release-octopus-base.yml
@@ -277,6 +277,8 @@ jobs:
         if: ${{ failure() && steps.publish-sonatype.outcome == 'failure' }}
         env:
           RELEASE_VERSION: ${{ needs.calculate-version.outputs.release_version }}
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
         run: |
           set +e
           log="$RUNNER_TEMP/publish.log"
@@ -285,11 +287,25 @@ jobs:
             echo "RELEASE_PUBLISH_CLASS=resumable"
             echo "RELEASE_PUBLISH_RETRYABLE=false"
             echo "RELEASE_PUBLISH_COMPAT_KEY=$repo"
-            echo "::error title=Resumable publish failure::${RELEASE_VERSION} is already staged as ${repo}. Do NOT plainly re-run (that uploads the version twice): look the deployment up via GET https://ossrh-staging-api.central.sonatype.com/manual/search/repositories?ip=any (Bearer auth) and re-dispatch with resume-deployment-id, or drop that staging repository first."
+            # Resolve the Portal deployment id too, so the operator can resume
+            # directly instead of looking it up by hand.
+            auth="Authorization: Bearer $(printf '%s' "${MAVEN_USERNAME}:${MAVEN_PASSWORD}" | base64 | tr -d '\n')"
+            sf="$RUNNER_TEMP/diag-search.json"
+            scode=$(curl -sS --connect-timeout 15 --max-time 60 -o "$sf" -w '%{http_code}' \
+              -H "$auth" -H 'Accept: application/json' \
+              "https://ossrh-staging-api.central.sonatype.com/manual/search/repositories?ip=any&profile_id=org.octopusden" 2>/dev/null)
+            did=$(jq -r --arg k "$repo" '.repositories[]? | select(.key | endswith($k)) | .portal_deployment_id // empty' "$sf" 2>/dev/null | head -1)
+            echo "GET /manual/search/repositories -> HTTP ${scode:-?}"
+            if [ -n "$did" ] && [ "$did" != "null" ]; then
+              echo "RELEASE_PUBLISH_RESUME_DEPLOYMENT_ID=$did"
+              echo "::error title=Resumable publish failure::${RELEASE_VERSION} is already staged as ${repo} (Portal deployment ${did}). Do NOT plainly re-run — that uploads the version twice. Re-dispatch this workflow with resume-deployment-id=${did}."
+            else
+              echo "::error title=Resumable publish failure::${RELEASE_VERSION} is already staged as ${repo}, but no Portal deployment is mapped to it yet. Do NOT plainly re-run — that uploads the version twice. Re-check the Compat/Portal state and resume with resume-deployment-id once the id appears, or drop that staging repository first."
+            fi
           else
             echo "RELEASE_PUBLISH_CLASS=unknown"
             echo "RELEASE_PUBLISH_RETRYABLE=unknown"
-            echo "::warning title=Publish failed before staging::Nothing was staged, so a plain re-dispatch is safe."
+            echo "::warning title=Publish failed, staging state unknown::Staging repository could not be identified from the log, which does NOT prove the remote create/upload failed. A plain re-dispatch is not proven safe: inspect the Compat/Portal state for ${RELEASE_VERSION} first."
           fi
 
   create-release:

--- a/.github/workflows/release-octopus-base.yml
+++ b/.github/workflows/release-octopus-base.yml
@@ -269,6 +269,29 @@ jobs:
           REQUIRE_COORDS: 'org.octopusden.octopus-quality:org.octopusden.octopus-quality.gradle.plugin'
         run: bash .github/scripts/portal-publish.sh
 
+      # If the Gradle upload/close failed after the staging repository was created,
+      # the artifacts already exist and a plain re-run would upload this version
+      # twice. The Portal helper classifies its own failures; this covers the
+      # Gradle stage, which has no diagnose step here.
+      - name: Report resumable publish failure
+        if: ${{ failure() && steps.publish-sonatype.outcome == 'failure' }}
+        env:
+          RELEASE_VERSION: ${{ needs.calculate-version.outputs.release_version }}
+        run: |
+          set +e
+          log="$RUNNER_TEMP/publish.log"
+          repo=$(grep -oE "Created staging repository '[^']+'" "$log" 2>/dev/null | head -1 | sed -E "s/^.*'([^']+)'.*$/\1/")
+          if [ -n "$repo" ]; then
+            echo "RELEASE_PUBLISH_CLASS=resumable"
+            echo "RELEASE_PUBLISH_RETRYABLE=false"
+            echo "RELEASE_PUBLISH_COMPAT_KEY=$repo"
+            echo "::error title=Resumable publish failure::${RELEASE_VERSION} is already staged as ${repo}. Do NOT plainly re-run (that uploads the version twice): look the deployment up via GET https://ossrh-staging-api.central.sonatype.com/manual/search/repositories?ip=any (Bearer auth) and re-dispatch with resume-deployment-id, or drop that staging repository first."
+          else
+            echo "RELEASE_PUBLISH_CLASS=unknown"
+            echo "RELEASE_PUBLISH_RETRYABLE=unknown"
+            echo "::warning title=Publish failed before staging::Nothing was staged, so a plain re-dispatch is safe."
+          fi
+
   create-release:
     name: Create GitHub release
     needs:


### PR DESCRIPTION
Implements the agreed **P0**: replace the unreliable OSSRH-compat `release` transition with an explicit **Central Portal** publish, and treat a release as done only once the artifact is resolvable on Maven Central.

## Problem

Releases fail at `:releaseSonatypeStagingRepository`:

```
Staging repository is not in desired state [released, not_found]:
  StagingRepository(id=org.octopusden--…, state=closed, transitioning=false)
```

Upload and close succeed (profile pinning from #160/#165 works); the compat `release` does not complete within the plugin's wait, so the job fails.

**What that actually costs — observed on the `2.5.0` self-release** ([run 30106149189](https://github.com/octopusden/octopus-base/actions/runs/30106149189), commit `80e3eb8`): the workflow failed, so no tag and no GitHub release were created — but the compat layer finished the transition **asynchronously afterwards** and the deployment was published. `octopus-quality-plugin-2.5.0` (POM/JAR) and the plugin **marker** POM are all resolvable on `repo1.maven.org`, and the metadata reports `<release>2.5.0</release>`.

So the contract is broken either way: **the workflow reported failure after an irreversible success**, publishing to Central is immutable, and the release could not simply be re-run. `v2.5.0` had to be [restored after the fact](https://github.com/octopusden/octopus-base/releases/tag/v2.5.0) to map the published version to its source commit and to keep version numbering coherent. That tag is explicitly **not** a workflow baseline.

This blocks every consumer release (#158/#140), and the quality plugin it publishes is applied in every consumer's `build`/`quality`/`security`/`merge-gate`.

## What changes

Gradle now only **uploads + closes** (`publishToSonatype closeSonatypeStagingRepository`). The publish is driven by `.github/scripts/portal-publish.sh`:

1. map the closed staging repository → `portal_deployment_id` (`/manual/search/repositories`, Bearer auth);
2. poll `POST /api/v1/publisher/status` until `VALIDATED` (`FAILED` → dump `.errors`, stop);
3. **guard before the irreversible publish** — the deployment's `purls` must carry this release's version and stay inside the namespace (self-release additionally requires the plugin **marker** coordinate);
4. `POST /api/v1/publisher/deployment/<id>`;
5. wait for `PUBLISHED`;
6. **verify every artifact resolves on `repo1.maven.org`** — only then is the tag/GitHub release created.

## Reliability

- **Never blindly re-POST a publish.** Timeouts/5xx *and* late `400/404/409/422` are reconciled against the deployment state (a late 4xx usually means "no longer VALIDATED", i.e. it already went through); only a still-`VALIDATED` deployment is reported deterministic. `401/403` are deterministic; `429` honours `Retry-After`.
- **Classification**: `deterministic` / `transient` / **`resumable`**. Anything that fails once a staging repository exists is `resumable` — never "retry the whole release" — and prints `RELEASE_PUBLISH_COMPAT_KEY` plus the deployment id when it can be mapped. If the staging state cannot be identified at all, the class stays `unknown` and the message explicitly does **not** promise that a re-dispatch is safe.
- **New optional input `resume-deployment-id`** (both workflows): skips the Gradle upload and finishes the existing deployment, so a run that died past the upload never uploads the version twice. Callers must expose it in their own `workflow_dispatch` inputs to use it.
- **Helper pinning**: the reusable workflow runs against the *consumer's* checkout, so it fetches the script from octopus-base at **`job.workflow_sha`** — its own commit — and refuses to continue unless that resolves to a full 40-hex SHA (an empty/non-SHA ref would make `actions/checkout` silently resolve a branch and run an unpinned script). Both steps run *before* anything is staged, so a failure there is a plain retry.
- **Concurrency**: real releases serialize per repository (two overlapping ones would compute and upload the same version); dry runs get a per-run, per-variant key, because a shared group would cancel parallel release-smoke variants (GitHub keeps only one pending member per group).
- **`publish-to-nexus: false` (#164) is preserved**: the whole Portal chain, its Sonatype secrets and the resume input are gated off, so deployable-only repos keep releasing without Central.
- #161's diagnose step also fires on a Portal-stage failure and defers to the script's classification instead of emitting a second one.

## Failure model

| Situation | Action |
|---|---|
| workflow alive | retries transient operations itself |
| died **before** the upload | ordinary re-dispatch |
| died **after** the upload | re-dispatch with `resume-deployment-id=<printed id>` |
| validation / auth error | fix the cause (not a retry) |
| staging state unidentifiable | inspect Compat/Portal state before re-dispatching |
| published but no tag | one-time manual tag restore (automated in follow-up) |

## Verification

- **Live canary** — [octopus-test run 30119636174](https://github.com/octopusden/octopus-test/actions/runs/30119636174): a real consumer shape (group `org.octopusden`, no build-script change) published `org.octopusden:octopus-test:9.9.9` end-to-end — helper pinned to a real SHA, `close` handed the repo off to the Portal on its own, `purls` were already present at `VALIDATED`, publish `204`, `PUBLISHING → PUBLISHED` in ~9.5 min, POM verified on repo1, tag `v9.9.9` created. Independently confirmed: `octopus-test-9.9.9.pom` and `.jar` return HTTP 200 from `repo1.maven.org`. This is the first successful automated release to Maven Central since the breakage.
- **Committed scenario suite** — `.github/scripts/test/portal-publish-scenarios.sh` runs 15 stubbed-Central scenarios in the `workflow-lint` job, covering what cannot be provoked on demand against the live service: `FAILED` validation, inconclusive and late-4xx publishes, wrong/foreign deployment id, missing namespace, nothing staged, two staged repositories, resume-without-upload, required-coordinate guard.
- Workflow YAML, `actionlint` (1.7.7 as pinned in CI and 1.7.12), the naming lint and `bash -n` all pass; the release-smoke matrix in the consumer canary completes with zero cancelled jobs.

## Rollout after merge

1. Self-release → **`2.5.1`** (the first tag carrying this flow; also its first live exercise, gated on the marker POM being resolvable).
2. Move 1–2 pilot consumers to **`v2.5.1`** — never to `v2.5.0` — and watch a real release land on Central.
3. Mass ref-bump the rest once the pilots pass.

## Follow-up (deferred, not P0)

Public `fresh`/`resume`/`restore-tag` modes with a formal input contract, `<scm><tag>` SHA provenance verified before publish, a full publication manifest with a three-way preflight, automatic tag restore, and universal idempotent GitHub tag/release reconciliation. Also #163 (Central publishing limits — this rollout itself spends soft-limit budget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for resuming interrupted releases via a provided deployment ID, skipping re-upload and publishing the existing deployment.
  * Publishing now goes through the Central Portal flow and verifies that released artifacts are resolvable on Maven Central.
  * Added stronger validation to confirm published artifacts match the expected version and required coordinates.

* **Bug Fixes**
  * Prevented overlapping release runs from concurrently publishing the same next version.
  * Improved retry/resume classification and handling of ambiguous publishing responses.

* **Tests / CI**
  * Added offline scenario coverage for the Portal publish process and improved CI lint documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->