### PR TITLE
Fix Release by registering the version that was actually released (not the highest tag)

### DIFF
--- a/.github/scripts/resolve-released-version.sh
+++ b/.github/scripts/resolve-released-version.sh
@@ -6,6 +6,7 @@
 # Environment:
 #   EXPLICIT_VERSION  version supplied by the caller; wins when set (leading "v" ok)
 #   RELEASE_RUN_ID    id of the triggering release run
+#   RELEASE_RUN_ATTEMPT attempt number of that run
 #   RELEASE_RUN_SHA   commit reported for the triggering release run
 #   GITHUB_REPOSITORY owner/repo, used for the release lookups
 #   GH_TOKEN          token for those lookups
@@ -14,9 +15,11 @@
 #
 #   1. What the caller says. The release workflow knows the version it built, so when
 #      it registers directly there is nothing to infer.
-#   2. The release stamped with the triggering run's id. The release workflow writes
-#      "octopus-release-run: <id>" into the release body precisely so this step exists:
-#      it is the only identity that cannot drift.
+#   2. The release stamped with the triggering run's id and attempt. The release
+#      workflow writes that marker into the release body precisely so this step exists:
+#      it is the only identity that cannot drift. The attempt matters because a rerun
+#      keeps the run id while the public flow recomputes the version, so id alone would
+#      match two different releases.
 #   3. The single version tag on the commit the run reports. Correct only when that
 #      commit carries exactly one version tag.
 #   4. The most recently created release. Last resort, for a release made before the
@@ -38,6 +41,7 @@ set -euo pipefail
 
 EXPLICIT_VERSION="${EXPLICIT_VERSION:-}"
 RELEASE_RUN_ID="${RELEASE_RUN_ID:-}"
+RELEASE_RUN_ATTEMPT="${RELEASE_RUN_ATTEMPT:-}"
 RELEASE_RUN_SHA="${RELEASE_RUN_SHA:-}"
 GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-}"
 
@@ -61,18 +65,22 @@ if [ -n "$EXPLICIT_VERSION" ]; then
 fi
 
 # Source 2: the release this very run stamped.
-if [ -n "$RELEASE_RUN_ID" ] && [ -n "$GITHUB_REPOSITORY" ]; then
-  marker="octopus-release-run: ${RELEASE_RUN_ID}"
+if [ -n "$RELEASE_RUN_ID" ] && [ -z "$RELEASE_RUN_ATTEMPT" ]; then
+  note "Run ${RELEASE_RUN_ID} was given without an attempt number, so its stamp cannot be addressed; falling back."
+fi
+if [ -n "$RELEASE_RUN_ID" ] && [ -n "$RELEASE_RUN_ATTEMPT" ] && [ -n "$GITHUB_REPOSITORY" ]; then
+  # Delimited so one run's marker cannot be a prefix of another's (555/1 vs 555/10).
+  marker="<!-- octopus-release-run: ${RELEASE_RUN_ID}/${RELEASE_RUN_ATTEMPT} -->"
   stamped="$(gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=50" \
     --jq "map(select((.body // \"\") | contains(\"${marker}\"))) | first | .tag_name // empty" 2>/dev/null || true)"
   if [ -n "$stamped" ] && [ "$stamped" != "null" ]; then
     version="${stamped#v}"
     if grep -qE "$SEMVER" <<<"$version"; then
-      note "Resolved from the release stamped with run ${RELEASE_RUN_ID}."
+      note "Resolved from the release stamped with run ${RELEASE_RUN_ID}, attempt ${RELEASE_RUN_ATTEMPT}."
       printf '%s\n' "$version"
       exit 0
     fi
-    note "The release stamped with run ${RELEASE_RUN_ID} is tagged '$stamped', which is not a version number."
+    note "The release stamped with run ${RELEASE_RUN_ID}/${RELEASE_RUN_ATTEMPT} is tagged '$stamped', which is not a version number."
   else
     note "No release carries this run's stamp; it predates the stamping step, so falling back."
   fi

--- a/.github/scripts/resolve-released-version.sh
+++ b/.github/scripts/resolve-released-version.sh
@@ -5,31 +5,39 @@
 #
 # Environment:
 #   EXPLICIT_VERSION  version supplied by the caller; wins when set (leading "v" ok)
+#   RELEASE_RUN_ID    id of the triggering release run
 #   RELEASE_RUN_SHA   commit reported for the triggering release run
-#   GITHUB_REPOSITORY owner/repo, used for the release lookup
-#   GH_TOKEN          token for that lookup
+#   GITHUB_REPOSITORY owner/repo, used for the release lookups
+#   GH_TOKEN          token for those lookups
 #
-# Three sources, in order of how much they can be trusted:
+# Four sources, in order of how tightly each is bound to the run being registered:
 #
 #   1. What the caller says. The release workflow knows the version it built, so when
 #      it registers directly there is nothing to infer.
-#   2. The version tag on the commit the release run reports. Precise when it yields
-#      exactly one candidate.
-#   3. The most recently created release in the repository. Needed because neither of
-#      the above always holds: for a repository_dispatch run, the reported commit is
-#      the default branch tip at dispatch time, while a hybrid-flow release tags the
-#      commit it was told to build; and a commit can carry several version tags —
-#      octopus-test has two on one commit today.
+#   2. The release stamped with the triggering run's id. The release workflow writes
+#      "octopus-release-run: <id>" into the release body precisely so this step exists:
+#      it is the only identity that cannot drift.
+#   3. The single version tag on the commit the run reports. Correct only when that
+#      commit carries exactly one version tag.
+#   4. The most recently created release. Last resort, for a release made before the
+#      stamp existed.
+#
+# Why 3 and 4 are not enough on their own — both can name a version another run
+# released: a commit accumulates a tag per release cut from it (octopus-test has three
+# such pairs in its last ten releases), and "the newest release" can advance while this
+# job sits in the queue. They stay as fallbacks so releases published by an earlier
+# version of the release workflow can still be registered, and each says in the log
+# which source answered.
 #
 # What is deliberately NOT used: the highest version tag in the repository. That was
 # the previous implementation, and it is wrong by construction — it answers "which tag
 # sorts highest", not "what did this run release". A leftover canary tag v9.9.9 thereby
 # hijacked a real 2.2.37 release: the log recorded 9.9.9, post-processing ran for
-# 9.9.9, and the component's stored latest version became 9.9.9. Sorting by creation
-# time instead of by version number is what makes source 3 safe against that.
+# 9.9.9, and the component's stored latest version became 9.9.9.
 set -euo pipefail
 
 EXPLICIT_VERSION="${EXPLICIT_VERSION:-}"
+RELEASE_RUN_ID="${RELEASE_RUN_ID:-}"
 RELEASE_RUN_SHA="${RELEASE_RUN_SHA:-}"
 GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-}"
 
@@ -52,7 +60,25 @@ if [ -n "$EXPLICIT_VERSION" ]; then
   exit 0
 fi
 
-# Source 2: version tags on the reported commit.
+# Source 2: the release this very run stamped.
+if [ -n "$RELEASE_RUN_ID" ] && [ -n "$GITHUB_REPOSITORY" ]; then
+  marker="octopus-release-run: ${RELEASE_RUN_ID}"
+  stamped="$(gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=50" \
+    --jq "map(select((.body // \"\") | contains(\"${marker}\"))) | first | .tag_name // empty" 2>/dev/null || true)"
+  if [ -n "$stamped" ] && [ "$stamped" != "null" ]; then
+    version="${stamped#v}"
+    if grep -qE "$SEMVER" <<<"$version"; then
+      note "Resolved from the release stamped with run ${RELEASE_RUN_ID}."
+      printf '%s\n' "$version"
+      exit 0
+    fi
+    note "The release stamped with run ${RELEASE_RUN_ID} is tagged '$stamped', which is not a version number."
+  else
+    note "No release carries this run's stamp; it predates the stamping step, so falling back."
+  fi
+fi
+
+# Source 3: version tags on the reported commit.
 candidates=()
 if [ -n "$RELEASE_RUN_SHA" ]; then
   while IFS= read -r tag; do
@@ -75,7 +101,7 @@ else
   note "No version tag on ${RELEASE_RUN_SHA:-<no commit reported>}; the release was probably cut from another commit."
 fi
 
-# Source 3: the most recently created release.
+# Source 4: the most recently created release.
 [ -n "$GITHUB_REPOSITORY" ] || die "Cannot look up the latest release: the repository is unknown. Pass release-version explicitly."
 
 latest_tag="$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq '.tag_name' 2>/dev/null || true)"

--- a/.github/scripts/resolve-released-version.sh
+++ b/.github/scripts/resolve-released-version.sh
@@ -1,52 +1,90 @@
 #!/usr/bin/env bash
-# Resolves the version that a release run actually published, for registration in
-# the release log. Prints the bare version (no leading "v") on stdout.
+# Resolves the version that a release run published, for registration in the release
+# log. Prints the bare version (no leading "v") on stdout; explains its reasoning on
+# stderr.
 #
 # Environment:
 #   EXPLICIT_VERSION  version supplied by the caller; wins when set (leading "v" ok)
