### PR TITLE
test(quality): stop generated build scripts from failing ktlint

### DIFF
--- a/gradle-quality-plugin/src/test/kotlin/org/octopusden/octopus/quality/OctopusQualityPluginFunctionalTest.kt
+++ b/gradle-quality-plugin/src/test/kotlin/org/octopusden/octopus/quality/OctopusQualityPluginFunctionalTest.kt
@@ -1339,7 +1339,7 @@ class OctopusQualityPluginFunctionalTest {
                 fun mul(a: Int, b: Int): Int = a * b
                 fun div(a: Int, b: Int): Int = a / b
             }
-            """.trimIndent(),
+            """.trimIndent().withTrailingNewline(),
         )
         writeKotlinFile(
             "src/test/kotlin/com/example/CalcTest.kt",
@@ -1350,7 +1350,7 @@ class OctopusQualityPluginFunctionalTest {
             class CalcTest {
                 @Test fun t() { assertEquals(3, Calc().add(1, 2)) }
             }
-            """.trimIndent(),
+            """.trimIndent().withTrailingNewline(),
         )
     }
 
@@ -1366,7 +1366,7 @@ class OctopusQualityPluginFunctionalTest {
                 public int mul(int a, int b) { return a * b; }
                 public int div(int a, int b) { return a / b; }
             }
-            """.trimIndent(),
+            """.trimIndent().withTrailingNewline(),
         )
         subDir("src/test/java/com/example")
         File(projectDir, "src/test/java/com/example/CalcTest.java").writeText(
@@ -1377,7 +1377,7 @@ class OctopusQualityPluginFunctionalTest {
             class CalcTest {
                 @Test void t() { assertEquals(3, new Calc().add(1, 2)); }
             }
-            """.trimIndent(),
+            """.trimIndent().withTrailingNewline(),
         )
     }
 

--- a/gradle-quality-plugin/src/test/kotlin/org/octopusden/octopus/quality/OctopusQualityPluginFunctionalTest.kt
+++ b/gradle-quality-plugin/src/test/kotlin/org/octopusden/octopus/quality/OctopusQualityPluginFunctionalTest.kt
@@ -54,12 +54,25 @@ class OctopusQualityPluginFunctionalTest {
 
     private val ansiEscape = Regex("\\u001B\\[[0-9;]*m")
 
+    /**
+     * Generated build scripts are ktlint-checked like any other source. Written without a
+     * trailing newline they violate `standard:final-newline`, so `ktlintKotlinScriptCheck`
+     * fails; in a test that runs the aggregate `ktlintCheck`, Gradle then aborts before
+     * `ktlintMainSourceSetCheck` and the source violation the test asserts on is never
+     * reported. Whether that happens depends on task ordering, which is what made
+     * `ktlint scans sources under a build package segment` flaky.
+     *
+     * Kotlin sources are deliberately NOT normalised this way — some tests omit the trailing
+     * newline on purpose to plant a `final-newline` violation.
+     */
+    private fun String.withTrailingNewline(): String = if (endsWith("\n")) this else this + "\n"
+
     private fun settingsFile(content: String) {
-        File(projectDir, "settings.gradle.kts").writeText(content)
+        File(projectDir, "settings.gradle.kts").writeText(content.withTrailingNewline())
     }
 
     private fun buildFile(content: String) {
-        File(projectDir, "build.gradle.kts").writeText(content)
+        File(projectDir, "build.gradle.kts").writeText(content.withTrailingNewline())
     }
 
     private fun subDir(path: String): File = File(projectDir, path).also { it.mkdirs() }
@@ -808,7 +821,7 @@ class OctopusQualityPluginFunctionalTest {
             "package com.example\nfun foo() = 1",
         )
 
-        val result = runner("clean", "ktlintCheck").buildAndFail()
+        val result = runner("clean", "ktlintCheck", "--continue").buildAndFail()
         assertKtlintReported(result, "Bad.kt")
     }
 
