### PR TITLE
feat(release): guard Maven Central publications against fat jars

### DIFF
--- a/.github/workflows/common-java-gradle-release.yml
+++ b/.github/workflows/common-java-gradle-release.yml
@@ -55,6 +55,16 @@ on:
         required: false
         type: boolean
         default: true
+      fat-jar-publication-allowlist:
+        description: 'Comma-separated artifactIds exempt from the Maven Central publication guard (fat jar or oversized artifact). Any other artifact that trips the guard fails the release before upload. Use only for artifacts a consumer genuinely resolves from a Maven repository — e.g. an automation module fetched by a TeamCity metarunner.'
+        required: false
+        type: string
+        default: ''
+      max-central-artifact-mb:
+        description: 'Size above which a published artifact fails the Maven Central publication guard, in MB. Catches fat jars that carry no marker in their name — e.g. a shadow jar published with the classifier stripped.'
+        required: false
+        type: number
+        default: 8
       resume-deployment-id:
         description: 'Emergency re-run knob: Portal deployment id printed as RELEASE_PUBLISH_RESUME_DEPLOYMENT_ID by a failed run OF THIS SAME REPOSITORY. When set, the Gradle upload is SKIPPED and that existing deployment is published instead — use it after a run died past the upload, so the version is not uploaded twice. Callers must expose it in their own workflow_dispatch inputs to use it.'
         required: false
@@ -306,6 +316,97 @@ jobs:
           ref: ${{ steps.helper-ref.outputs.sha }}
           path: .octopus-base-helper
           sparse-checkout: .github/scripts