-#   RELEASE_RUN_SHA   the commit the triggering release run built
+#   RELEASE_RUN_SHA   commit reported for the triggering release run
+#   GITHUB_REPOSITORY owner/repo, used for the release lookup
+#   GH_TOKEN          token for that lookup
 #
-# Why not "the highest version tag in the repository", which this replaces: that
-# picks whichever tag sorts highest, related to this release or not. It happened —
-# a leftover canary tag v9.9.9 outranked a real 2.2.37 release, so the release log
-# recorded 9.9.9, and the downstream post-processing then set the component's
-# "latest released version" to 9.9.9 as well. The release run tags the commit it
-# built, so the version tag on that commit is the one thing that cannot belong to
-# another release.
+# Three sources, in order of how much they can be trusted:
+#
+#   1. What the caller says. The release workflow knows the version it built, so when
+#      it registers directly there is nothing to infer.
+#   2. The version tag on the commit the release run reports. Precise when it yields
+#      exactly one candidate.
+#   3. The most recently created release in the repository. Needed because neither of
+#      the above always holds: for a repository_dispatch run, the reported commit is
+#      the default branch tip at dispatch time, while a hybrid-flow release tags the
+#      commit it was told to build; and a commit can carry several version tags —
+#      octopus-test has two on one commit today.
+#
+# What is deliberately NOT used: the highest version tag in the repository. That was
+# the previous implementation, and it is wrong by construction — it answers "which tag
+# sorts highest", not "what did this run release". A leftover canary tag v9.9.9 thereby
+# hijacked a real 2.2.37 release: the log recorded 9.9.9, post-processing ran for
+# 9.9.9, and the component's stored latest version became 9.9.9. Sorting by creation
+# time instead of by version number is what makes source 3 safe against that.
 set -euo pipefail
 
 EXPLICIT_VERSION="${EXPLICIT_VERSION:-}"
 RELEASE_RUN_SHA="${RELEASE_RUN_SHA:-}"
+GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-}"
+
+SEMVER='^[0-9]+\.[0-9]+\.[0-9]+$'
 
 die() {
   echo "$*" >&2
   exit 1
 }
 
+note() {
+  echo "$*" >&2
+}
+
 if [ -n "$EXPLICIT_VERSION" ]; then
-  printf '%s\n' "${EXPLICIT_VERSION#v}"
+  version="${EXPLICIT_VERSION#v}"
+  grep -qE "$SEMVER" <<<"$version" || die "The supplied release version is not a version number: '$EXPLICIT_VERSION'."
+  note "Version supplied by the caller."
+  printf '%s\n' "$version"
   exit 0
 fi
 
-[ -n "$RELEASE_RUN_SHA" ] || die \
-  "Neither a release version nor a release commit was given, so the published version cannot be determined. Pass release-version explicitly."
-
+# Source 2: version tags on the reported commit.
 candidates=()
-while IFS= read -r tag; do
-  [ -n "$tag" ] || continue
-  candidates+=("${tag#v}")
-done < <(git tag --points-at "$RELEASE_RUN_SHA" 2>/dev/null \
-  | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
-  | sort -u)
+if [ -n "$RELEASE_RUN_SHA" ]; then
+  while IFS= read -r tag; do
+    [ -n "$tag" ] || continue
+    candidates+=("${tag#v}")
+  done < <(git tag --points-at "$RELEASE_RUN_SHA" 2>/dev/null \
+    | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$" \
+    | sort -u)
+fi
 
-case "${#candidates[@]}" in
-  0)
-    die "No vX.Y.Z tag points at $RELEASE_RUN_SHA. That run published no release, so there is nothing to register — refusing to guess from other tags in the repository."
-    ;;
-  1)
-    printf '%s\n' "${candidates[0]}"
-    ;;
-  *)
-    die "Several version tags point at $RELEASE_RUN_SHA: ${candidates[*]}. Pass release-version explicitly to say which one to register."
-    ;;
-esac
+if [ "${#candidates[@]}" -eq 1 ]; then
+  note "Resolved from the only version tag on $RELEASE_RUN_SHA."
+  printf '%s\n' "${candidates[0]}"
+  exit 0
+fi
+
+if [ "${#candidates[@]}" -gt 1 ]; then
+  note "Commit $RELEASE_RUN_SHA carries several version tags (${candidates[*]}), so it cannot say which one this run released."
+else
+  note "No version tag on ${RELEASE_RUN_SHA:-<no commit reported>}; the release was probably cut from another commit."
+fi
+
+# Source 3: the most recently created release.
+[ -n "$GITHUB_REPOSITORY" ] || die "Cannot look up the latest release: the repository is unknown. Pass release-version explicitly."
+
+latest_tag="$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq '.tag_name' 2>/dev/null || true)"
+[ -n "$latest_tag" ] && [ "$latest_tag" != "null" ] \
+  || die "Could not determine the released version: no version tag on the reported commit and the latest release could not be read. Pass release-version explicitly."
+
+version="${latest_tag#v}"
+grep -qE "$SEMVER" <<<"$version" \
+  || die "The latest release is tagged '$latest_tag', which is not a plain version number, so it cannot be registered. Pass release-version explicitly."
+
+note "Resolved from the most recently created release ($latest_tag)."
+printf '%s\n' "$version"

--- a/.github/scripts/resolve-released-version.sh
+++ b/.github/scripts/resolve-released-version.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Resolves the version that a release run actually published, for registration in
+# the release log. Prints the bare version (no leading "v") on stdout.
+#
+# Environment:
+#   EXPLICIT_VERSION  version supplied by the caller; wins when set (leading "v" ok)
+#   RELEASE_RUN_SHA   the commit the triggering release run built
+#
+# Why not "the highest version tag in the repository", which this replaces: that
+# picks whichever tag sorts highest, related to this release or not. It happened —
+# a leftover canary tag v9.9.9 outranked a real 2.2.37 release, so the release log
+# recorded 9.9.9, and the downstream post-processing then set the component's
+# "latest released version" to 9.9.9 as well. The release run tags the commit it
+# built, so the version tag on that commit is the one thing that cannot belong to
+# another release.
+set -euo pipefail
+
+EXPLICIT_VERSION="${EXPLICIT_VERSION:-}"
+RELEASE_RUN_SHA="${RELEASE_RUN_SHA:-}"
+
+die() {
+  echo "$*" >&2
+  exit 1
+}
+
+if [ -n "$EXPLICIT_VERSION" ]; then
+  printf '%s\n' "${EXPLICIT_VERSION#v}"
+  exit 0
+fi
+
+[ -n "$RELEASE_RUN_SHA" ] || die \
+  "Neither a release version nor a release commit was given, so the published version cannot be determined. Pass release-version explicitly."
+
+candidates=()
+while IFS= read -r tag; do
+  [ -n "$tag" ] || continue
+  candidates+=("${tag#v}")
+done < <(git tag --points-at "$RELEASE_RUN_SHA" 2>/dev/null \
+  | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+  | sort -u)
+
+case "${#candidates[@]}" in
+  0)
+    die "No vX.Y.Z tag points at $RELEASE_RUN_SHA. That run published no release, so there is nothing to register — refusing to guess from other tags in the repository."
+    ;;
+  1)
+    printf '%s\n' "${candidates[0]}"
+    ;;
+  *)
+    die "Several version tags point at $RELEASE_RUN_SHA: ${candidates[*]}. Pass release-version explicitly to say which one to register."
+    ;;
+esac

--- a/.github/scripts/test/gh
+++ b/.github/scripts/test/gh
@@ -2,9 +2,26 @@
 # Fake gh for resolve-released-version.sh tests. Only the one call the script makes is
 # answered; anything else is a test bug and fails loudly.
 #
+#   STAMPED_RELEASE_TAG  tag of the release that carries a run stamp
+#   STAMPED_FOR_RUN      run id that stamp belongs to; a query about any other run
+#                        gets nothing, so a script that ignores the run id cannot pass
 #   LATEST_RELEASE_TAG   tag_name to report for repos/<repo>/releases/latest
-#   LATEST_RELEASE_FAILS  when non-empty, behave like a failed API call
+#   LATEST_RELEASE_FAILS when non-empty, behave like a failed API call
 set -u
+
+if [ "${1:-}" = "api" ] && [[ "${2:-}" == repos/*/releases\?per_page=* ]]; then
+  if [ -n "${LATEST_RELEASE_FAILS:-}" ]; then
+    echo "gh: could not list releases" >&2
+    exit 1
+  fi
+  # The script embeds the marker it is looking for in the jq filter; only answer when
+  # that marker names the run these fixtures belong to.
+  if [ -n "${STAMPED_RELEASE_TAG:-}" ] && [ -n "${STAMPED_FOR_RUN:-}" ] \
+     && [[ "$*" == *"octopus-release-run: ${STAMPED_FOR_RUN}"* ]]; then
+    printf '%s\n' "$STAMPED_RELEASE_TAG"
+  fi
+  exit 0
+fi
 
 if [ "${1:-}" = "api" ] && [[ "${2:-}" == repos/*/releases/latest ]]; then
   if [ -n "${LATEST_RELEASE_FAILS:-}" ]; then

