### PR TITLE
Fix Release by making dry-run gating work when triggered from the API

### DIFF
--- a/.github/workflows/release-octopus-base.yml
+++ b/.github/workflows/release-octopus-base.yml
@@ -44,8 +44,52 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  flags:
+    name: Normalise inputs
+    runs-on: ubuntu-latest
+    outputs:
+      dry-run: ${{ steps.normalise.outputs.dry-run }}
+      verify-octopus-test: ${{ steps.normalise.outputs.verify-octopus-test }}
+    steps:
+      # A workflow_dispatch boolean arrives as a real boolean from the UI but as a
+      # string from the API, and the two behave differently in an if: expression: the
+      # string "false" is non-empty and therefore truthy, so `!inputs.dry-run` was false
+      # and a real release triggered with `gh workflow run -f dry-run=false` skipped its
+      # publish without a word. Comparing against 'true' instead is not a fix either —
+      # a UI dry-run passes the boolean true, and `true != 'true'` is true, which would
+      # publish during a dry run.
+      #
+      # Both representations stringify identically in env, so the decision is made once,
+      # here, and every job compares a plain string. An unexpected value stops the run
+      # rather than being guessed at.
+      - name: Normalise boolean inputs
+        id: normalise
+        env:
+          DRY_RUN: ${{ inputs.dry-run }}
+          VERIFY_OCTOPUS_TEST: ${{ inputs.verify_octopus_test }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          normalise() { # name value
+            case "$2" in
+              true|false) echo "$1=$2" >> "$GITHUB_OUTPUT" ;;
+              *)
+                echo "::error title=Unusable input::${1} arrived as '${2}', which is neither true nor false."
+                exit 1
+                ;;
+            esac
+          }
+          normalise dry-run "$DRY_RUN"
+          normalise verify-octopus-test "$VERIFY_OCTOPUS_TEST"
+          {
+            echo "### Normalised inputs"
+            echo "- dry-run: \`${DRY_RUN}\` -> \`$(grep '^dry-run=' "$GITHUB_OUTPUT" | tail -1 | cut -d= -f2)\`"
+            echo "- verify-octopus-test: \`${VERIFY_OCTOPUS_TEST}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   resolve-target:
     name: Resolve target ref
+    needs: flags
     runs-on: ubuntu-latest
     outputs:
       target_sha: ${{ steps.resolve.outputs.target_sha }}
@@ -61,7 +105,7 @@ jobs:
         id: resolve
         env:
           INPUT_TARGET_REF: ${{ inputs.target-ref }}
-          INPUT_DRY_RUN: ${{ inputs.dry-run }}
+          INPUT_DRY_RUN: ${{ needs.flags.outputs.dry-run }}
         shell: bash
         run: |
           set -euo pipefail
@@ -86,8 +130,10 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
   verify-octopus-test:
-    needs: resolve-target
-    if: ${{ inputs.verify_octopus_test }}
+    needs:
+      - flags
+      - resolve-target
+    if: ${{ needs.flags.outputs.verify-octopus-test == 'true' }}
     name: Verify octopus-test consumer
     uses: ./.github/workflows/verify-octopus-test-consumer.yml
     with:
@@ -98,9 +144,13 @@ jobs:
   calculate-version:
     name: Calculate release version
     needs:
+      - flags
       - resolve-target
       - verify-octopus-test
-    if: ${{ always() && (!inputs.verify_octopus_test || needs.verify-octopus-test.result == 'success') }}
+    # always() is needed because the verification job is skipped when it was not asked
+    # for; requiring flags to have succeeded keeps an empty output from reading as "not
+    # requested".
+    if: ${{ always() && needs.flags.result == 'success' && (needs.flags.outputs.verify-octopus-test != 'true' || needs.verify-octopus-test.result == 'success') }}
     runs-on: ubuntu-latest
     outputs:
       release_version: ${{ steps.version.outputs.release_version }}
@@ -180,7 +230,7 @@ jobs:
           fi
 
       - name: Dry run summary
-        if: ${{ inputs.dry-run }}
+        if: ${{ needs.flags.outputs.dry-run == 'true' }}
         shell: bash
         run: |
           echo "Dry run enabled: no GitHub Release will be created."
@@ -188,8 +238,10 @@ jobs:
 
   publish-quality-plugin:
     name: Publish quality convention plugin
-    needs: calculate-version
-    if: ${{ !inputs.dry-run }}
+    needs:
+      - flags
+      - calculate-version
+    if: ${{ needs.flags.outputs.dry-run != 'true' }}
     runs-on: ubuntu-latest
     environment: Prod
 
@@ -311,9 +363,10 @@ jobs:
   create-release:
     name: Create GitHub release
     needs:
+      - flags
       - calculate-version
       - publish-quality-plugin
-    if: ${{ !inputs.dry-run }}
+    if: ${{ needs.flags.outputs.dry-run != 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -341,8 +394,9 @@ jobs:
           echo "- Target SHA: ${{ needs.calculate-version.outputs.target_sha }}"
 
   register-release-in-log:
-    if: ${{ !inputs.dry-run }}
+    if: ${{ needs.flags.outputs.dry-run != 'true' }}
     needs:
+      - flags
       - calculate-version
       - create-release
     uses: ./.github/workflows/common-register-release.yml

--- a/.github/workflows/release-octopus-base.yml
+++ b/.github/workflows/release-octopus-base.yml
@@ -148,9 +148,11 @@ jobs:
       - resolve-target
       - verify-octopus-test
     # always() is needed because the verification job is skipped when it was not asked
-    # for; requiring flags to have succeeded keeps an empty output from reading as "not
-    # requested".
-    if: ${{ always() && needs.flags.result == 'success' && (needs.flags.outputs.verify-octopus-test != 'true' || needs.verify-octopus-test.result == 'success') }}
+    # for — but it also lets this job run after a *failed* dependency, which is how a
+    # rejected target-ref still produced a computed version from an unintended checkout.
+    # So every dependency that must have succeeded is named explicitly, and an empty
+    # flags output can no longer read as "verification was not requested".
+    if: ${{ always() && needs.flags.result == 'success' && needs.resolve-target.result == 'success' && (needs.flags.outputs.verify-octopus-test != 'true' || needs.verify-octopus-test.result == 'success') }}
     runs-on: ubuntu-latest
     outputs:
       release_version: ${{ steps.version.outputs.release_version }}


### PR DESCRIPTION
A real release started with `gh workflow run -f dry-run=false` skipped publishing, created the GitHub release and registered it — silently. Closes #154.

## Why

A `workflow_dispatch` boolean arrives as a real boolean from the UI and as a **string** from the API. The two behave differently in an `if:` expression: the string `"false"` is non-empty and therefore truthy, so `!inputs.dry-run` evaluated to `false` and every publishing step was skipped. Only the UI path worked, which is exactly what hid the bug.

The obvious repair is worse. Comparing `inputs.dry-run != 'true'` would publish **during a UI dry run**, because there the input is the boolean `true` and `true != 'true'` is true.

## The fix

Both representations stringify identically in `env`, so a first job decides once and every other job compares a plain string. An input that is neither `true` nor `false` stops the run instead of being guessed at — a wrong value can only fail loudly, never publish quietly.

The same normalisation covers `verify_octopus_test`, which had the mirror problem: the string `"false"` made the consumer verification run when it had not been asked for.

## Proof

Both API representations were exercised against this branch, using the real workflow rather than a mock:

| Trigger | Arrived as | Result |
|---|---|---|
| `gh … -f dry-run=true` ([run](https://github.com/octopusden/octopus-base/actions/runs/30280408520)) | `DRY_RUN: true` | dry path; publish, release and registration all **skipped**; consumer verification also skipped, which is the mirror bug fixed |
| `gh … -f dry-run=false` ([run](https://github.com/octopusden/octopus-base/actions/runs/30280647230)) | `DRY_RUN: false` | treated as a real release: the non-dry-run guard rejected a commit-as-target-ref and stopped there, so nothing was published |

The second case was made safe deliberately: `target-ref` was a commit SHA, which the workflow only rejects when it believes the run is *not* a dry run. That the run failed on that guard is the proof that the string `"false"` is now understood as false.

**One combination cannot be self-served:** a real boolean only ever arrives from the UI — the API stringifies even a JSON boolean. Two things cover it. The `resolve-target` step has compared the stringified value since before this change and behaved correctly in UI releases, including 2.5.1. And if a boolean ever stringified to anything other than `true`/`false`, the new normalisation stops the run with an error rather than choosing a path. Still worth one confirming click: a **UI dry run on this branch** (checked box) should show the dry path. Please do not test the unchecked case by hand — that publishes for real; it will be exercised by the 2.5.2 release itself, where a failure would be loud and pre-publish.

## Found while proving it

`calculate-version` used `always()` so that it could run when consumer verification was skipped — but `always()` also let it run after `resolve-target` had **failed**, so a rejected `target-ref` still produced a version computed from an unintended checkout. Nothing published, and only because the failed ancestor skipped the downstream jobs. Every dependency that must have succeeded is now named explicitly; re-running the same rejected dispatch now skips version calculation ([run](https://github.com/octopusden/octopus-base/actions/runs/30280647230)).

## Scope

Only `release-octopus-base.yml` is triggered by `workflow_dispatch`; the shared release workflows are `workflow_call`, where GitHub types the inputs, so they are not exposed to this. #154 asked for that check — it was made, and the family is clean.