+
+      # Maven Central is for artifacts other projects consume as a DEPENDENCY. A Spring Boot
+      # executable jar or a shadow/uber jar there is usually unintended — Gradle module metadata
+      # can pull the shadow variant into `from(components.java)` without anyone asking — and a
+      # single such artifact can exceed the org's entire monthly Central size quota.
+      # Publish to a throwaway local repository first and inspect what would be uploaded, so an
+      # oversized artifact fails the release BEFORE it reaches Central, where versions are
+      # immutable. Runs in dry-run too: that is where the check is cheapest to act on.
+      # Signing is force-disabled for this invocation — the guard must not need the GPG key, and
+      # unsigned artifacts are enough to inspect names, sizes and archive contents.
+      - name: Guard against publishing fat jars to Maven Central
+        if: ${{ inputs.publish-to-nexus && inputs.resume-deployment-id == '' }}
+        env:
+          FAT_JAR_ALLOWLIST: ${{ inputs.fat-jar-publication-allowlist }}
+          MAX_ARTIFACT_MB: ${{ inputs.max-central-artifact-mb }}
+        run: |
+          set -euo pipefail
+
+          GUARD_REPO="$RUNNER_TEMP/m2-publication-guard"
+          rm -rf "$GUARD_REPO"
+
+          cat > "$RUNNER_TEMP/no-signing.init.gradle" <<'GRADLE'
+          allprojects { proj ->
+              proj.plugins.withId('signing') {
+                  proj.extensions.getByName('signing').required = false
+              }
+          }
+          GRADLE
+
+          ./gradlew publishToMavenLocal \
+            -Dmaven.repo.local="$GUARD_REPO" \
+            --init-script "$RUNNER_TEMP/no-signing.init.gradle" \
+            -PbuildVersion=${{ env.BUILD_VERSION }} -Pversion=${{ env.BUILD_VERSION }} -s
+
+          python3 - "$GUARD_REPO" <<'PY'
+          import os, sys, zipfile
+          from pathlib import Path
+
+          repo = Path(sys.argv[1])
+          allowed = {a.strip() for a in os.environ.get("FAT_JAR_ALLOWLIST", "").split(",") if a.strip()}
+          max_mb = float(os.environ.get("MAX_ARTIFACT_MB") or 8)
+
+          published, offenders = [], []
+          # .zip is included because automation modules can publish shadow distributions and
+          # TeamCity plugin bundles, which cost the same quota as a jar.
+          for path in sorted(p for ext in ("*.jar", "*.zip") for p in repo.rglob(ext)):
+              # <group path>/<artifactId>/<version>/<file>
+              artifact_id = path.parent.parent.name
+              size_mb = path.stat().st_size / 1048576
+              published.append((artifact_id, path.name, size_mb))
+              reasons = []
+              if path.name.endswith("-all.jar"):
+                  reasons.append("shadow/uber jar (-all classifier)")
+              else:
+                  try:
+                      with zipfile.ZipFile(path) as z:
+                          if any(n.startswith("BOOT-INF/") for n in z.namelist()):
+                              reasons.append("Spring Boot executable jar (BOOT-INF/)")
+                  except zipfile.BadZipFile:
+                      pass
+              # Size is the signal that catches what the markers miss — e.g. a shadow jar
+              # published with the classifier stripped, which is indistinguishable from a
+              # library jar by name and has no BOOT-INF/ either.
+              if size_mb > max_mb:
+                  reasons.append(f"exceeds {max_mb:g} MB")
+              if reasons and artifact_id not in allowed:
+                  offenders.append((artifact_id, path.name, size_mb, "; ".join(reasons)))
+
+          print(f"Inspected {len(published)} artifact(s) that would be published to Maven Central "
+                f"(size limit {max_mb:g} MB):")
+          for artifact_id, name, size_mb in published:
+              print(f"  {artifact_id:<45} {name:<55} {size_mb:7.2f} MB")
+          if allowed:
+              print(f"Explicitly allowed: {', '.join(sorted(allowed))}")
+
+          if offenders:
+              print("\n::error::Artifact(s) unfit for Maven Central would be published", flush=True)
+              for artifact_id, name, size_mb, reason in offenders:
+                  print(f"  {artifact_id}: {name} ({size_mb:.2f} MB) — {reason}", file=sys.stderr)
+              print(
+                  "\nCentral is for artifacts consumed as a Maven dependency. Either stop publishing "
+                  "this module (declare no MavenPublication for it, or set publish-to-nexus: false for "
+                  "a repository nobody consumes), or — if a consumer really resolves this artifact from "
+                  "a Maven repository, e.g. a TeamCity metarunner — add its artifactId to the "
+                  "fat-jar-publication-allowlist input with that justification. Raise "
+                  "max-central-artifact-mb only if a genuinely consumed library is legitimately large.",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+          print("\nPublication set is fit for Maven Central.")
+          PY
 
       # Bind -PstagingProfileId to the gradle-nexus publish-plugin extension for
       # every project that applies it, without requiring any consumer build-script

--- a/.github/workflows/common-java-gradle-release.yml
+++ b/.github/workflows/common-java-gradle-release.yml
@@ -109,8 +109,10 @@ jobs:
       # check input parameters
       - name: Unknown flow
         if: inputs.flow-type != 'public' && inputs.flow-type != 'hybrid'
+        env:
+          FLOW_TYPE: ${{ inputs.flow-type }}
         run: |
-          echo "Unknown flow specified, should be one of {public, hybrid}: " ${{ inputs.flow-type }}
+          echo "Unknown flow specified, should be one of {public, hybrid}: $FLOW_TYPE"
           exit 1
 
       - name: Fail if commit-hash is not set for hybrid flow
@@ -132,14 +134,24 @@ jobs:
 
       - name: Hybrid flow
         if: inputs.flow-type == 'hybrid'
+        env:
+          COMMIT_HASH: ${{ inputs.commit-hash }}
+          INPUT_BUILD_VERSION: ${{ inputs.build-version }}
         run: |
+          set -euo pipefail
           echo "Hybrid flow:"
           echo "- Skipping tests"
-          echo "- Commit hash: ${{ inputs.commit-hash }}"
-          echo "- Version: ${{ inputs.build-version }}"
+          echo "- Commit hash: $COMMIT_HASH"
+          echo "- Version: $INPUT_BUILD_VERSION"
+          # A version is a coordinate that ends up in shell commands and file paths, so reject
+          # anything that is not a plain version string before it reaches either.
+          if [[ ! "$INPUT_BUILD_VERSION" =~ ^[A-Za-z0-9._+-]+$ ]]; then
+            echo "build-version contains unexpected characters: $INPUT_BUILD_VERSION" >&2
+            exit 1
+          fi
           # set hybrid flow variables
-          echo "SKIP_TESTS=-x test" >> $GITHUB_ENV
-          echo "BUILD_VERSION=${{ inputs.build-version }}" >> $GITHUB_ENV
+          echo "SKIP_TESTS=-x test" >> "$GITHUB_ENV"
+          echo "BUILD_VERSION=$INPUT_BUILD_VERSION" >> "$GITHUB_ENV"
 
       - name: Apply extra skipped tasks
         if: inputs.skip-extra-tasks != ''
@@ -246,8 +258,10 @@ jobs:
 
       - name: Save new version to env
         if: inputs.flow-type == 'public'
+        env:
+          NEW_VERSION: ${{ steps.new-version.outputs.version }}
         run: |
-          echo "BUILD_VERSION=${{ steps.new-version.outputs.version }}" >> $GITHUB_ENV
+          echo "BUILD_VERSION=$NEW_VERSION" >> "$GITHUB_ENV"
 
       # setup env
       - name: Set up Java
@@ -263,11 +277,15 @@ jobs:
       # gradle build
       - name: Gradle build
         if: inputs.docker-image == ''
-        run: ./gradlew build ${{ env.SKIP_TESTS }} -PbuildVersion=${{ env.BUILD_VERSION }} -Pversion=${{ env.BUILD_VERSION }} --info -s
+        # shellcheck disable=SC2086 # SKIP_TESTS intentionally word-splits into `-x <task>` pairs
+        run: ./gradlew build $SKIP_TESTS -PbuildVersion="$BUILD_VERSION" -Pversion="$BUILD_VERSION" --info -s
 
       - name: Gradle build docker image
         if: inputs.docker-image
-        run: ./gradlew build dockerBuildImage ${{ env.SKIP_TESTS }} -Pdocker.image=${{ inputs.docker-image }} -Poctopus.github.docker.registry=ghcr.io -Pdocker.registry=docker.io -PbuildVersion=${{ env.BUILD_VERSION }} -Pversion=${{ env.BUILD_VERSION }} --info -s
+        env:
+          DOCKER_IMAGE: ${{ inputs.docker-image }}
+        # shellcheck disable=SC2086 # SKIP_TESTS intentionally word-splits into `-x <task>` pairs
+        run: ./gradlew build dockerBuildImage $SKIP_TESTS -Pdocker.image="$DOCKER_IMAGE" -Poctopus.github.docker.registry=ghcr.io -Pdocker.registry=docker.io -PbuildVersion="$BUILD_VERSION" -Pversion="$BUILD_VERSION" --info -s
 
       # push to docker
       - name: Log in to Docker Registry
@@ -280,7 +298,9 @@ jobs:
 
       - name: Push to docker registry
         if: inputs.docker-image && !inputs.dry-run
-        run: docker push ghcr.io/octopusden/${{ inputs.docker-image }}:${{ env.BUILD_VERSION }}
+        env:
+          DOCKER_IMAGE: ${{ inputs.docker-image }}
+        run: docker push "ghcr.io/octopusden/$DOCKER_IMAGE:$BUILD_VERSION"
 
       # The publish helper lives in octopus-base, but this reusable workflow runs
       # against the CONSUMER's checkout — so fetch the script from the very commit
@@ -352,7 +372,7 @@ jobs:
             -Pnexus=true \
             -Dmaven.repo.local="$GUARD_REPO" \
             --init-script "$RUNNER_TEMP/no-signing.init.gradle" \
-            -PbuildVersion=${{ env.BUILD_VERSION }} -Pversion=${{ env.BUILD_VERSION }} -s
+            -PbuildVersion="$BUILD_VERSION" -Pversion="$BUILD_VERSION" -s
 
           python3 - "$GUARD_REPO" <<'PY'
           import os, re, sys, zipfile
@@ -443,7 +463,7 @@ jobs:
         if: ${{ !inputs.dry-run && inputs.publish-to-nexus && inputs.resume-deployment-id == '' }}
         run: |
           set -o pipefail
-          ./gradlew -Pnexus=true -PstagingProfileId="$STAGING_PROFILE_ID" --init-script "$RUNNER_TEMP/staging-profile.init.gradle" publishToSonatype closeSonatypeStagingRepository -PbuildVersion=${{ env.BUILD_VERSION }} -Pversion=${{ env.BUILD_VERSION }} --info -s 2>&1 | tee "$RUNNER_TEMP/publish.log"
+          ./gradlew -Pnexus=true -PstagingProfileId="$STAGING_PROFILE_ID" --init-script "$RUNNER_TEMP/staging-profile.init.gradle" publishToSonatype closeSonatypeStagingRepository -PbuildVersion="$BUILD_VERSION" -Pversion="$BUILD_VERSION" --info -s 2>&1 | tee "$RUNNER_TEMP/publish.log"
         env:
           STAGING_PROFILE_ID: ${{ inputs.staging-profile-id }}
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}