@@ -843,7 +856,7 @@ class OctopusQualityPluginFunctionalTest {
             """.trimIndent(),
         )
 
-        val result = runner("clean", "ktlintCheck").buildAndFail()
+        val result = runner("clean", "ktlintCheck", "--continue").buildAndFail()
         // "build.gradle.kts" proves the .kts file was scanned; the rule-message assertion guards
         // against a false positive where the filename appears in unrelated output (deprecation
         // warnings, stack traces). ktlint's PLAIN reporter prints the human message, not the rule id.
@@ -870,7 +883,7 @@ class OctopusQualityPluginFunctionalTest {
                 kotlin { failOnViolation.set(true) }
                 coverage { enabled.set(false) }
             }
-            """.trimIndent() + "\n",
+            """.trimIndent(),
         )
         // Long arithmetic expression — non-comment code so ktlint can't apply any
         // single-string-literal or comment-only exemption. Line length below works
@@ -881,7 +894,7 @@ class OctopusQualityPluginFunctionalTest {
             "package com.example\n\nfun a(): Int = $longExpr\n",
         )
 
-        val result = runner("ktlintCheck").buildAndFail()
+        val result = runner("ktlintCheck", "--continue").buildAndFail()
         assertKtlintReported(result, "Exceeded max line length (140)")
     }
 
@@ -917,7 +930,7 @@ class OctopusQualityPluginFunctionalTest {
             )
             // Reference the val so the Kotlin compiler doesn't strip it as unused.
             tasks.register("printTrigger") { doLast { println(triggerList) } }
-            """.trimIndent() + "\n",
+            """.trimIndent(),
         )
 
         val result = runner("ktlintCheck").build()
@@ -954,7 +967,7 @@ class OctopusQualityPluginFunctionalTest {
                 kotlin { failOnViolation.set(true) }
                 coverage { enabled.set(false) }
             }
-            """.trimIndent() + "\n",
+            """.trimIndent(),
         )
         // 100 chars: violates local 80, well within plugin's 140.
         val line100 = "// " + "x".repeat(97)
@@ -992,7 +1005,7 @@ class OctopusQualityPluginFunctionalTest {
             ktlint {
                 additionalEditorconfig.put("max_line_length", "100")
             }
-            """.trimIndent() + "\n",
+            """.trimIndent(),
         )
         // Long arithmetic expression — non-comment code so ktlint can't apply any
         // single-literal or comment-only exemption. 113 chars: passes plugin's
@@ -1003,7 +1016,7 @@ class OctopusQualityPluginFunctionalTest {
             "package com.example\n\nfun a(): Int = $longExpr\n",
         )
 
-        val result = runner("ktlintCheck").buildAndFail()
+        val result = runner("ktlintCheck", "--continue").buildAndFail()
         assertKtlintReported(result, "max line length")
     }
 
@@ -1070,7 +1083,7 @@ class OctopusQualityPluginFunctionalTest {
             "package org.octopusden.octopus.build.integration\n\nimport java.util.*\n\nval x: UUID? = null\n",
         )
 
-        val result = runner("ktlintCheck").buildAndFail()
+        val result = runner("ktlintCheck", "--continue").buildAndFail()
         assertKtlintReported(result, "Bad.kt", "Wildcard import")
     }
 
@@ -1326,7 +1339,7 @@ class OctopusQualityPluginFunctionalTest {
                 fun mul(a: Int, b: Int): Int = a * b
                 fun div(a: Int, b: Int): Int = a / b
             }
-            """.trimIndent() + "\n",
+            """.trimIndent(),
         )
         writeKotlinFile(
             "src/test/kotlin/com/example/CalcTest.kt",
@@ -1337,7 +1350,7 @@ class OctopusQualityPluginFunctionalTest {
             class CalcTest {
                 @Test fun t() { assertEquals(3, Calc().add(1, 2)) }
             }
-            """.trimIndent() + "\n",
+            """.trimIndent(),
         )
     }
 
@@ -1353,7 +1366,7 @@ class OctopusQualityPluginFunctionalTest {
                 public int mul(int a, int b) { return a * b; }
                 public int div(int a, int b) { return a / b; }
             }
-            """.trimIndent() + "\n",
+            """.trimIndent(),
         )
         subDir("src/test/java/com/example")
         File(projectDir, "src/test/java/com/example/CalcTest.java").writeText(
@@ -1364,7 +1377,7 @@ class OctopusQualityPluginFunctionalTest {
             class CalcTest {
                 @Test void t() { assertEquals(3, new Calc().add(1, 2)); }
             }
-            """.trimIndent() + "\n",
+            """.trimIndent(),
         )
     }
 


### PR DESCRIPTION
## Why

`OctopusQualityPluginFunctionalTest > ktlint scans sources under a build package segment` **failed the octopus-base release run**, so v2.6.0 was never tagged and version 2.6.0 is stuck in a Sonatype staging repository awaiting manual cleanup. The same test failed once on a PR run and passed on a plain re-run of the identical commit.

The report gave no hint of the real problem — it contained only:

```
/tmp/junit-…/build.gradle.kts:10:1: File must end with a newline (\n) (standard:final-newline)
```

`Bad.kt`, where the test plants the wildcard-import violation it asserts on, was absent entirely.

## Cause

`settingsFile()` / `buildFile()` wrote fixture content verbatim, and the callers pass `""" … """.trimIndent()`, which ends without a newline. So **every** generated `build.gradle.kts` violated `standard:final-newline`.

The affected tests run the aggregate `ktlintCheck`. That task fans out through plain `dependsOn` to `ktlintKotlinScriptCheck` (the script) and `ktlintMainSourceSetCheck` (`Bad.kt`), with **no ordering between the two** — confirmed in `ktlint-gradle-14.0.1`. Without `--continue`, whichever fails first aborts the build. When the script check went first, the source set was never scanned, so the asserted violation was never reported and `assertKtlintReported` failed with `expected: <true> but was: <false>`.

Hence the flakiness: the build fails either way (the test expects `buildAndFail`), but *why* it failed depended on scheduling.

## What

- **Normalise generated build scripts** to end with a newline. Kotlin sources are deliberately **not** normalised — two tests plant a `final-newline` violation in a `.kt` file on purpose.
- **Drop eight ad-hoc `""".trimIndent() + "\n"` call sites.** This bug had already been hit and patched one fixture at a time, which is exactly why tests written later were exposed again. The helper now covers all of them, so the workaround does not linger next to the general fix.
- **Pass `--continue` in the five ktlint tests that assert a specific finding**, so an unrelated task failure can no longer hide the asserted one. This guards the same *class* of flake — e.g. a future ktlint version adding a default rule that some fixture trips. Not applied globally: several tests assert exact `TaskOutcome`s, where running more tasks could change expectations.

## Verification

| Check | Result |
|---|--:|
| Script check on the fixture, **without** the newline fix | ❌ `BUILD FAILED` |
| Same, **with** the fix | ✅ `BUILD SUCCESSFUL` |
| Full suite | ✅ **63 tests, 0 failures, 0 errors** |
| `ktlint baselined violation passes after clean` (relies on a `.kt` file lacking a trailing newline) | ✅ passed |

The first two rows isolate the mechanism deterministically: same test, same commit, only the trailing newline differs.

**Honest limitation:** the flake itself did not reproduce locally — the unfixed test passed, which is consistent with the ordering-dependent explanation. The diagnosis therefore rests on the release log (only the script violation present, `Bad.kt` absent), the deterministic probe above, and the absence of ordering between the two ktlint tasks — not on a local reproduction.

## Follow-up, not in this PR

Version **2.6.0 is staged but unpublished** on Sonatype (`org.octopusden--e9df3594-…`). A plain re-run of the release would upload it a second time; the staging repository has to be dropped first, or the run resumed with `resume-deployment-id` once a Portal deployment is mapped. Nothing reached Maven Central — 2.5.2 is still the latest published version.

Independent review (Sonnet): diagnosis confirmed by decompiling the ktlint plugin; the eight redundant workarounds and the `--continue` hardening are its findings, applied here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved functional test reliability when validating ktlint violations.
  * Added consistent handling for trailing newlines in generated Gradle scripts and fixture files.
  * Preserved targeted missing-newline and editor configuration test scenarios.
  * Updated failing lint checks to continue execution so expected violations can be verified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->