--- a/.github/scripts/test/gh
+++ b/.github/scripts/test/gh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Fake gh for resolve-released-version.sh tests. Only the one call the script makes is
+# answered; anything else is a test bug and fails loudly.
+#
+#   LATEST_RELEASE_TAG   tag_name to report for repos/<repo>/releases/latest
+#   LATEST_RELEASE_FAILS  when non-empty, behave like a failed API call
+set -u
+
+if [ "${1:-}" = "api" ] && [[ "${2:-}" == repos/*/releases/latest ]]; then
+  if [ -n "${LATEST_RELEASE_FAILS:-}" ]; then
+    echo "gh: could not read the latest release" >&2
+    exit 1
+  fi
+  printf '%s\n' "${LATEST_RELEASE_TAG:-null}"
+  exit 0
+fi
+
+echo "stub gh: unexpected invocation: $*" >&2
+exit 99

--- a/.github/scripts/test/gh
+++ b/.github/scripts/test/gh
@@ -3,8 +3,9 @@
 # answered; anything else is a test bug and fails loudly.
 #
 #   STAMPED_RELEASE_TAG  tag of the release that carries a run stamp
-#   STAMPED_FOR_RUN      run id that stamp belongs to; a query about any other run
-#                        gets nothing, so a script that ignores the run id cannot pass
+#   STAMPED_FOR_RUN      run id/attempt that stamp belongs to, e.g. 555/1; a query about
+#                        any other run or attempt gets nothing, so a script that ignores
+#                        either cannot pass
 #   LATEST_RELEASE_TAG   tag_name to report for repos/<repo>/releases/latest
 #   LATEST_RELEASE_FAILS when non-empty, behave like a failed API call
 set -u

--- a/.github/scripts/test/git
+++ b/.github/scripts/test/git
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Fake git for resolve-released-version.sh tests. Only the one command the script
+# uses is answered; anything else is a test bug and fails loudly.
+#
+#   TAGS_AT_SHA   tags reported for the requested commit (space-separated)
+#   ALL_TAGS      every tag in the "repository" — present only to prove the script
+#                 never consults it (that habit is what caused the bug)
+set -u
+
+if [ "${1:-}" = "tag" ] && [ "${2:-}" = "--points-at" ]; then
+  for tag in ${TAGS_AT_SHA:-}; do
+    printf '%s\n' "$tag"
+  done
+  exit 0
+fi
+
+echo "stub git: unexpected invocation: $*" >&2
+exit 99

--- a/.github/scripts/test/git
+++ b/.github/scripts/test/git
@@ -2,12 +2,19 @@
 # Fake git for resolve-released-version.sh tests. Only the one command the script
 # uses is answered; anything else is a test bug and fails loudly.
 #
-#   TAGS_AT_SHA   tags reported for the requested commit (space-separated)
-#   ALL_TAGS      every tag in the "repository" — present only to prove the script
-#                 never consults it (that habit is what caused the bug)
+#   TAGS_AT_SHA   tags to report (space-separated)
+#   TAGS_FOR_SHA  the commit those tags belong to; querying any other commit is a
+#                 failure, so a script that asks about HEAD instead of the commit the
+#                 release run reported cannot pass
 set -u
 
 if [ "${1:-}" = "tag" ] && [ "${2:-}" = "--points-at" ]; then
+  queried="${3:-}"
+  expected="${TAGS_FOR_SHA:-}"
+  if [ -n "$expected" ] && [ "$queried" != "$expected" ]; then
+    echo "stub git: asked about '$queried' but the tags belong to '$expected'" >&2
+    exit 98
+  fi
   for tag in ${TAGS_AT_SHA:-}; do
     printf '%s\n' "$tag"
   done

--- a/.github/scripts/test/resolve-released-version-scenarios.sh
+++ b/.github/scripts/test/resolve-released-version-scenarios.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 # Scenarios for resolve-released-version.sh.
 #
-# git is replaced by the stub next to this file (put on PATH), so tag layouts that
-# would need a crafted repository — several version tags on one commit, a higher
-# unrelated tag elsewhere — are exercised directly.
+# git and gh are replaced by the stubs next to this file (put on PATH), so tag layouts
+# that would otherwise need a crafted repository — several version tags on one commit, a
+# higher unrelated tag elsewhere, a release cut from a commit the run never reported —
+# are exercised directly. Each stub answers exactly one invocation and exits 99 on
+# anything else, so a future change that reaches for the full tag list, or for another
+# API call, fails this suite instead of passing quietly.
 set -uo pipefail
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -12,7 +15,7 @@ script="$here/../resolve-released-version.sh"
 failures=0
 checks=0
 
-run() { # name expected_status expected_output env...
+run() { # name expected_status expected_output_regex env...
   local name="$1" want_status="$2" want_out="$3"
   shift 3
   checks=$((checks + 1))
@@ -34,36 +37,51 @@ run() { # name expected_status expected_output env...
   echo "ok   [$name]"
 }
 
-# An explicit version always wins, with or without the tag prefix.
-run 'explicit version' 0 '^2\.5\.2$' EXPLICIT_VERSION=2.5.2 TAGS_AT_SHA='v1.0.0'
-run 'explicit version with v prefix' 0 '^2\.5\.2$' EXPLICIT_VERSION=v2.5.2 TAGS_AT_SHA=''
+common=(GITHUB_REPOSITORY=octopusden/octopus-test GH_TOKEN=stub)
 
-# The normal path: exactly one version tag on the commit the release run built.
-run 'single tag on the release commit' 0 '^2\.2\.37$' \
-  RELEASE_RUN_SHA=178e83a0 TAGS_AT_SHA='v2.2.37'
+# Source 1 — what the caller says, with or without the tag prefix.
+run 'explicit version' 0 '2\.5\.2' EXPLICIT_VERSION=2.5.2 TAGS_AT_SHA='v1.0.0' "${common[@]}"
+run 'explicit version with v prefix' 0 '2\.5\.2' EXPLICIT_VERSION=v2.5.2 TAGS_AT_SHA='' "${common[@]}"
+run 'explicit garbage is rejected' 1 'not a version number' EXPLICIT_VERSION=latest "${common[@]}"
 
-# The regression this replaced: a higher tag exists in the repository but points at
-# a different commit, so it must not be picked. ALL_TAGS is deliberately populated
-# with it — the stub fails the test if the script ever reads it.
-run 'higher unrelated tag is ignored' 0 '^2\.2\.37$' \
-  RELEASE_RUN_SHA=178e83a0 TAGS_AT_SHA='v2.2.37' ALL_TAGS='v9.9.9 v2.2.37'
+# Source 2 — exactly one version tag on the commit the run reported.
+run 'single tag on the reported commit' 0 '2\.2\.37' \
+  RELEASE_RUN_SHA=178e83a0 TAGS_AT_SHA='v2.2.37' "${common[@]}"
+run 'non-semver tags are not candidates' 0 '2\.2\.37' \
+  RELEASE_RUN_SHA=178e83a0 TAGS_AT_SHA='latest v9.9.9-pr99 v2.2.37 release-2' "${common[@]}"
 
-# Non-semver tags on the same commit are not candidates.
-run 'non-semver tags filtered out' 0 '^2\.2\.37$' \
-  RELEASE_RUN_SHA=178e83a0 TAGS_AT_SHA='latest v9.9.9-pr99 v2.2.37 release-2'
+# The bug this replaced: a higher tag exists elsewhere in the repository. It must never
+# win — not through the tag list (the stub rejects any call that asks for it) and not
+# through the latest release, which is ordered by creation time, so an older canary
+# loses to a newer real release.
+run 'higher unrelated tag never wins' 0 '2\.2\.37' \
+  RELEASE_RUN_SHA=178e83a0 TAGS_AT_SHA='v2.2.37' LATEST_RELEASE_TAG=v9.9.9 "${common[@]}"
 
-# Nothing was released from that commit: refuse rather than register a guess.
-run 'no version tag on the commit' 1 'No vX\.Y\.Z tag points at' \
-  RELEASE_RUN_SHA=deadbeef TAGS_AT_SHA='latest nightly'
+# Source 3 — the reported commit cannot answer, so fall back to the newest release. This
+# is the hybrid-flow case: the run reports the default branch tip while the release was
+# cut from, and tagged on, a different commit.
+run 'no tag on the reported commit falls back' 0 '2\.2\.37' \
+  RELEASE_RUN_SHA=deadbeef TAGS_AT_SHA='' LATEST_RELEASE_TAG=v2.2.37 "${common[@]}"
+run 'several tags on one commit fall back' 0 '2\.2\.36' \
+  RELEASE_RUN_SHA=cdfdd24d TAGS_AT_SHA='v2.2.35 v2.2.36' LATEST_RELEASE_TAG=v2.2.36 "${common[@]}"
+run 'fallback explains itself' 0 'most recently created release' \
+  RELEASE_RUN_SHA=deadbeef TAGS_AT_SHA='' LATEST_RELEASE_TAG=v2.2.37 "${common[@]}"
 
-# Ambiguity must be surfaced, not resolved silently.
-run 'several version tags on one commit' 1 'Several version tags point at' \
-  RELEASE_RUN_SHA=178e83a0 TAGS_AT_SHA='v2.2.37 v2.3.0'
-
-# Called outside a release-run context and without an explicit version.
-run 'no inputs at all' 1 'cannot be determined' TAGS_AT_SHA='v2.2.37'
+# Nothing can answer: fail with something actionable rather than registering a guess.
+run 'no tag and no readable release' 1 'Pass release-version explicitly' \
+  RELEASE_RUN_SHA=deadbeef TAGS_AT_SHA='' LATEST_RELEASE_FAILS=1 "${common[@]}"
+run 'no tag and no release at all' 1 'Pass release-version explicitly' \
+  RELEASE_RUN_SHA=deadbeef TAGS_AT_SHA='' LATEST_RELEASE_TAG=null "${common[@]}"
+run 'latest release is not a version tag' 1 'not a plain version number' \
+  RELEASE_RUN_SHA=deadbeef TAGS_AT_SHA='' LATEST_RELEASE_TAG=nightly-2026-07-27 "${common[@]}"
+run 'no repository to look up' 1 'repository is unknown' \
+  RELEASE_RUN_SHA=deadbeef TAGS_AT_SHA='' GH_TOKEN=stub
 
 echo
+if [ "$checks" -eq 0 ]; then
+  echo "No scenarios ran — the suite would have passed vacuously." >&2
+  exit 1
+fi
 if [ "$failures" -eq 0 ]; then
   echo "All $checks scenarios passed."
 else

--- a/.github/scripts/test/resolve-released-version-scenarios.sh
+++ b/.github/scripts/test/resolve-released-version-scenarios.sh
@@ -36,8 +36,9 @@ run() { # name expected_status expected_stdout_or_stderr_regex [stderr_regex] en
   # GitHub Actions sets GITHUB_REPOSITORY, which silently defeated the scenario that
   # checks behaviour when the repository is unknown — it passed locally and failed in CI.
   PATH="$here:$PATH" env \
-    EXPLICIT_VERSION= RELEASE_RUN_SHA= GITHUB_REPOSITORY= GH_TOKEN= \
+    EXPLICIT_VERSION= RELEASE_RUN_ID= RELEASE_RUN_SHA= GITHUB_REPOSITORY= GH_TOKEN= \
     TAGS_AT_SHA= TAGS_FOR_SHA= LATEST_RELEASE_TAG= LATEST_RELEASE_FAILS= \
+    STAMPED_RELEASE_TAG= STAMPED_FOR_RUN= \
     "$@" bash "$script" >"$outfile" 2>"$errfile"
   status=$?
   out="$(cat "$outfile")"
@@ -79,7 +80,17 @@ run 'explicit version' 0 '2.5.2' EXPLICIT_VERSION=2.5.2 TAGS_AT_SHA='v1.0.0' "${
 run 'explicit version with v prefix' 0 '2.5.2' EXPLICIT_VERSION=v2.5.2 TAGS_AT_SHA='' "${common[@]}"
 run 'explicit garbage is rejected' 1 'not a version number' EXPLICIT_VERSION=latest "${common[@]}"
 
-# Source 2 — exactly one version tag on the commit the run reported.
+# Source 2 — the release stamped with this run's id: exact, and it wins over both
+# fallbacks even when they would answer differently.
+run 'release stamped with this run' 0 '2.2.38' 'stamped with run 555' \
+  RELEASE_RUN_ID=555 STAMPED_FOR_RUN=555 STAMPED_RELEASE_TAG=v2.2.38 \
+  RELEASE_RUN_SHA=cdfdd24d TAGS_FOR_SHA=cdfdd24d TAGS_AT_SHA='v2.2.37' \
+  LATEST_RELEASE_TAG=v9.9.9 "${common[@]}"
+run 'a stamp for another run is ignored' 0 '2.2.37' 'predates the stamping step' \
+  RELEASE_RUN_ID=777 STAMPED_FOR_RUN=555 STAMPED_RELEASE_TAG=v2.2.38 \
+  RELEASE_RUN_SHA=178e83a0 TAGS_FOR_SHA=178e83a0 TAGS_AT_SHA='v2.2.37' "${common[@]}"
+
+# Source 3 — exactly one version tag on the commit the run reported.
 run 'single tag on the reported commit' 0 '2.2.37' 'only version tag' \
   RELEASE_RUN_SHA=178e83a0 TAGS_FOR_SHA=178e83a0 TAGS_AT_SHA='v2.2.37' "${common[@]}"
 run 'non-semver tags are not candidates' 0 '2.2.37' \
@@ -92,7 +103,8 @@ run 'non-semver tags are not candidates' 0 '2.2.37' \
 run 'higher unrelated tag never wins' 0 '2.2.37' \
   RELEASE_RUN_SHA=178e83a0 TAGS_FOR_SHA=178e83a0 TAGS_AT_SHA='v2.2.37' LATEST_RELEASE_TAG=v9.9.9 "${common[@]}"
 
-# Source 3 — the reported commit cannot answer, so fall back to the newest release. This
+# Source 4 — the reported commit cannot answer either, so fall back to the newest
+# release. This
 # is the hybrid-flow case: the run reports the default branch tip while the release was
 # cut from, and tagged on, a different commit.
 run 'no tag on the reported commit falls back' 0 '2.2.37' \

--- a/.github/scripts/test/resolve-released-version-scenarios.sh
+++ b/.github/scripts/test/resolve-released-version-scenarios.sh
@@ -15,22 +15,57 @@ script="$here/../resolve-released-version.sh"
 failures=0
 checks=0
 
-run() { # name expected_status expected_output_regex env...
-  local name="$1" want_status="$2" want_out="$3"
+# On success, stdout is compared EXACTLY: the workflow assigns it to a step output,
+# which is a single line, so anything the helper adds to stdout would be silently
+# truncated into the registered version. On failure, stdout must be empty and the
+# reason is matched against stderr.
+run() { # name expected_status expected_stdout_or_stderr_regex [stderr_regex] env...
+  local name="$1" want_status="$2" want_main="$3"
   shift 3
-  checks=$((checks + 1))
-  local out status
-  out="$(PATH="$here:$PATH" env "$@" bash "$script" 2>&1)"
-  status=$?
-  if [ "$status" -ne "$want_status" ]; then
-    echo "FAIL [$name]: expected exit $want_status, got $status"
-    echo "       output: $out"
-    failures=$((failures + 1))
-    return
+  local want_err=""
+  if [ "${1:-}" != "" ] && [[ "$1" != *=* ]]; then
+    want_err="$1"
+    shift
   fi
-  if ! grep -qE "$want_out" <<<"$out"; then
-    echo "FAIL [$name]: output did not match /$want_out/"
-    echo "       output: $out"
+  checks=$((checks + 1))
+  local outfile errfile out err status
+  outfile="$(mktemp)"
+  errfile="$(mktemp)"
+  # Blank every variable the script or the stubs read before applying the scenario's
+  # own values (later assignments win). Without this the ambient environment leaks in:
+  # GitHub Actions sets GITHUB_REPOSITORY, which silently defeated the scenario that
+  # checks behaviour when the repository is unknown — it passed locally and failed in CI.
+  PATH="$here:$PATH" env \
+    EXPLICIT_VERSION= RELEASE_RUN_SHA= GITHUB_REPOSITORY= GH_TOKEN= \
+    TAGS_AT_SHA= TAGS_FOR_SHA= LATEST_RELEASE_TAG= LATEST_RELEASE_FAILS= \
+    "$@" bash "$script" >"$outfile" 2>"$errfile"
+  status=$?
+  out="$(cat "$outfile")"
+  err="$(cat "$errfile")"
+  rm -f "$outfile" "$errfile"
+
+  local problem=""
+  if [ "$status" -ne "$want_status" ]; then
+    problem="expected exit $want_status, got $status"
+  elif [ "$want_status" -eq 0 ]; then
+    if [ "$out" != "$want_main" ]; then
+      problem="stdout was not exactly '$want_main'"
+    fi
+  else
+    if [ -n "$out" ]; then
+      problem="a failing run must print nothing to stdout"
+    elif ! grep -qE "$want_main" <<<"$err"; then
+      problem="stderr did not match /$want_main/"
+    fi
+  fi
+  if [ -z "$problem" ] && [ -n "$want_err" ] && ! grep -qE "$want_err" <<<"$err"; then
+    problem="stderr did not match /$want_err/"
+  fi
+
+  if [ -n "$problem" ]; then
+    echo "FAIL [$name]: $problem"
+    echo "       stdout: $out"
+    echo "       stderr: $err"
     failures=$((failures + 1))
     return
   fi
@@ -40,32 +75,32 @@ run() { # name expected_status expected_output_regex env...
 common=(GITHUB_REPOSITORY=octopusden/octopus-test GH_TOKEN=stub)
 
 # Source 1 — what the caller says, with or without the tag prefix.
-run 'explicit version' 0 '2\.5\.2' EXPLICIT_VERSION=2.5.2 TAGS_AT_SHA='v1.0.0' "${common[@]}"
-run 'explicit version with v prefix' 0 '2\.5\.2' EXPLICIT_VERSION=v2.5.2 TAGS_AT_SHA='' "${common[@]}"
+run 'explicit version' 0 '2.5.2' EXPLICIT_VERSION=2.5.2 TAGS_AT_SHA='v1.0.0' "${common[@]}"
+run 'explicit version with v prefix' 0 '2.5.2' EXPLICIT_VERSION=v2.5.2 TAGS_AT_SHA='' "${common[@]}"
 run 'explicit garbage is rejected' 1 'not a version number' EXPLICIT_VERSION=latest "${common[@]}"
 
 # Source 2 — exactly one version tag on the commit the run reported.
-run 'single tag on the reported commit' 0 '2\.2\.37' \
-  RELEASE_RUN_SHA=178e83a0 TAGS_AT_SHA='v2.2.37' "${common[@]}"
-run 'non-semver tags are not candidates' 0 '2\.2\.37' \
-  RELEASE_RUN_SHA=178e83a0 TAGS_AT_SHA='latest v9.9.9-pr99 v2.2.37 release-2' "${common[@]}"
+run 'single tag on the reported commit' 0 '2.2.37' 'only version tag' \
+  RELEASE_RUN_SHA=178e83a0 TAGS_FOR_SHA=178e83a0 TAGS_AT_SHA='v2.2.37' "${common[@]}"
+run 'non-semver tags are not candidates' 0 '2.2.37' \
+  RELEASE_RUN_SHA=178e83a0 TAGS_FOR_SHA=178e83a0 TAGS_AT_SHA='latest v9.9.9-pr99 v2.2.37 release-2' "${common[@]}"
 
 # The bug this replaced: a higher tag exists elsewhere in the repository. It must never
 # win — not through the tag list (the stub rejects any call that asks for it) and not
 # through the latest release, which is ordered by creation time, so an older canary
 # loses to a newer real release.
-run 'higher unrelated tag never wins' 0 '2\.2\.37' \
-  RELEASE_RUN_SHA=178e83a0 TAGS_AT_SHA='v2.2.37' LATEST_RELEASE_TAG=v9.9.9 "${common[@]}"
+run 'higher unrelated tag never wins' 0 '2.2.37' \
+  RELEASE_RUN_SHA=178e83a0 TAGS_FOR_SHA=178e83a0 TAGS_AT_SHA='v2.2.37' LATEST_RELEASE_TAG=v9.9.9 "${common[@]}"
 
 # Source 3 — the reported commit cannot answer, so fall back to the newest release. This
 # is the hybrid-flow case: the run reports the default branch tip while the release was
 # cut from, and tagged on, a different commit.
-run 'no tag on the reported commit falls back' 0 '2\.2\.37' \
-  RELEASE_RUN_SHA=deadbeef TAGS_AT_SHA='' LATEST_RELEASE_TAG=v2.2.37 "${common[@]}"
-run 'several tags on one commit fall back' 0 '2\.2\.36' \
-  RELEASE_RUN_SHA=cdfdd24d TAGS_AT_SHA='v2.2.35 v2.2.36' LATEST_RELEASE_TAG=v2.2.36 "${common[@]}"
-run 'fallback explains itself' 0 'most recently created release' \
-  RELEASE_RUN_SHA=deadbeef TAGS_AT_SHA='' LATEST_RELEASE_TAG=v2.2.37 "${common[@]}"
+run 'no tag on the reported commit falls back' 0 '2.2.37' \
+  RELEASE_RUN_SHA=deadbeef TAGS_FOR_SHA=deadbeef TAGS_AT_SHA='' LATEST_RELEASE_TAG=v2.2.37 "${common[@]}"
+run 'several tags on one commit fall back' 0 '2.2.36' 'several version tags' \
+  RELEASE_RUN_SHA=cdfdd24d TAGS_FOR_SHA=cdfdd24d TAGS_AT_SHA='v2.2.35 v2.2.36' LATEST_RELEASE_TAG=v2.2.36 "${common[@]}"
+run 'fallback explains itself' 0 '2.2.37' 'most recently created release' \
+  RELEASE_RUN_SHA=deadbeef TAGS_FOR_SHA=deadbeef TAGS_AT_SHA='' LATEST_RELEASE_TAG=v2.2.37 "${common[@]}"
 
 # Nothing can answer: fail with something actionable rather than registering a guess.
 run 'no tag and no readable release' 1 'Pass release-version explicitly' \

--- a/.github/scripts/test/resolve-released-version-scenarios.sh
+++ b/.github/scripts/test/resolve-released-version-scenarios.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Scenarios for resolve-released-version.sh.
+#
+# git is replaced by the stub next to this file (put on PATH), so tag layouts that
+# would need a crafted repository — several version tags on one commit, a higher
+# unrelated tag elsewhere — are exercised directly.
+set -uo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script="$here/../resolve-released-version.sh"
+
+failures=0
+checks=0
+
+run() { # name expected_status expected_output env...
+  local name="$1" want_status="$2" want_out="$3"
+  shift 3
+  checks=$((checks + 1))
+  local out status
+  out="$(PATH="$here:$PATH" env "$@" bash "$script" 2>&1)"
+  status=$?
+  if [ "$status" -ne "$want_status" ]; then
+    echo "FAIL [$name]: expected exit $want_status, got $status"
+    echo "       output: $out"
+    failures=$((failures + 1))
+    return
+  fi
+  if ! grep -qE "$want_out" <<<"$out"; then
+    echo "FAIL [$name]: output did not match /$want_out/"
+    echo "       output: $out"
+    failures=$((failures + 1))
+    return
+  fi
+  echo "ok   [$name]"
+}
+
+# An explicit version always wins, with or without the tag prefix.
+run 'explicit version' 0 '^2\.5\.2$' EXPLICIT_VERSION=2.5.2 TAGS_AT_SHA='v1.0.0'
+run 'explicit version with v prefix' 0 '^2\.5\.2$' EXPLICIT_VERSION=v2.5.2 TAGS_AT_SHA=''
+
+# The normal path: exactly one version tag on the commit the release run built.
+run 'single tag on the release commit' 0 '^2\.2\.37$' \
+  RELEASE_RUN_SHA=178e83a0 TAGS_AT_SHA='v2.2.37'
+
+# The regression this replaced: a higher tag exists in the repository but points at
+# a different commit, so it must not be picked. ALL_TAGS is deliberately populated
+# with it — the stub fails the test if the script ever reads it.
+run 'higher unrelated tag is ignored' 0 '^2\.2\.37$' \
+  RELEASE_RUN_SHA=178e83a0 TAGS_AT_SHA='v2.2.37' ALL_TAGS='v9.9.9 v2.2.37'
+
+# Non-semver tags on the same commit are not candidates.
+run 'non-semver tags filtered out' 0 '^2\.2\.37$' \
+  RELEASE_RUN_SHA=178e83a0 TAGS_AT_SHA='latest v9.9.9-pr99 v2.2.37 release-2'
+
+# Nothing was released from that commit: refuse rather than register a guess.
+run 'no version tag on the commit' 1 'No vX\.Y\.Z tag points at' \
+  RELEASE_RUN_SHA=deadbeef TAGS_AT_SHA='latest nightly'
+
+# Ambiguity must be surfaced, not resolved silently.
+run 'several version tags on one commit' 1 'Several version tags point at' \
+  RELEASE_RUN_SHA=178e83a0 TAGS_AT_SHA='v2.2.37 v2.3.0'
+
+# Called outside a release-run context and without an explicit version.
+run 'no inputs at all' 1 'cannot be determined' TAGS_AT_SHA='v2.2.37'
+
+echo
+if [ "$failures" -eq 0 ]; then
+  echo "All $checks scenarios passed."
+else
+  echo "$failures of $checks scenarios failed."
+fi
+exit $((failures > 0))

--- a/.github/scripts/test/resolve-released-version-scenarios.sh
+++ b/.github/scripts/test/resolve-released-version-scenarios.sh
@@ -36,7 +36,8 @@ run() { # name expected_status expected_stdout_or_stderr_regex [stderr_regex] en
   # GitHub Actions sets GITHUB_REPOSITORY, which silently defeated the scenario that
   # checks behaviour when the repository is unknown — it passed locally and failed in CI.
   PATH="$here:$PATH" env \
-    EXPLICIT_VERSION= RELEASE_RUN_ID= RELEASE_RUN_SHA= GITHUB_REPOSITORY= GH_TOKEN= \
+    EXPLICIT_VERSION= RELEASE_RUN_ID= RELEASE_RUN_ATTEMPT= RELEASE_RUN_SHA= \
+    GITHUB_REPOSITORY= GH_TOKEN= \
     TAGS_AT_SHA= TAGS_FOR_SHA= LATEST_RELEASE_TAG= LATEST_RELEASE_FAILS= \
     STAMPED_RELEASE_TAG= STAMPED_FOR_RUN= \
     "$@" bash "$script" >"$outfile" 2>"$errfile"
@@ -82,12 +83,25 @@ run 'explicit garbage is rejected' 1 'not a version number' EXPLICIT_VERSION=lat
 
 # Source 2 — the release stamped with this run's id: exact, and it wins over both
 # fallbacks even when they would answer differently.
-run 'release stamped with this run' 0 '2.2.38' 'stamped with run 555' \
-  RELEASE_RUN_ID=555 STAMPED_FOR_RUN=555 STAMPED_RELEASE_TAG=v2.2.38 \
+run 'release stamped with this run' 0 '2.2.38' 'stamped with run 555, attempt 1' \
+  RELEASE_RUN_ID=555 RELEASE_RUN_ATTEMPT=1 STAMPED_FOR_RUN=555/1 STAMPED_RELEASE_TAG=v2.2.38 \
   RELEASE_RUN_SHA=cdfdd24d TAGS_FOR_SHA=cdfdd24d TAGS_AT_SHA='v2.2.37' \
   LATEST_RELEASE_TAG=v9.9.9 "${common[@]}"
 run 'a stamp for another run is ignored' 0 '2.2.37' 'predates the stamping step' \
-  RELEASE_RUN_ID=777 STAMPED_FOR_RUN=555 STAMPED_RELEASE_TAG=v2.2.38 \
+  RELEASE_RUN_ID=777 RELEASE_RUN_ATTEMPT=1 STAMPED_FOR_RUN=555/1 STAMPED_RELEASE_TAG=v2.2.38 \
+  RELEASE_RUN_SHA=178e83a0 TAGS_FOR_SHA=178e83a0 TAGS_AT_SHA='v2.2.37' "${common[@]}"
+# A rerun keeps the run id and bumps the attempt, and the public flow recomputes the
+# version, so the first attempt's release must not answer for the second.
+run 'a stamp from an earlier attempt is ignored' 0 '2.2.37' 'predates the stamping step' \
+  RELEASE_RUN_ID=555 RELEASE_RUN_ATTEMPT=2 STAMPED_FOR_RUN=555/1 STAMPED_RELEASE_TAG=v2.2.38 \
+  RELEASE_RUN_SHA=178e83a0 TAGS_FOR_SHA=178e83a0 TAGS_AT_SHA='v2.2.37' "${common[@]}"
+run 'the matching attempt answers' 0 '2.2.39' 'attempt 2' \
+  RELEASE_RUN_ID=555 RELEASE_RUN_ATTEMPT=2 STAMPED_FOR_RUN=555/2 STAMPED_RELEASE_TAG=v2.2.39 \
+  RELEASE_RUN_SHA=178e83a0 TAGS_FOR_SHA=178e83a0 TAGS_AT_SHA='v2.2.37' "${common[@]}"
+# Without an attempt the stamp cannot be addressed at all, so it is skipped rather than
+# matched loosely.
+run 'no attempt means no stamp lookup' 0 '2.2.37' 'without an attempt number' \
+  RELEASE_RUN_ID=555 STAMPED_FOR_RUN=555/1 STAMPED_RELEASE_TAG=v2.2.38 \
   RELEASE_RUN_SHA=178e83a0 TAGS_FOR_SHA=178e83a0 TAGS_AT_SHA='v2.2.37' "${common[@]}"
 
 # Source 3 — exactly one version tag on the commit the run reported.

--- a/.github/workflows/check-octopus-test-consumer.yml
+++ b/.github/workflows/check-octopus-test-consumer.yml
@@ -125,6 +125,12 @@ jobs:
       - name: Portal publish helper scenarios
         shell: bash
         run: bash .github/scripts/test/portal-publish-scenarios.sh
+      # Covers tag layouts that would otherwise need a crafted repository: several
+      # version tags on one commit, and a higher unrelated tag elsewhere — the case
+      # that once made a release register a version it never published.
+      - name: Released-version resolution scenarios
+        shell: bash
+        run: bash .github/scripts/test/resolve-released-version-scenarios.sh
 
   security:
     name: security

--- a/.github/workflows/common-check-and-register-release.yml
+++ b/.github/workflows/common-check-and-register-release.yml
@@ -70,6 +70,12 @@ jobs:
         run: |
           set -euo pipefail
           version="$(bash .octopus-base-helper/.github/scripts/resolve-released-version.sh)"
+          # Validate before writing: a step output is a single line, so any extra
+          # output from the helper would be truncated into it silently.
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error title=Unusable version::The version helper printed \"${version}\", which is not a version number."
+            exit 1
+          fi
           echo "Registering version $version"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/common-check-and-register-release.yml
+++ b/.github/workflows/common-check-and-register-release.yml
@@ -62,7 +62,11 @@ jobs:
         id: released-version
         env:
           EXPLICIT_VERSION: ${{ inputs.release-version }}
+          # For a repository_dispatch run this is the default branch tip at dispatch
+          # time, not necessarily the commit the release built — the helper knows that
+          # and falls back accordingly.
           RELEASE_RUN_SHA: ${{ github.event.workflow_run.head_sha }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           version="$(bash .octopus-base-helper/.github/scripts/resolve-released-version.sh)"
@@ -74,8 +78,10 @@ jobs:
         id: check-artifact
         env:
           VER: ${{ steps.released-version.outputs.version }}
+          # Through env rather than inline interpolation: a pattern containing shell
+          # metacharacters would otherwise be executed.
+          PATTERN: ${{ inputs.artifact-pattern }}
         run: |
-          PATTERN=${{ inputs.artifact-pattern }}
           ART_PATH=${PATTERN//_VER_/$VER}
           
           ART_URL=${BASE_URL}/${ART_PATH}

--- a/.github/workflows/common-check-and-register-release.yml
+++ b/.github/workflows/common-check-and-register-release.yml
@@ -65,6 +65,9 @@ jobs:
           # The id of the run that triggered this one: the release workflow stamps the
           # release it creates with it, which is the only identity that cannot drift.
           RELEASE_RUN_ID: ${{ github.event.workflow_run.id }}
+          # A rerun keeps the run id and increments the attempt, and the public flow
+          # recomputes the version on a rerun, so both are needed to name one release.
+          RELEASE_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
           # For a repository_dispatch run this is the default branch tip at dispatch
           # time, not necessarily the commit the release built — the helper knows that
           # and falls back accordingly.

--- a/.github/workflows/common-check-and-register-release.yml
+++ b/.github/workflows/common-check-and-register-release.yml
@@ -6,6 +6,13 @@ on:
       artifact-pattern:
         required: true
         type: string
+      release-version:
+        description: >-
+          Version that was released. Leave empty to resolve it from the version tag
+          on the commit the triggering release run built.
+        required: false
+        type: string
+        default: ''
 
 jobs:
   check-http-artifact:
@@ -15,28 +22,59 @@ jobs:
       ATTEMPTS: 45
       BASE_URL: "https://repo1.maven.org/maven2/org/octopusden"
     outputs:
-      release-version: ${{ steps.check-artifact.outputs.RELEASE_VERSION }}
+      release-version: ${{ steps.released-version.outputs.version }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Get latest tag
-        id: tag_version
-        uses: oprypin/find-latest-tag@v1
         with:
-          repository: ${{ github.repository }}
-          # check for version like this v222.444.0 or v1.0.34
-          regex: '^v([0-9]|([1-9][0-9]*))\.([0-9]|([1-9][0-9]*))\.([0-9]|([1-9][0-9]*))$'
+          # Full history and tags: the released version is read from the tag on the
+          # commit the release run built.
+          fetch-depth: 0
+
+      # This workflow runs against the caller's checkout, which has no copy of the
+      # helper, so it is fetched from the pinned version of this workflow. A full
+      # commit SHA is required: an empty or non-SHA ref would make actions/checkout
+      # silently fall back to a default branch and run a different script version.
+      - name: Resolve helper ref
+        id: helper-ref
+        env:
+          HELPER_SHA: ${{ job.workflow_sha }}
+        run: |
+          set -euo pipefail
+          if [[ ! "${HELPER_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error title=Cannot pin the version helper::job.workflow_sha resolved to '${HELPER_SHA}', which is not a full commit SHA. Refusing to run an unpinned helper."
+            exit 1
+          fi
+          echo "sha=${HELPER_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch helper
+        uses: actions/checkout@v4
+        with:
+          repository: octopusden/octopus-base
+          ref: ${{ steps.helper-ref.outputs.sha }}
+          path: .octopus-base-helper
+          sparse-checkout: .github/scripts
+
+      # Replaces a "highest version tag in the repository" lookup, which registered
+      # whichever tag sorted highest whether this run released it or not.
+      - name: Resolve the released version
+        id: released-version
+        env:
+          EXPLICIT_VERSION: ${{ inputs.release-version }}
+          RELEASE_RUN_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          version="$(bash .octopus-base-helper/.github/scripts/resolve-released-version.sh)"
+          echo "Registering version $version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
       # check artifact exists on nexus - synchronous implementation
       - name: Check Sonatype Nexus publish
         id: check-artifact
+        env:
+          VER: ${{ steps.released-version.outputs.version }}
         run: |
-          VERSION_FROM_TAG=${{ steps.tag_version.outputs.tag }}      # v2.3.4
-          VER=${VERSION_FROM_TAG#v}                                  # 2.3.4
-          echo "RELEASE_VERSION=$VER" >> $GITHUB_OUTPUT
-
           PATTERN=${{ inputs.artifact-pattern }}
           ART_PATH=${PATTERN//_VER_/$VER}
           

--- a/.github/workflows/common-check-and-register-release.yml
+++ b/.github/workflows/common-check-and-register-release.yml
@@ -62,6 +62,9 @@ jobs:
         id: released-version
         env:
           EXPLICIT_VERSION: ${{ inputs.release-version }}
+          # The id of the run that triggered this one: the release workflow stamps the
+          # release it creates with it, which is the only identity that cannot drift.
+          RELEASE_RUN_ID: ${{ github.event.workflow_run.id }}
           # For a repository_dispatch run this is the default branch tip at dispatch
           # time, not necessarily the commit the release built — the helper knows that
           # and falls back accordingly.

--- a/.github/workflows/common-java-gradle-release.yml
+++ b/.github/workflows/common-java-gradle-release.yml
@@ -485,15 +485,19 @@ jobs:
           automatic_release_tag: v${{ env.BUILD_VERSION }}
 
       # Bind the release to the run that produced it. Registration happens afterwards
-      # in a workflow_run context whose only trustworthy identity is this run's id:
-      # a tag cannot say which release a run made when several releases share a commit,
-      # and "the newest release" can move on while that job is still queued.
+      # in a workflow_run context whose only trustworthy identity is this run's id and
+      # attempt: a tag cannot say which release a run made when several releases share
+      # a commit, and "the newest release" can move on while that job is queued. The
+      # attempt is part of it because a rerun keeps the run id while the public flow
+      # recomputes the version, so two releases would otherwise carry the same mark.
+      # The marker is a delimited HTML comment: invisible in the rendered notes, and
+      # not a prefix of another run's marker (555/1 vs 555/10).
       - name: Stamp the release with this run
         if: ${{ !inputs.dry-run }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: v${{ env.BUILD_VERSION }}
-          MARKER: "octopus-release-run: ${{ github.run_id }}"
+          MARKER: "<!-- octopus-release-run: ${{ github.run_id }}/${{ github.run_attempt }} -->"
         run: |
           set -euo pipefail
           release_id="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" --jq '.id')"

--- a/.github/workflows/common-java-gradle-release.yml
+++ b/.github/workflows/common-java-gradle-release.yml
@@ -484,6 +484,25 @@ jobs:
           prerelease: false
           automatic_release_tag: v${{ env.BUILD_VERSION }}
 
+      # Bind the release to the run that produced it. Registration happens afterwards
+      # in a workflow_run context whose only trustworthy identity is this run's id:
+      # a tag cannot say which release a run made when several releases share a commit,
+      # and "the newest release" can move on while that job is still queued.
+      - name: Stamp the release with this run
+        if: ${{ !inputs.dry-run }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: v${{ env.BUILD_VERSION }}
+          MARKER: "octopus-release-run: ${{ github.run_id }}"
+        run: |
+          set -euo pipefail
+          release_id="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" --jq '.id')"
+          body="$(gh api "repos/${GITHUB_REPOSITORY}/releases/${release_id}" --jq '.body // ""')"
+          printf '%s\n\n%s\n' "$body" "$MARKER" > "$RUNNER_TEMP/release-body.md"
+          gh api -X PATCH "repos/${GITHUB_REPOSITORY}/releases/${release_id}" \
+            -F body=@"$RUNNER_TEMP/release-body.md" --jq '.tag_name' > /dev/null
+          echo "Release ${TAG} stamped with '${MARKER}'"
+
   register-release-in-log:
       # register release in octopus-release-log
       if: inputs.register-release-immediately && !inputs.dry-run

--- a/.github/workflows/common-java-gradle-release.yml
+++ b/.github/workflows/common-java-gradle-release.yml
@@ -86,6 +86,11 @@ jobs:
           && format('dry-{0}-{1}-{2}-{3}', github.run_id, github.run_attempt, inputs.flow-type, inputs.docker-image)
           || 'publish' }}
       cancel-in-progress: false
+    # The version is an input only for the hybrid flow; the public flow computes it
+    # here. Publishing it as an output is what lets registration receive the version
+    # that was actually released instead of an empty string.
+    outputs:
+      build-version: ${{ inputs.build-version || steps.new-version.outputs.version }}
     env:
       SKIP_TESTS: ''
       BUILD_VERSION: ''
@@ -487,5 +492,5 @@ jobs:
       name: Register release
       with:
         octopus-repository: ${{ github.repository }}
-        release-version:  ${{ inputs.build-version }}
+        release-version: ${{ needs.prepare-build-publish-release.outputs.build-version }}
       secrets: inherit

--- a/.github/workflows/common-java-maven-release.yml
+++ b/.github/workflows/common-java-maven-release.yml
@@ -207,6 +207,28 @@ jobs:
           automatic_release_tag: v${{ env.BUILD_VERSION }}
           files: |
             pom.xml
+      # Bind the release to the run that produced it. Registration happens afterwards
+      # in a workflow_run context whose only trustworthy identity is this run's id and
+      # attempt: a tag cannot say which release a run made when several releases share
+      # a commit, and "the newest release" can move on while that job is queued. The
+      # attempt is part of it because a rerun keeps the run id while the public flow
+      # recomputes the version, so two releases would otherwise carry the same mark.
+      # The marker is a delimited HTML comment: invisible in the rendered notes, and
+      # not a prefix of another run's marker (555/1 vs 555/10).
+      - name: Stamp the release with this run
+        if: ${{ !inputs.dry-run }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: v${{ env.BUILD_VERSION }}
+          MARKER: "<!-- octopus-release-run: ${{ github.run_id }}/${{ github.run_attempt }} -->"
+        run: |
+          set -euo pipefail
+          release_id="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" --jq '.id')"
+          body="$(gh api "repos/${GITHUB_REPOSITORY}/releases/${release_id}" --jq '.body // ""')"
+          printf '%s\n\n%s\n' "$body" "$MARKER" > "$RUNNER_TEMP/release-body.md"
+          gh api -X PATCH "repos/${GITHUB_REPOSITORY}/releases/${release_id}" \
+            -F body=@"$RUNNER_TEMP/release-body.md" --jq '.tag_name' > /dev/null
+          echo "Release ${TAG} stamped with '${MARKER}'"
 
   register-release-in-log:
       # register release in octopus-release-log

--- a/.github/workflows/common-java-maven-release.yml
+++ b/.github/workflows/common-java-maven-release.yml
@@ -52,6 +52,11 @@ jobs:
   prepare-build-publish-release:
     runs-on: ubuntu-latest
     environment: Prod
+    # The version is an input only for the hybrid flow; the public flow computes it
+    # here. Publishing it as an output is what lets registration receive the version
+    # that was actually released instead of an empty string.
+    outputs:
+      build-version: ${{ inputs.build-version || steps.new-version.outputs.version }}
     env:
       BUILD_VERSION: ''
 
@@ -238,5 +243,5 @@ jobs:
       name: Register release
       with:
         octopus-repository: ${{ github.repository }}
-        release-version:  ${{ inputs.build-version }}
+        release-version: ${{ needs.prepare-build-publish-release.outputs.build-version }}
       secrets: inherit

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -41,7 +41,12 @@ jobs:
       # Both registration paths can be wired at the same time — the release workflow's
       # immediate registration and the separate artifact-check workflow — and each
       # release-log entry is a commit that triggers downstream post-processing, so
-      # registering twice runs that twice. Skip when the version is already recorded.
+      # registering twice runs that twice.
+      #
+      # This is an optimisation, NOT a guarantee: registration is an asynchronous
+      # dispatch, so two callers can both read the log before either dispatch lands.
+      # Removing duplicates for good has to happen where the log is written; see #174.
+      #
       # Deliberately fail-open: if the log cannot be read, register anyway, because a
       # missing entry stalls the release pipeline while a duplicate one only repeats
       # bookkeeping.
@@ -67,9 +72,17 @@ jobs:
           # ~1 MB), which decodes to garbage rather than failing; treat it as unreadable.
           log=""
           if [ -n "$encoded" ] && [ "$encoded" != "null" ]; then
-            # Strip CR so the whole-line match still works if the log ever gains CRLF
-            # endings; without it the guard would silently never match.
-            log="$(base64 -d <<<"$encoded" 2>/dev/null | tr -d '\r')"
+            # Keep the decoded text only if decoding actually succeeded: base64 can emit
+            # valid bytes before reporting malformed input, and since this step omits
+            # set -e, that partial text would otherwise be searched — a match in it would
+            # skip registration, the opposite of the intended fail-open.
+            if decoded="$(base64 -d <<<"$encoded" 2>/dev/null)"; then
+              # Strip CR so the whole-line match still works if the log ever gains CRLF
+              # endings; without it the guard would silently never match.
+              log="$(tr -d '\r' <<<"$decoded")"
+            else
+              echo "Release log could not be decoded; registering."
+            fi
           fi
           if [ -n "$log" ]; then
             if grep -qxF "$RELEASE_VERSION" <<<"$log"; then

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -38,7 +38,36 @@ jobs:
           set -euo pipefail
           echo "OCTOPUS_MODULE_NAME=${OCTOPUS_REPOSITORY##*/}" >> "$GITHUB_ENV"
 
+      # Both registration paths can be wired at the same time — the release workflow's
+      # immediate registration and the separate artifact-check workflow — and each
+      # release-log entry is a commit that triggers downstream post-processing, so
+      # registering twice runs that twice. Skip when the version is already recorded.
+      # Deliberately fail-open: if the log cannot be read, register anyway, because a
+      # missing entry stalls the release pipeline while a duplicate one only repeats
+      # bookkeeping.
+      - name: Skip if already registered
+        id: already-registered
+        env:
+          GH_TOKEN: ${{ secrets.OCTOPUS_GITHUB_TOKEN }}
+          RELEASE_LOG_REPOSITORY: ${{ inputs.release-log-repository }}
+          RELEASE_VERSION: ${{ inputs.release-version }}
+        run: |
+          set -uo pipefail
+          registered=false
+          log="$(gh api "repos/${RELEASE_LOG_REPOSITORY}/contents/${OCTOPUS_MODULE_NAME}.txt" \
+            --jq '.content' 2>/dev/null | tr -d '\n' | base64 -d 2>/dev/null)"
+          if [ -n "$log" ]; then
+            if grep -qxF "$RELEASE_VERSION" <<<"$log"; then
+              registered=true
+              echo "::notice title=Already registered::${OCTOPUS_MODULE_NAME} ${RELEASE_VERSION} is already in the release log; skipping."
+            fi
+          else
+            echo "Release log for ${OCTOPUS_MODULE_NAME} could not be read (new module, or a read failure); registering."
+          fi
+          echo "registered=${registered}" >> "$GITHUB_OUTPUT"
+
       - name: Launch action using REST
+        if: ${{ steps.already-registered.outputs.registered != 'true' }}
         env:
           OCTOPUS_GITHUB_TOKEN: ${{ secrets.OCTOPUS_GITHUB_TOKEN }}
           RELEASE_LOG_REPOSITORY: ${{ inputs.release-log-repository }}

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -53,6 +53,13 @@ jobs:
           RELEASE_VERSION: ${{ inputs.release-version }}
         run: |
           set -uo pipefail
+          # An empty version would match any blank line in the log and read as "already
+          # registered", so a caller that failed to resolve its version would silently
+          # register nothing at all.
+          if [ -z "$RELEASE_VERSION" ]; then
+            echo "::error title=No version to register::The caller passed an empty release version."
+            exit 1
+          fi
           registered=false
           encoded="$(gh api "repos/${RELEASE_LOG_REPOSITORY}/contents/${OCTOPUS_MODULE_NAME}.txt" \
             --jq '.content' 2>/dev/null | tr -d '\n')"

--- a/.github/workflows/common-register-release.yml
+++ b/.github/workflows/common-register-release.yml
@@ -54,8 +54,16 @@ jobs:
         run: |
           set -uo pipefail
           registered=false
-          log="$(gh api "repos/${RELEASE_LOG_REPOSITORY}/contents/${OCTOPUS_MODULE_NAME}.txt" \
-            --jq '.content' 2>/dev/null | tr -d '\n' | base64 -d 2>/dev/null)"
+          encoded="$(gh api "repos/${RELEASE_LOG_REPOSITORY}/contents/${OCTOPUS_MODULE_NAME}.txt" \
+            --jq '.content' 2>/dev/null | tr -d '\n')"
+          # The contents API returns an empty payload for files it will not inline (over
+          # ~1 MB), which decodes to garbage rather than failing; treat it as unreadable.
+          log=""
+          if [ -n "$encoded" ] && [ "$encoded" != "null" ]; then
+            # Strip CR so the whole-line match still works if the log ever gains CRLF
+            # endings; without it the guard would silently never match.
+            log="$(base64 -d <<<"$encoded" 2>/dev/null | tr -d '\r')"
+          fi
           if [ -n "$log" ]; then
             if grep -qxF "$RELEASE_VERSION" <<<"$log"; then
               registered=true
@@ -67,7 +75,9 @@ jobs:
           echo "registered=${registered}" >> "$GITHUB_OUTPUT"
 
       - name: Launch action using REST
-        if: ${{ steps.already-registered.outputs.registered != 'true' }}
+        # success() is explicit because a custom condition replaces the implicit
+        # success gate rather than being added to it.
+        if: ${{ success() && steps.already-registered.outputs.registered != 'true' }}
         env:
           OCTOPUS_GITHUB_TOKEN: ${{ secrets.OCTOPUS_GITHUB_TOKEN }}
           RELEASE_LOG_REPOSITORY: ${{ inputs.release-log-repository }}


### PR DESCRIPTION
After a release publishes, the version is recorded in the release log, and that record is what downstream post-processing acts on. It was resolved by asking "what is the highest version tag in this repository?" — a question whose answer has nothing to do with the release that just ran.

## What went wrong, concretely

octopus-test released `2.2.37` today. A leftover canary tag `v9.9.9` was still in the repository, and it sorts higher. So:

- the release log recorded **9.9.9**, a version that was never released from that run;
- post-processing created a fix version and a deployment issue for 9.9.9;
- it set the component`s "latest released version" parameter to **9.9.9**, which would have poisoned the next version calculation;
- the real `2.2.37` received no post-processing at all.

The canary tag was mine and is now deleted, but the mechanism remains: any repository that ever carries a higher tag — a test tag, an experiment, a mistake — silently mis-registers its next release.

## The fix

Resolve the version from the **version tag on the commit the triggering release run built**. That tag is created by the release run itself, so it is the one candidate that cannot belong to a different release. When there is no such tag, or more than one, registration fails with an explicit message instead of guessing.

Callers that already know the version pass it via the new optional `release-version` input — the release workflow`s own immediate-registration path always did, and is unaffected.

## Second defect found while fixing the first

Both registration paths can be active at once: `register-release-immediately` inside the release workflow, plus the separate artifact-check workflow. octopus-test has both. Each release-log entry is a commit that triggers post-processing, so the same version gets processed twice — the log already contains duplicate lines from this.

Registration now skips a version that is already recorded. It fails open on purpose: if the log cannot be read, it registers anyway, because a missing entry stalls the release pipeline while a duplicate only repeats bookkeeping.

## Verification

The resolution logic is a helper script with a stubbed-`git` scenario suite, wired into `workflow-lint`. Eight cases, all passing, including the exact hijack described above:

| Scenario | Expected |
|---|---|
| explicit version, with and without `v` prefix | used as given |
| one version tag on the release commit | that version |
| a higher unrelated tag elsewhere in the repository | ignored — the stub fails the test if the script ever reads the full tag list |
| non-semver tags on the same commit | filtered out |
| no version tag on the commit | fails, refuses to guess |
| several version tags on one commit | fails, asks for an explicit version |
| neither input available | fails with an actionable message |

The idempotency check was exercised against the live release log: `2.2.37` reads as already registered, `9.9.9` and `3.0.0` as not.

## Notes

- The helper is fetched from the pinned workflow SHA, the same way the Portal publish helper is, because a reusable workflow runs against the caller`s checkout and has no copy of it.
- Drops the third-party `find-latest-tag` action.
- Worth considering separately: now that the release workflow itself confirms every artifact is resolvable on Maven Central before tagging, the "wait for the artifact, then register" workflow is largely redundant for the gradle path — consumers could rely on immediate registration alone.

Part of #140.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved release version detection using explicit versions, release tags, or the latest published release.
  * Added validation and clearer errors for missing or invalid release versions.
  * Release checks now use the resolved version when verifying published artifacts.
  * Prevented duplicate release registrations when a version is already recorded.

* **Tests**
  * Added automated scenarios covering version resolution, fallback behavior, invalid inputs, and release-registration safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->