### PR TITLE
ci: bump actionlint 1.7.7 → 1.7.12

### DIFF
--- a/.github/workflows/check-octopus-test-consumer.yml
+++ b/.github/workflows/check-octopus-test-consumer.yml
@@ -28,7 +28,7 @@ on:
         description: 'Docker image (with tag) used for actionlint workflow linting'
         required: false
         type: string
-        default: rhysd/actionlint:1.7.7
+        default: rhysd/actionlint:1.7.12
 
 permissions:
   contents: read
@@ -84,17 +84,17 @@ jobs:
     runs-on: ubuntu-latest
     # `pull_request` triggers cannot supply inputs, so default explicitly.
     env:
-      ACTIONLINT_IMAGE: ${{ inputs.actionlint_image || 'rhysd/actionlint:1.7.7' }}
+      ACTIONLINT_IMAGE: ${{ inputs.actionlint_image || 'rhysd/actionlint:1.7.12' }}
     steps:
       - uses: actions/checkout@v4
       # Note on the last -ignore: `job.workflow_sha` is a documented job-context
       # property (the commit SHA of the workflow file defining the current job).
       # common-java-gradle-release.yml uses it to pin its helper script to its own
-      # version. actionlint — including the newest 1.7.12 — still ships an older
-      # job-context type list and
-      # reports it as undefined, so that one message is filtered out. The workflow
-      # additionally fails loudly if the value is ever empty, so the filter cannot
-      # hide a real breakage.
+      # version. Every actionlint release up to the pinned 1.7.12 still ships an
+      # older job-context type list and reports the property as undefined, so that
+      # one message is filtered out. The workflow additionally refuses to run unless
+      # the value is a full commit SHA, so the filter cannot hide a real breakage;
+      # drop the -ignore once actionlint knows the property.
       - name: actionlint
         shell: bash
         run: |


### PR DESCRIPTION
Bumps the pinned `actionlint` image from **1.7.7** (Jan 2025) to **1.7.12** (Mar 2026) — one line in the input default plus the matching env fallback.

## Verified before proposing

The same workflow already accepts an `actionlint_image` input, so the new version was exercised on octopus-base itself first: [run 30122234309](https://github.com/octopusden/octopus-base/actions/runs/30122234309) dispatched with `actionlint_image=rhysd/actionlint:1.7.12` finished `workflow-lint` **success with zero findings** across every workflow, with the existing `-ignore` set unchanged. So the bump is behaviour-neutral for this repository while picking up a year of upstream fixes.

(That run shows a red `gate/merge`, unrelated to actionlint: a `workflow_dispatch` of this workflow without the PR-context inputs makes `consumer-verify` fail — tracked in #167.)

## What it does not fix

The `job.workflow_sha` suppression stays. No actionlint release knows the newer job-context properties — checked 1.7.8, 1.7.10 and 1.7.12, all still report `{container; services; status}` (+`check_run_id` from 1.7.8) and flag the documented property as undefined. The comment next to the `-ignore` is corrected accordingly, including when it can be dropped.

Note the suppression cannot hide a real problem: `common-java-gradle-release.yml` refuses to run unless `job.workflow_sha` resolves to a full 40-hex commit SHA.

## Risk

Low, and this PR self-validates — for `pull_request` the workflow file comes from the PR head, so its own `workflow-lint` job already runs on 1.7.12.

The one thing this cannot prove is other people's open branches: a newer linter may flag genuine issues that 1.7.7 missed. That is the point of upgrading, but it may surprise an in-flight PR, so merge when nobody is mid-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