--- a/.github/workflows/common-java-gradle-release.yml
+++ b/.github/workflows/common-java-gradle-release.yml
@@ -345,13 +345,17 @@ jobs:
           }
           GRADLE
 
+          # -Pnexus=true must match the real upload below: some consumers shape their plugins
+          # and publications on that property, so without it this dry publication could inspect
+          # a different artifact set than the one publishToSonatype actually uploads.
           ./gradlew publishToMavenLocal \
+            -Pnexus=true \
             -Dmaven.repo.local="$GUARD_REPO" \
             --init-script "$RUNNER_TEMP/no-signing.init.gradle" \
             -PbuildVersion=${{ env.BUILD_VERSION }} -Pversion=${{ env.BUILD_VERSION }} -s
 
           python3 - "$GUARD_REPO" <<'PY'
-          import os, sys, zipfile
+          import os, re, sys, zipfile
           from pathlib import Path
 
           repo = Path(sys.argv[1])
@@ -361,14 +365,15 @@ jobs:
           published, offenders = [], []
           # .zip is included because automation modules can publish shadow distributions and
           # TeamCity plugin bundles, which cost the same quota as a jar.
-          for path in sorted(p for ext in ("*.jar", "*.zip") for p in repo.rglob(ext)):
+          for path in sorted(p for ext in ("*.jar", "*.zip", "*.tar", "*.tar.gz") for p in repo.rglob(ext)):
               # <group path>/<artifactId>/<version>/<file>
               artifact_id = path.parent.parent.name
               size_mb = path.stat().st_size / 1048576
               published.append((artifact_id, path.name, size_mb))
               reasons = []
-              if path.name.endswith("-all.jar"):
-                  reasons.append("shadow/uber jar (-all classifier)")
+              # Covers both the jar and the shadow distribution archive (-all.zip/-all.tar).
+              if re.search(r"-all\.(jar|zip|tar(\.gz)?)$", path.name):
+                  reasons.append("shadow/uber artifact (-all classifier)")
               else:
                   try:
                       with zipfile.ZipFile(path) as z:

--- a/docs/Octopus Developer Guide.md
+++ b/docs/Octopus Developer Guide.md
@@ -165,20 +165,23 @@ jobs:
       java-version: '21'
 ```
 
-## Skipping Maven Central publishing (`publish-to-nexus`)
+## Maven Central publishing
 
-`common-java-gradle-release` publishes the module's Maven artifacts to Sonatype
-Central by default (`publish-to-nexus: true`). Set it to `false` for
-**deployable-only** repositories — an application or UI that ships as a docker
-image and is never consumed by anyone as a Maven dependency. Skipping the
-upload keeps the org under Maven Central's monthly publishing limits (a Spring
-Boot fat-jar can be tens of MB per release).
+Publish to Central only what other projects consume as a **Maven dependency**. Deployables
+and internal tooling do not belong there:
 
-When `publish-to-nexus: false`, the release still builds, pushes the docker
-image, and creates the GitHub release — only the Sonatype publish (and its
-secret check) are skipped. Pair it with `register-release-immediately: true`
-so the release is logged directly instead of waiting for a Maven Central
-artifact that will never appear.
+- a service or app ships as a docker image on ghcr;
+- a CLI ships as a GitHub Release asset, or is built locally;
+- test harnesses and compat suites have no consumers at all.
+
+### Keeping a repository off Central
+
+Set `publish-to-nexus: false` **and** remove the `MavenPublication` from the build script: the
+input guards the pipeline, the build-script change is what stops a manual
+`./gradlew publishToSonatype`. The release still builds, pushes the docker image and creates the
+GitHub release — only the Sonatype publish and its secret check are skipped. Pair it with
+`register-release-immediately: true`, or the release-log gate waits for an artifact that will
+never appear.
 
 ```yaml
 jobs:
@@ -192,50 +195,25 @@ jobs:
       register-release-immediately: true
 ```
 
-## What belongs on Maven Central
+### Keeping single modules off Central
 
-Maven Central is an exchange for artifacts **other projects consume as a Maven
-dependency**. Deployables and internal tooling do not belong there:
+When some modules are consumed and some are not (a service plus its client libraries), declare
+**no publication** for the deployable modules and keep it for the libraries. Note that
+`tasks.named('publish') { enabled = false }` does **not** work — `publishToSonatype` depends on
+the `PublishToMavenRepository` tasks, not on the `publish` lifecycle task.
 
-- a service or app ships as a **docker image** on ghcr;
-- a CLI ships as a **GitHub Release asset** (or is built locally);
-- test harnesses and compat suites are internal and have no consumers at all.
+If the module you stop publishing is the one `check-and-register.yml` polls, re-point that
+workflow's `artifact-pattern` at a module that is still published.
 
-This is not a style preference. Sonatype's limits are **monthly and org-wide**
-(80 MB release size, 1000 files, 7 releases), so one repository publishing a
-60 MB Spring Boot fat jar can consume the whole organisation's quota in a single
-release — and Central versions are **immutable**, so a mistake cannot be undone.
+### The publication guard
 
-Two ways to keep an artifact off Central, depending on the repository:
+Before uploading, the release inspects what would reach Central and **fails** on:
 
-- **Nothing in the repository is consumed as a dependency** (an app, a UI):
-  set `publish-to-nexus: false` (see the section above) *and* remove the
-  `MavenPublication` from the build script. The workflow input guards the
-  pipeline; without the build-script change a manual `./gradlew publishToSonatype`
-  can still upload.
-- **Some modules are consumed, some are not** (a service plus its client
-  libraries): declare **no publication** for the deployable modules and keep it
-  for the libraries. Note that `tasks.named('publish') { enabled = false }` does
-  *not* work — `publishToSonatype` depends on the `PublishToMavenRepository`
-  tasks, not on the `publish` lifecycle task.
-
-If a repository stops publishing the artifact its `check-and-register.yml` polls,
-re-point that workflow's `artifact-pattern` at a module that is still published,
-or drop the workflow and use `register-release-immediately: true` instead —
-otherwise the release-log gate waits ~90 minutes for an artifact that will never
-appear, then fails.
-
-## The publication guard (`fat-jar-publication-allowlist`)
-
-Before uploading, the release publishes to a throwaway local repository and
-inspects what would reach Central. The release **fails** if an artifact is unfit
-for it:
-
-- a shadow/uber jar (`-all` classifier);
-- a Spring Boot executable jar, detected by a `BOOT-INF/` entry inside the
-  archive — its file name is indistinguishable from a library's;
-- anything larger than `max-central-artifact-mb` (default 8), which catches a
-  shadow jar published with the classifier stripped.
+- a shadow/uber artifact (`-all` classifier);
+- a Spring Boot executable jar, detected by a `BOOT-INF/` entry inside the archive — its file
+  name is indistinguishable from a library's;
+- anything larger than `max-central-artifact-mb` (default 8), which catches a shadow jar
+  published with the classifier stripped.
 
 A fat jar often appears without anyone asking for it: the shadow plugin exposes
 `shadowRuntimeElements` as a variant of the `java` component, so `from(components.java)`
@@ -245,27 +223,19 @@ If the guard fails your release, pick one:
 
 | Situation | Fix |
 |---|---|
-| The module is a deployable nobody depends on | Stop publishing it (see the section above) |
+| The module is a deployable nobody depends on | Stop publishing it |
 | The whole repository is a deployable | `publish-to-nexus: false` |
 | A consumer really resolves this fat jar from a Maven repository — e.g. an automation module fetched by a TeamCity metarunner | Add its artifactId to `fat-jar-publication-allowlist` |
 | A genuinely consumed library is legitimately large | Raise `max-central-artifact-mb` |
 
-The allowlist exists so that a legitimate exception is explicit and reviewed
-instead of silent:
+The allowlist keeps a legitimate exception explicit and reviewed instead of silent:
 
 ```yaml
-jobs:
-  build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@<tag>
-    with:
-      flow-type: hybrid
-      java-version: '21'
       # The automation module's fat jar is resolved by its TeamCity metarunner
       # (-Dartifact=<group>:<name>:<version>:jar:all), so it must stay on Central.
       fat-jar-publication-allowlist: automation
 ```
 
-The guard runs in dry-run too, so a `dry-run: true` release rehearses it before a
-real one. Because callers pin `octopus-base` by tag, the guard starts applying to
-a repository only when it bumps that ref — **check what the repository publishes
-today and add the exception in the same PR as the bump**.
+The guard runs in dry-run too, so `dry-run: true` rehearses it before a real release. Callers
+pin `octopus-base` by tag, so the guard starts applying to a repository only when it bumps that
+ref — check what the repository publishes today and add the exception in the same PR as the bump.

--- a/docs/Octopus Developer Guide.md
+++ b/docs/Octopus Developer Guide.md
@@ -191,3 +191,81 @@ jobs:
       publish-to-nexus: false
       register-release-immediately: true
 ```
+
+## What belongs on Maven Central
+
+Maven Central is an exchange for artifacts **other projects consume as a Maven
+dependency**. Deployables and internal tooling do not belong there:
+
+- a service or app ships as a **docker image** on ghcr;
+- a CLI ships as a **GitHub Release asset** (or is built locally);
+- test harnesses and compat suites are internal and have no consumers at all.
+
+This is not a style preference. Sonatype's limits are **monthly and org-wide**
+(80 MB release size, 1000 files, 7 releases), so one repository publishing a
+60 MB Spring Boot fat jar can consume the whole organisation's quota in a single
+release — and Central versions are **immutable**, so a mistake cannot be undone.
+
+Two ways to keep an artifact off Central, depending on the repository:
+
+- **Nothing in the repository is consumed as a dependency** (an app, a UI):
+  set `publish-to-nexus: false` (see the section above) *and* remove the
+  `MavenPublication` from the build script. The workflow input guards the
+  pipeline; without the build-script change a manual `./gradlew publishToSonatype`
+  can still upload.
+- **Some modules are consumed, some are not** (a service plus its client
+  libraries): declare **no publication** for the deployable modules and keep it
+  for the libraries. Note that `tasks.named('publish') { enabled = false }` does
+  *not* work — `publishToSonatype` depends on the `PublishToMavenRepository`
+  tasks, not on the `publish` lifecycle task.
+
+If a repository stops publishing the artifact its `check-and-register.yml` polls,
+re-point that workflow's `artifact-pattern` at a module that is still published,
+or drop the workflow and use `register-release-immediately: true` instead —
+otherwise the release-log gate waits ~90 minutes for an artifact that will never
+appear, then fails.
+
+## The publication guard (`fat-jar-publication-allowlist`)
+
+Before uploading, the release publishes to a throwaway local repository and
+inspects what would reach Central. The release **fails** if an artifact is unfit
+for it:
+
+- a shadow/uber jar (`-all` classifier);
+- a Spring Boot executable jar, detected by a `BOOT-INF/` entry inside the
+  archive — its file name is indistinguishable from a library's;
+- anything larger than `max-central-artifact-mb` (default 8), which catches a
+  shadow jar published with the classifier stripped.
+
+A fat jar often appears without anyone asking for it: the shadow plugin exposes
+`shadowRuntimeElements` as a variant of the `java` component, so `from(components.java)`
+publishes the fat jar alongside the thin one.
+
+If the guard fails your release, pick one:
+
+| Situation | Fix |
+|---|---|
+| The module is a deployable nobody depends on | Stop publishing it (see the section above) |
+| The whole repository is a deployable | `publish-to-nexus: false` |
+| A consumer really resolves this fat jar from a Maven repository — e.g. an automation module fetched by a TeamCity metarunner | Add its artifactId to `fat-jar-publication-allowlist` |
+| A genuinely consumed library is legitimately large | Raise `max-central-artifact-mb` |
+
+The allowlist exists so that a legitimate exception is explicit and reviewed
+instead of silent:
+
+```yaml
+jobs:
+  build:
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@<tag>
+    with:
+      flow-type: hybrid
+      java-version: '21'
+      # The automation module's fat jar is resolved by its TeamCity metarunner
+      # (-Dartifact=<group>:<name>:<version>:jar:all), so it must stay on Central.
+      fat-jar-publication-allowlist: automation
+```
+
+The guard runs in dry-run too, so a `dry-run: true` release rehearses it before a
+real one. Because callers pin `octopus-base` by tag, the guard starts applying to
+a repository only when it bumps that ref — **check what the repository publishes
+today and add the exception in the same PR as the bump**.


### PR DESCRIPTION
## Why

The org is over Maven Central's monthly limits (Release Size 1.21 GB vs 80 MB, File Count 10 094 vs 1 000), and the cause is **deployables reaching Central** — Spring Boot bootJars and shadow/uber jars nobody consumes as a Maven dependency. We are cleaning that up repo by repo (portal#203 merged, CRS#456, api-gateway#34, ORMS#72), but nothing stops it coming back, and **Central versions are immutable** — by the time a quota audit notices, the artifact cannot be removed.

This makes the rule enforceable in the one place all Gradle releases pass through.

## What

A guard step before the upload: publish to a throwaway local repository (`-Dmaven.repo.local`), inspect what *would* go to Central, and fail if an artifact is unfit for it.

Three signals, because no single one is sufficient:

| Signal | Catches |
|---|---|
| `-all.jar` | shadow/uber jar with the conventional classifier |
| `BOOT-INF/` **inside the archive** | Spring Boot executable jar — its file name is indistinguishable from a library's |
| size > `max-central-artifact-mb` (default 8) | a shadow jar published with the classifier **stripped**, which carries no marker at all |

Both `.jar` and `.zip` are inspected — shadow distributions and TeamCity plugin bundles cost the same quota.

Legitimate exceptions go through **`fat-jar-publication-allowlist`** (comma-separated artifactIds), which makes them explicit and reviewable rather than silent. The real case: an automation module whose fat jar a TeamCity metarunner resolves from a Maven repository.

Two deliberate choices:
- **Runs in dry-run too.** That is where the failure is cheapest to act on; catching it during a real release wastes a release attempt.
- **Force-disables signing for its own invocation** via an init script, so the guard never needs the GPG key — it inspects names, sizes and archive contents, which do not require signatures. (An earlier draft passed the signing secrets; review flagged that as new exposure of the key to a code path that previously never ran in dry-run.)

## Rollout — read before merging

Callers pin `octopus-base` by tag, so **nothing breaks on merge**: the guard only applies to a repository once it bumps its ref. But that bump PR must carry the exception, or the release fails. Reviewed state of the consumers:

| Repository | Publishes a fat jar today | Needed with the bump |
|---|---|---|
| octopus-components-registry-service | `components-registry-automation` `-all.jar` (19.7 MB) | `fat-jar-publication-allowlist: components-registry-automation` |
| octopus-release-management-service | `automation` `-all.jar` (21 MB) | `fat-jar-publication-allowlist: automation` |
| octopus-teamcity-automation | shadow `-all` | allowlist entry |
| octopus-sonar-automation | shadow jar, **classifier stripped** (16.4 MB) | allowlist entry (this is the case the size rule exists for) |
| octopus-reporting-service | bootJar + `-all` | stop publishing the deployable, or allowlist |
| octopus-employee-service | bootJar (65 MB) | stop publishing the deployable |
| octopus-dms-service | bootJar | stop publishing the deployable |
| octopus-vcs-facade | bootJar | stop publishing the deployable |
| octopus-api-gateway | bootJar — **being removed** in #34 | nothing, once #34 lands |
| octopus-components-management-portal | already `publish-to-nexus: false` | nothing |
| octopus-external-systems-client | no fat jar | nothing |

For the "stop publishing the deployable" rows the guard is doing exactly the job it exists for — those bootJars are the bulk of the overage.

## Verification

Exercised end-to-end against a **real** CRS publication (31 artifacts) and synthetic fixtures:

| Case | Expected | Result |
|---|--:|--:|
| CRS, `allowlist=components-registry-automation` (9 library modules) | 0 | ✅ 0 — no false positives |
| CRS, empty allowlist | 1 | ✅ 1 — `automation-*-all.jar` (19.69 MB), both markers |
| jar containing `BOOT-INF/`, library-style name | 1 | ✅ 1 — detected by content |
| shadow jar, classifier stripped, 17 MB, no marker | 1 | ✅ 1 — detected by size (this case slipped through the first draft) |
| each of the above, allowlisted | 0 | ✅ 0 |

Independent review (Sonnet) caught two issues, both fixed here: the classifier-stripped false negative, and the signing-key exposure in dry-run.

## Not addressed

The guard scans published files, so a fat artifact carrying no marker and under the size limit would pass. That is a deliberate trade-off against false positives on genuinely large libraries; `max-central-artifact-mb` is the knob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added workflow safeguards to prevent oversized or improperly packaged artifacts from being published to Maven Central.
  * Release now fails early if produced archives look like Spring Boot executable jars, include uber/shadow “-all” artifacts, or exceed the configured size limit (with an allowlist for exceptions).
  * Hardened workflow validation and version/build handling to reduce misconfiguration risk.

* **Documentation**
  * Expanded Maven Central publishing guidance, including deployable-only repositories, mixed-module setups, and examples for configuring publication guards and preventing release-log gating delays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->