### PR TITLE
fix(release): tag the commit that was actually built

### DIFF
--- a/.github/scripts/resolve-released-version.sh
+++ b/.github/scripts/resolve-released-version.sh
@@ -21,7 +21,11 @@
 #      keeps the run id while the public flow recomputes the version, so id alone would
 #      match two different releases.
 #   3. The single version tag on the commit the run reports. Correct only when that
-#      commit carries exactly one version tag.
+#      commit carries exactly one version tag. Note that RELEASE_RUN_SHA is the release
+#      run's reported commit — for a repository_dispatch run, the default-branch head at
+#      dispatch time — while the release workflow now tags the commit it actually BUILT.
+#      For a hybrid release of anything other than that head the two differ by design, so
+#      this source simply will not match; source 2 covers those releases.
 #   4. The most recently created release. Last resort, for a release made before the
 #      stamp existed.
 #

--- a/.github/scripts/resolve-released-version.sh
+++ b/.github/scripts/resolve-released-version.sh
@@ -20,12 +20,16 @@
 #      it is the only identity that cannot drift. The attempt matters because a rerun
 #      keeps the run id while the public flow recomputes the version, so id alone would
 #      match two different releases.
-#   3. The single version tag on the commit the run reports. Correct only when that
-#      commit carries exactly one version tag. Note that RELEASE_RUN_SHA is the release
-#      run's reported commit — for a repository_dispatch run, the default-branch head at
-#      dispatch time — while the release workflow now tags the commit it actually BUILT.
-#      For a hybrid release of anything other than that head the two differ by design, so
-#      this source simply will not match; source 2 covers those releases.
+#      Its lookup must succeed: see the fail-closed note at the call site for why a failed
+#      one cannot be treated as "unstamped".
+#   3. The single version tag on the commit the run reports. Correct only when that commit
+#      carries exactly one version tag. RELEASE_RUN_SHA is the run's REPORTED commit — for
+#      a repository_dispatch run, the default-branch head at dispatch time — while the
+#      release workflow tags the commit it actually BUILT, so for a hybrid release of
+#      anything else the two differ by design. That is sound rather than lucky: source 3
+#      is only reached once source 2 has looked and found nothing, which means the release
+#      predates stamping — and releases from that era were tagged on the reported commit,
+#      which is exactly what this source reads.
 #   4. The most recently created release. Last resort, for a release made before the
 #      stamp existed.
 #
@@ -75,8 +79,17 @@ fi
 if [ -n "$RELEASE_RUN_ID" ] && [ -n "$RELEASE_RUN_ATTEMPT" ] && [ -n "$GITHUB_REPOSITORY" ]; then
   # Delimited so one run's marker cannot be a prefix of another's (555/1 vs 555/10).
   marker="<!-- octopus-release-run: ${RELEASE_RUN_ID}/${RELEASE_RUN_ATTEMPT} -->"
+  # Fail closed. An unreadable release list is NOT the same as "no release carries this
+  # stamp", and conflating them is how a transient blip turns into a wrongly registered
+  # version: the run falls through to source 3, finds the one tag an EARLIER release left
+  # on the commit this run reports, and registers that version with every job green.
+  stamp_lookup=0
   stamped="$(gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=50" \
-    --jq "map(select((.body // \"\") | contains(\"${marker}\"))) | first | .tag_name // empty" 2>/dev/null || true)"
+    --jq "map(select((.body // \"\") | contains(\"${marker}\"))) | first | .tag_name // empty" 2>&1)" || stamp_lookup=$?
+  if [ "$stamp_lookup" -ne 0 ]; then
+    printf '%s\n' "$stamped" >&2
+    die "Could not read this repository's releases, so the release stamped by run ${RELEASE_RUN_ID}/${RELEASE_RUN_ATTEMPT} cannot be identified. Refusing to fall back to tag topology, which can name a version an earlier run released. Re-run when the API is reachable, or pass release-version explicitly."
+  fi
   if [ -n "$stamped" ] && [ "$stamped" != "null" ]; then
     version="${stamped#v}"
     if grep -qE "$SEMVER" <<<"$version"; then

--- a/.github/scripts/test/gh
+++ b/.github/scripts/test/gh
@@ -6,13 +6,16 @@
 #   STAMPED_FOR_RUN      run id/attempt that stamp belongs to, e.g. 555/1; a query about
 #                        any other run or attempt gets nothing, so a script that ignores
 #                        either cannot pass
+#   STAMP_LOOKUP_FAILS   when non-empty, the release LIST call fails like a rate limit or
+#                        5xx would; kept separate from LATEST_RELEASE_FAILS so a failed
+#                        stamp lookup can be told apart from an unreadable latest release
 #   LATEST_RELEASE_TAG   tag_name to report for repos/<repo>/releases/latest
-#   LATEST_RELEASE_FAILS when non-empty, behave like a failed API call
+#   LATEST_RELEASE_FAILS when non-empty, repos/<repo>/releases/latest fails
 set -u
 
 if [ "${1:-}" = "api" ] && [[ "${2:-}" == repos/*/releases\?per_page=* ]]; then
-  if [ -n "${LATEST_RELEASE_FAILS:-}" ]; then
-    echo "gh: could not list releases" >&2
+  if [ -n "${STAMP_LOOKUP_FAILS:-}" ]; then
+    echo "gh: could not list releases (HTTP 502)" >&2
     exit 1
   fi
   # The script embeds the marker it is looking for in the jq filter; only answer when

--- a/.github/scripts/test/resolve-released-version-scenarios.sh
+++ b/.github/scripts/test/resolve-released-version-scenarios.sh
@@ -38,7 +38,7 @@ run() { # name expected_status expected_stdout_or_stderr_regex [stderr_regex] en
   PATH="$here:$PATH" env \
     EXPLICIT_VERSION= RELEASE_RUN_ID= RELEASE_RUN_ATTEMPT= RELEASE_RUN_SHA= \
     GITHUB_REPOSITORY= GH_TOKEN= \
-    TAGS_AT_SHA= TAGS_FOR_SHA= LATEST_RELEASE_TAG= LATEST_RELEASE_FAILS= \
+    TAGS_AT_SHA= TAGS_FOR_SHA= LATEST_RELEASE_TAG= LATEST_RELEASE_FAILS= STAMP_LOOKUP_FAILS= \
     STAMPED_RELEASE_TAG= STAMPED_FOR_RUN= \
     "$@" bash "$script" >"$outfile" 2>"$errfile"
   status=$?
@@ -126,6 +126,17 @@ run 'no tag on the reported commit falls back' 0 '2.2.37' \
 run 'several tags on one commit fall back' 0 '2.2.36' 'several version tags' \
   RELEASE_RUN_SHA=cdfdd24d TAGS_FOR_SHA=cdfdd24d TAGS_AT_SHA='v2.2.35 v2.2.36' LATEST_RELEASE_TAG=v2.2.36 "${common[@]}"
 run 'fallback explains itself' 0 '2.2.37' 'most recently created release' \
+  RELEASE_RUN_SHA=deadbeef TAGS_FOR_SHA=deadbeef TAGS_AT_SHA='' LATEST_RELEASE_TAG=v2.2.37 "${common[@]}"
+
+# A failed stamp lookup is not an unstamped release. Falling through would let the tag an
+# EARLIER release left on the commit this run reports answer for this one — silently, and
+# with every job green, because the release log's dedup step then skips the version that
+# really shipped. Both scenarios below pass trivially if that distinction is dropped.
+run 'failed stamp lookup does not read as unstamped' 1 'Refusing to fall back to tag topology' \
+  RELEASE_RUN_ID=555 RELEASE_RUN_ATTEMPT=1 STAMP_LOOKUP_FAILS=1 \
+  RELEASE_RUN_SHA=tipsha TAGS_FOR_SHA=tipsha TAGS_AT_SHA='v2.2.36' LATEST_RELEASE_TAG=v2.2.37 "${common[@]}"
+run 'failed stamp lookup does not fall through to the latest release either' 1 'Re-run when the API is reachable' \
+  RELEASE_RUN_ID=555 RELEASE_RUN_ATTEMPT=1 STAMP_LOOKUP_FAILS=1 \
   RELEASE_RUN_SHA=deadbeef TAGS_FOR_SHA=deadbeef TAGS_AT_SHA='' LATEST_RELEASE_TAG=v2.2.37 "${common[@]}"
 
 # Nothing can answer: fail with something actionable rather than registering a guess.

--- a/.github/workflows/common-java-gradle-release.yml
+++ b/.github/workflows/common-java-gradle-release.yml
@@ -218,30 +218,35 @@ jobs:
         with:
           ref: ${{ inputs.commit-hash }}
 
-      # A release must be able to tag the commit it builds — but for some commits
-      # GITHUB_TOKEN cannot. GitHub refuses ANY ref update, via REST or git push, that
-      # points a ref at a commit whose `.github/workflows/` files differ from the default
-      # branch, unless the token is authorized to modify workflows — which the
-      # GITHUB_TOKEN of Actions can never be. Verified empirically against a real
-      # repository: the identical request succeeds at the default-branch head and is
-      # refused for an older commit whose workflow files differ, and the REST refusal is
-      # masked as HTTP 404 (`git push` says so plainly: "refusing to allow ... to create
-      # or update workflow ... without `workflow` scope").
+      # A release must be able to tag the commit it builds — and for some commits the
+      # Actions GITHUB_TOKEN cannot. GitHub refuses any ref update, REST or git push,
+      # that points a ref at a commit carrying a workflow file that exists on no branch
+      # head, unless the token is authorized to modify workflows, which GITHUB_TOKEN can
+      # never be. Measured against a real repository with a token lacking `workflow`
+      # scope, which is the same authorization GITHUB_TOKEN lacks:
       #
-      # This is checked here, before the build and the publish, because the tagging step
-      # runs after artifacts are already on Maven Central. Failing there would leave a
-      # version published, immutable, and untagged; failing here costs nothing.
+      #   default-branch head                                          -> allowed
+      #   head of another branch, workflows differing from the default  -> allowed
+      #   non-head commit whose workflows equal another branch head's   -> allowed
+      #   commit merely missing a workflow file a branch head has       -> allowed
+      #   non-head commit whose workflows match no branch head          -> REFUSED
       #
-      # Deliberately skipped under dry-run, and NOT only to mirror the tagging step: the
-      # octopus-test canary dispatches its smoke releases with `commit-hash: github.sha`
-      # on a `verify/*` branch whose whole purpose is to repoint `uses:` at the octopus-base
-      # commit under test, so its workflow files always differ from the default branch.
-      # Running this check under dry-run would therefore fail every canary run, while
-      # protecting nothing — a dry run creates no tag.
+      # So the operative rule is "every workflow file this commit carries exists
+      # byte-identical on some branch head"; deleting one does not count as modifying it.
+      # Comparing against the default branch alone would be wrong — it would refuse the
+      # ordinary release of a maintenance-branch tip, which GitHub allows. REST disguises
+      # the refusal as HTTP 404; git push states it outright ("refusing to allow ... to
+      # create or update workflow ... without `workflow` scope").
+      #
+      # Checked before the build and the publish, because the tagging step runs after the
+      # artifacts are on Maven Central: failing there leaves a version published,
+      # immutable and untagged, while failing here costs nothing. It runs under dry-run
+      # too — it is read-only, and dry runs skip the tagging step itself, so this is the
+      # only coverage the logic gets.
       - name: Fail early if the built commit cannot be tagged
-        if: ${{ !inputs.dry-run }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRY_RUN: ${{ inputs.dry-run }}
         run: |
           set -euo pipefail
 
@@ -250,38 +255,82 @@ jobs:
           default_head="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${default_branch}" --jq '.sha')"
 
           if [ "$built_sha" = "$default_head" ]; then
-            echo "Built commit is the ${default_branch} head: tagging is unrestricted."
+            echo "Built commit is the ${default_branch} head: the tag can be created."
             exit 0
           fi
 
-          # Compare blob shas of the workflow directory rather than the commit diff: the
-          # compare API caps `files` at 300 entries, which a wide backport could exceed,
-          # hiding the very file that triggers the refusal. Only files present in the
-          # BUILT tree matter — the refusal is about the tagged commit creating or
-          # updating a workflow, so a workflow that exists only on the default branch is
-          # not a problem. A missing directory (404) yields an empty list.
+          # One "name blob-sha" line per workflow file. Fail closed: only a confirmed 404
+          # (no such directory at that ref) may be read as "no workflow files". Treating a
+          # rate limit, 5xx or auth error as an empty list would wave through exactly the
+          # release this step exists to stop. The directory listing is used rather than a
+          # commit diff because the compare API caps `files` at 300 entries, which a wide
+          # backport can exceed, hiding the one file that triggers the refusal.
           list_workflows() {
-            gh api "repos/${GITHUB_REPOSITORY}/contents/.github/workflows?ref=$1" \
-              --jq '[.[] | select(.type == "file") | .name + " " + .sha] | sort | .[]' 2>/dev/null || true
+            local out rc=0
+            out="$(gh api "repos/${GITHUB_REPOSITORY}/contents/.github/workflows?ref=$1" \
+              --jq '[.[] | select(.type == "file") | .name + " " + .sha] | sort | .[]' 2>&1)" || rc=$?
+            if [ "$rc" -eq 0 ]; then
+              printf '%s\n' "$out"
+              return 0
+            fi
+            if grep -qE 'HTTP 404|"status": ?"404"' <<<"$out"; then
+              return 0
+            fi
+            printf '%s\n' "$out" >&2
+            echo "::error title=Workflow listing failed::Could not list .github/workflows at $1, so whether ${built_sha} can be tagged is unknown. Refusing to start a release on unverified state; re-run when the API is reachable." >&2
+            return 1
           }
 
+          # Names of workflow files the built commit carries that the candidate does not
+          # carry identically. Empty means the candidate covers the built commit.
+          missing_against() {
+            local candidate_list="$1" missing="" entry
+            while IFS= read -r entry; do
+              [ -n "$entry" ] || continue
+              grep -qxF -- "$entry" <<<"$candidate_list" || missing="${missing}${missing:+, }${entry%% *}"
+            done <<<"$built_list"
+            printf '%s' "$missing"
+          }
+
+          # Assign every lookup to a variable: a command substitution that fails inside an
+          # argument list would not trip `set -e`, quietly restoring the fail-open bug.
           built_list="$(list_workflows "$built_sha")"
           default_list="$(list_workflows "$default_head")"
+          blocking="$(missing_against "$default_list")"
 
-          blocking=""
-          while IFS= read -r entry; do
-            [ -n "$entry" ] || continue
-            if ! grep -qxF -- "$entry" <<<"$default_list"; then
-              blocking="${blocking}${blocking:+, }${entry%% *}"
-            fi
-          done <<<"$built_list"
-
-          if [ -n "$blocking" ]; then
-            echo "::error title=Built commit cannot be tagged::This release builds ${built_sha}, whose workflow files differ from ${default_branch} (${blocking}). GitHub refuses to point a tag at such a commit with the Actions GITHUB_TOKEN, so the release could be published and never tagged. Release from a commit whose .github/workflows match ${default_branch}, or give the release a token authorized to modify workflows." >&2
-            exit 1
+          if [ -z "$blocking" ]; then
+            echo "Workflow files at ${built_sha} are present unchanged on ${default_branch}: the tag can be created."
+            exit 0
           fi
 
-          echo "Workflow files at ${built_sha} match ${default_branch}: the tag can be created."
+          # Any branch head will do, so try the rest, stopping at the first that covers
+          # the built tree. This is the path a maintenance-branch release takes.
+          branch_heads="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/branches" --jq '.[].commit.sha' | sort -u)"
+          while IFS= read -r branch_head; do
+            [ -n "$branch_head" ] || continue
+            [ "$branch_head" = "$default_head" ] && continue
+            if [ "$branch_head" = "$built_sha" ]; then
+              echo "Built commit is a branch head: the tag can be created."
+              exit 0
+            fi
+            candidate_list="$(list_workflows "$branch_head")"
+            if [ -z "$(missing_against "$candidate_list")" ]; then
+              echo "Workflow files at ${built_sha} are present unchanged on branch head ${branch_head}: the tag can be created."
+              exit 0
+            fi
+          done <<<"$branch_heads"
+
+          # A dry run publishes nothing and creates no tag, so there is nothing to
+          # protect: report and pass. This keeps the check exercised by the dry-run
+          # canary — whose commit is a pull-request merge commit, and therefore the head
+          # of no branch — without letting branch topology fail a rehearsal.
+          if [ "${DRY_RUN}" = "true" ]; then
+            echo "::warning title=Built commit would not be taggable::${built_sha} carries workflow files (${blocking}) that exist on no branch head, so a REAL release of this commit would be refused a tag. Ignored because this is a dry run."
+            exit 0
+          fi
+
+          echo "::error title=Built commit cannot be tagged::This release builds ${built_sha}, which carries workflow files (${blocking}) that exist on no branch head. GitHub refuses to point a tag at such a commit with the Actions GITHUB_TOKEN, so the release would publish and then fail untagged. Release a commit whose .github/workflows match a branch head, or give the release a token authorized to modify workflows." >&2
+          exit 1
 
       # determine release version (for public flow)
       - name: Get latest tag
@@ -735,8 +784,18 @@ jobs:
           # backport case this fix exists for — and it would fail here, after the artifacts are
           # already published. Creating a plain ref to an existing commit has no such
           # restriction; --verify-tag then pins the release to that tag.
-          gh api "repos/${GITHUB_REPOSITORY}/git/refs" \
-            -f ref="refs/tags/${TAG}" -f sha="${built_sha}" --jq '.ref' >/dev/null
+          # The pre-build check said this commit was taggable, but branches move: a
+          # workflow change merged while the build ran can withdraw that, and by now the
+          # artifacts are published and immutable. Say so explicitly rather than leaving a
+          # bare masked 404 in the log.
+          ref_create=0
+          ref_create_out="$(gh api "repos/${GITHUB_REPOSITORY}/git/refs" \
+            -f ref="refs/tags/${TAG}" -f sha="${built_sha}" --jq '.ref' 2>&1)" || ref_create=$?
+          if [ "$ref_create" -ne 0 ]; then
+            printf '%s\n' "$ref_create_out" >&2
+            echo "::error title=Tag creation refused::Could not create ${TAG} at ${built_sha}. An HTTP 404 here means GitHub refused the ref update because the commit carries a workflow file that now matches no branch head — the pre-build check passed, so a branch moved while this release was building. The artifacts for this version are already published and cannot be published again: create the tag manually with a token authorized to modify workflows, then re-run to attach the release." >&2
+            exit 1
+          fi
           gh release create "$TAG" --verify-tag --title "$TAG" --generate-notes
           echo "Created tag and release $TAG at $built_sha"
 

--- a/.github/workflows/common-java-gradle-release.yml
+++ b/.github/workflows/common-java-gradle-release.yml
@@ -303,31 +303,44 @@ jobs:
             exit 0
           fi
 
-          # Any branch head will do, so try the rest, stopping at the first that covers
-          # the built tree. This is the path a maintenance-branch release takes.
-          branch_heads="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/branches" --jq '.[].commit.sha' | sort -u)"
+          # Any branch head will do. Fetch them once, failing closed: an unreadable branch
+          # list must stop the release, not read as "no branch covers this commit".
+          branch_lookup=0
+          branch_heads_raw="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/branches" --jq '.[].commit.sha' 2>&1)" || branch_lookup=$?
+          if [ "$branch_lookup" -ne 0 ]; then
+            printf '%s\n' "$branch_heads_raw" >&2
+            echo "::error title=Branch lookup failed::Could not list branches, so whether ${built_sha} can be tagged is unknown. Refusing to start a release on unverified state; re-run when the API is reachable." >&2
+            exit 1
+          fi
+          branch_heads="$(sort -u <<<"$branch_heads_raw")"
+
+          # A commit that IS a branch head has workflow files trivially identical to that
+          # head's, so it is taggable. Checked before the scan below because it costs no
+          # further API calls and is the ordinary maintenance-branch-tip release.
+          if grep -qxF -- "$built_sha" <<<"$branch_heads"; then
+            echo "Built commit is a branch head: the tag can be created."
+            exit 0
+          fi
+
+          # The remaining question — does some OTHER branch head carry these same workflow
+          # files — costs one call per branch, and only a real release needs the answer: a
+          # dry run neither publishes nor tags, so it stops here rather than scanning. This
+          # matters because the dry-run canary builds a pull-request merge commit, which
+          # heads no branch, and would otherwise scan every branch on every run.
+          if [ "${DRY_RUN}" = "true" ]; then
+            echo "::warning title=Built commit may not be taggable::${built_sha} carries workflow files (${blocking}) that are not on ${default_branch}, and it heads no branch. A REAL release would now scan the other branch heads for a match and refuse the release if none covered it. Skipped here because this is a dry run."
+            exit 0
+          fi
+
           while IFS= read -r branch_head; do
             [ -n "$branch_head" ] || continue
             [ "$branch_head" = "$default_head" ] && continue
-            if [ "$branch_head" = "$built_sha" ]; then
-              echo "Built commit is a branch head: the tag can be created."
-              exit 0
-            fi
             candidate_list="$(list_workflows "$branch_head")"
             if [ -z "$(missing_against "$candidate_list")" ]; then
               echo "Workflow files at ${built_sha} are present unchanged on branch head ${branch_head}: the tag can be created."
               exit 0
             fi
           done <<<"$branch_heads"
-
-          # A dry run publishes nothing and creates no tag, so there is nothing to
-          # protect: report and pass. This keeps the check exercised by the dry-run
-          # canary — whose commit is a pull-request merge commit, and therefore the head
-          # of no branch — without letting branch topology fail a rehearsal.
-          if [ "${DRY_RUN}" = "true" ]; then
-            echo "::warning title=Built commit would not be taggable::${built_sha} carries workflow files (${blocking}) that exist on no branch head, so a REAL release of this commit would be refused a tag. Ignored because this is a dry run."
-            exit 0
-          fi
 
           echo "::error title=Built commit cannot be tagged::This release builds ${built_sha}, which carries workflow files (${blocking}) that exist on no branch head. GitHub refuses to point a tag at such a commit with the Actions GITHUB_TOKEN, so the release would publish and then fail untagged. Release a commit whose .github/workflows match a branch head, or give the release a token authorized to modify workflows." >&2
           exit 1
@@ -778,12 +791,13 @@ jobs:
             exit 1
           fi
 
-          # The tag is ours to create. Create the ref directly at the built commit instead of
-          # `release create --target`: the Create Release endpoint rejects GITHUB_TOKEN when the
-          # target commit differs from the default branch under .github/workflows — exactly the
-          # backport case this fix exists for — and it would fail here, after the artifacts are
-          # already published. Creating a plain ref to an existing commit has no such
-          # restriction; --verify-tag then pins the release to that tag.
+          # The tag is ours to create. The ref is created directly rather than through
+          # `release create --target` because --target is ignored once a tag exists (see
+          # above), and because creating the ref makes the ONE operation that can be
+          # refused explicit and separately reportable. It carries no lesser restriction
+          # than the release endpoint: the workflow-file rule measured in the pre-build
+          # check applies to any ref update, this one included. --verify-tag then pins the
+          # release to the tag that was just created.
           # The pre-build check said this commit was taggable, but branches move: a
           # workflow change merged while the build ran can withdraw that, and by now the
           # artifacts are published and immutable. Say so explicitly rather than leaving a

--- a/.github/workflows/common-java-gradle-release.yml
+++ b/.github/workflows/common-java-gradle-release.yml
@@ -218,6 +218,64 @@ jobs:
         with:
           ref: ${{ inputs.commit-hash }}
 
+      # A release must be able to tag the commit it builds — but for some commits
+      # GITHUB_TOKEN cannot. GitHub refuses ANY ref update, via REST or git push, that
+      # points a ref at a commit whose `.github/workflows/` files differ from the default
+      # branch, unless the token is authorized to modify workflows — which the
+      # GITHUB_TOKEN of Actions can never be. Verified empirically against a real
+      # repository: the identical request succeeds at the default-branch head and is
+      # refused for an older commit whose workflow files differ, and the REST refusal is
+      # masked as HTTP 404 (`git push` says so plainly: "refusing to allow ... to create
+      # or update workflow ... without `workflow` scope").
+      #
+      # This is checked here, before the build and the publish, because the tagging step
+      # runs after artifacts are already on Maven Central. Failing there would leave a
+      # version published, immutable, and untagged; failing here costs nothing.
+      - name: Fail early if the built commit cannot be tagged
+        if: ${{ !inputs.dry-run }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          built_sha="$(git rev-parse HEAD)"
+          default_branch="$(gh api "repos/${GITHUB_REPOSITORY}" --jq '.default_branch')"
+          default_head="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${default_branch}" --jq '.sha')"
+
+          if [ "$built_sha" = "$default_head" ]; then
+            echo "Built commit is the ${default_branch} head: tagging is unrestricted."
+            exit 0
+          fi
+
+          # Compare blob shas of the workflow directory rather than the commit diff: the
+          # compare API caps `files` at 300 entries, which a wide backport could exceed,
+          # hiding the very file that triggers the refusal. Only files present in the
+          # BUILT tree matter — the refusal is about the tagged commit creating or
+          # updating a workflow, so a workflow that exists only on the default branch is
+          # not a problem. A missing directory (404) yields an empty list.
+          list_workflows() {
+            gh api "repos/${GITHUB_REPOSITORY}/contents/.github/workflows?ref=$1" \
+              --jq '[.[] | select(.type == "file") | .name + " " + .sha] | sort | .[]' 2>/dev/null || true
+          }
+
+          built_list="$(list_workflows "$built_sha")"
+          default_list="$(list_workflows "$default_head")"
+
+          blocking=""
+          while IFS= read -r entry; do
+            [ -n "$entry" ] || continue
+            if ! grep -qxF -- "$entry" <<<"$default_list"; then
+              blocking="${blocking}${blocking:+, }${entry%% *}"
+            fi
+          done <<<"$built_list"
+
+          if [ -n "$blocking" ]; then
+            echo "::error title=Built commit cannot be tagged::This release builds ${built_sha}, whose workflow files differ from ${default_branch} (${blocking}). GitHub refuses to point a tag at such a commit with the Actions GITHUB_TOKEN, so the release could be published and never tagged. Release from a commit whose .github/workflows match ${default_branch}, or give the release a token authorized to modify workflows." >&2
+            exit 1
+          fi
+
+          echo "Workflow files at ${built_sha} match ${default_branch}: the tag can be created."
+
       # determine release version (for public flow)
       - name: Get latest tag
         if: inputs.flow-type == 'public'
@@ -638,9 +696,19 @@ jobs:
               echo "::error title=Release tag conflict::Tag ${TAG} already exists at ${tag_sha}, but this run built ${built_sha}. Not moving it. Delete the tag and its release (release immutability may prevent this once published), or release a new version." >&2
               exit 1
             fi
-            if gh release view "$TAG" >/dev/null 2>&1; then
+            # Fail closed here too: gh exits non-zero for a missing release and for a
+            # rate limit, auth error or 5xx alike, and reading the latter as "no release"
+            # makes the next line fail with a misleading "release already exists".
+            rel_lookup=0
+            rel_out="$(gh release view "$TAG" 2>&1)" || rel_lookup=$?
+            if [ "$rel_lookup" -eq 0 ]; then
               echo "Release $TAG already exists at $built_sha — nothing to do."
               exit 0
+            fi
+            if ! grep -qE 'release not found|HTTP 404|"status": ?"404"' <<<"$rel_out"; then
+              echo "$rel_out" >&2
+              echo "::error title=Release lookup failed::Could not determine whether release ${TAG} exists. Refusing to act on unverified state; re-run when the API is reachable." >&2
+              exit 1
             fi
             # Tag is correct but has no release: adopt it instead of creating a second one.
             gh release create "$TAG" --verify-tag --title "$TAG" --generate-notes
@@ -648,7 +716,7 @@ jobs:
             exit 0
           fi
 
-          if ! grep -q "HTTP 404" <<<"$ref_out"; then
+          if ! grep -qE 'HTTP 404|"status": ?"404"' <<<"$ref_out"; then
             echo "$ref_out" >&2
             echo "::error title=Tag lookup failed::Could not determine whether ${TAG} exists (the lookup failed with something other than 404). Refusing to create a release on unverified state; re-run when the API is reachable." >&2
             exit 1

--- a/.github/workflows/common-java-gradle-release.yml
+++ b/.github/workflows/common-java-gradle-release.yml
@@ -607,7 +607,7 @@ jobs:
       # default-branch head at dispatch time, frozen for the run, regardless of what was
       # checked out. A hybrid release of anything other than the current tip therefore
       # tagged code that was never built. HEAD here is the build's own checkout, so the
-      # tag is correct by construction and the release's target_commitish follows it.
+      # tag is correct by construction and the release is created from that tag.
       - name: Create release
         if: ${{ !inputs.dry-run }}
         env:
@@ -624,7 +624,14 @@ jobs:
           # unless it is removed separately — would otherwise silently re-point a new release at
           # stale code, which is the very bug this step exists to prevent. Ask the API rather than
           # the local clone: checkout is shallow and never fetches other tags.
-          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}" --jq '.object.sha' >/dev/null 2>&1; then
+          #
+          # Fail closed: only a confirmed 404 means the tag does not exist. gh exits non-zero
+          # for auth failures, rate limits, 5xx and network errors alike, and treating any of
+          # those as "no tag" would fall through to creation on unverified state.
+          ref_lookup=0
+          ref_out="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}" 2>&1)" || ref_lookup=$?
+
+          if [ "$ref_lookup" -eq 0 ]; then
             # Resolve through /commits so an annotated tag yields its commit, not the tag object.
             tag_sha="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${TAG}" --jq '.sha')"
             if [[ "$tag_sha" != "$built_sha" ]]; then
@@ -641,8 +648,22 @@ jobs:
             exit 0
           fi
 
-          gh release create "$TAG" --target "$built_sha" --title "$TAG" --generate-notes
-          echo "Created release $TAG at $built_sha"
+          if ! grep -q "HTTP 404" <<<"$ref_out"; then
+            echo "$ref_out" >&2
+            echo "::error title=Tag lookup failed::Could not determine whether ${TAG} exists (the lookup failed with something other than 404). Refusing to create a release on unverified state; re-run when the API is reachable." >&2
+            exit 1
+          fi
+
+          # The tag is ours to create. Create the ref directly at the built commit instead of
+          # `release create --target`: the Create Release endpoint rejects GITHUB_TOKEN when the
+          # target commit differs from the default branch under .github/workflows — exactly the
+          # backport case this fix exists for — and it would fail here, after the artifacts are
+          # already published. Creating a plain ref to an existing commit has no such
+          # restriction; --verify-tag then pins the release to that tag.
+          gh api "repos/${GITHUB_REPOSITORY}/git/refs" \
+            -f ref="refs/tags/${TAG}" -f sha="${built_sha}" --jq '.ref' >/dev/null
+          gh release create "$TAG" --verify-tag --title "$TAG" --generate-notes
+          echo "Created tag and release $TAG at $built_sha"
 
       # Bind the release to the run that produced it. Registration happens afterwards
       # in a workflow_run context whose only trustworthy identity is this run's id and

--- a/.github/workflows/common-java-gradle-release.yml
+++ b/.github/workflows/common-java-gradle-release.yml
@@ -231,6 +231,13 @@ jobs:
       # This is checked here, before the build and the publish, because the tagging step
       # runs after artifacts are already on Maven Central. Failing there would leave a
       # version published, immutable, and untagged; failing here costs nothing.
+      #
+      # Deliberately skipped under dry-run, and NOT only to mirror the tagging step: the
+      # octopus-test canary dispatches its smoke releases with `commit-hash: github.sha`
+      # on a `verify/*` branch whose whole purpose is to repoint `uses:` at the octopus-base
+      # commit under test, so its workflow files always differ from the default branch.
+      # Running this check under dry-run would therefore fail every canary run, while
+      # protecting nothing — a dry run creates no tag.
       - name: Fail early if the built commit cannot be tagged
         if: ${{ !inputs.dry-run }}
         env:

--- a/.github/workflows/common-java-gradle-release.yml
+++ b/.github/workflows/common-java-gradle-release.yml
@@ -601,14 +601,48 @@ jobs:
             esac
           fi
 
-      # github release
+      # github release — create the tag ourselves, at the commit that was actually built.
+      # marvinpinto/action-automatic-releases has no target-commit input: it tags
+      # `context.sha`, which for the repository_dispatch runs every release uses is the
+      # default-branch head at dispatch time, frozen for the run, regardless of what was
+      # checked out. A hybrid release of anything other than the current tip therefore
+      # tagged code that was never built. HEAD here is the build's own checkout, so the
+      # tag is correct by construction and the release's target_commitish follows it.
       - name: Create release
         if: ${{ !inputs.dry-run }}
-        uses: marvinpinto/action-automatic-releases@v1.2.1
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          prerelease: false
-          automatic_release_tag: v${{ env.BUILD_VERSION }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: v${{ env.BUILD_VERSION }}
+        run: |
+          set -euo pipefail
+
+          built_sha="$(git rev-parse HEAD)"
+
+          # The TAG is the authority, not the release: `gh release create --target` is IGNORED
+          # when the tag already exists (REST: target_commitish is "unused if the Git tag already
+          # exists"). A tag that outlived its release — deleting a release leaves the tag behind
+          # unless it is removed separately — would otherwise silently re-point a new release at
+          # stale code, which is the very bug this step exists to prevent. Ask the API rather than
+          # the local clone: checkout is shallow and never fetches other tags.
+          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}" --jq '.object.sha' >/dev/null 2>&1; then
+            # Resolve through /commits so an annotated tag yields its commit, not the tag object.
+            tag_sha="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${TAG}" --jq '.sha')"
+            if [[ "$tag_sha" != "$built_sha" ]]; then
+              echo "::error title=Release tag conflict::Tag ${TAG} already exists at ${tag_sha}, but this run built ${built_sha}. Not moving it. Delete the tag and its release (release immutability may prevent this once published), or release a new version." >&2
+              exit 1
+            fi
+            if gh release view "$TAG" >/dev/null 2>&1; then
+              echo "Release $TAG already exists at $built_sha — nothing to do."
+              exit 0
+            fi
+            # Tag is correct but has no release: adopt it instead of creating a second one.
+            gh release create "$TAG" --verify-tag --title "$TAG" --generate-notes
+            echo "Created release $TAG on the existing, correct tag $built_sha"
+            exit 0
+          fi
+
+          gh release create "$TAG" --target "$built_sha" --title "$TAG" --generate-notes
+          echo "Created release $TAG at $built_sha"
 
       # Bind the release to the run that produced it. Registration happens afterwards
       # in a workflow_run context whose only trustworthy identity is this run's id and

--- a/.github/workflows/common-java-maven-release.yml
+++ b/.github/workflows/common-java-maven-release.yml
@@ -202,16 +202,48 @@ jobs:
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
-      # github release
+      # github release — create the tag ourselves, at the commit that was actually built.
+      # marvinpinto/action-automatic-releases has no target-commit input: it tags
+      # `context.sha`, which for the repository_dispatch runs every release uses is the
+      # default-branch head at dispatch time, frozen for the run, regardless of what was
+      # checked out. A hybrid release of anything other than the current tip therefore
+      # tagged code that was never built. HEAD here is the build's own checkout, so the
+      # tag is correct by construction and the release's target_commitish follows it.
       - name: Create release
         if: ${{ !inputs.dry-run }}
-        uses: marvinpinto/action-automatic-releases@v1.2.1
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          prerelease: false
-          automatic_release_tag: v${{ env.BUILD_VERSION }}
-          files: |
-            pom.xml
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: v${{ env.BUILD_VERSION }}
+        run: |
+          set -euo pipefail
+
+          built_sha="$(git rev-parse HEAD)"
+
+          # The TAG is the authority, not the release: `gh release create --target` is IGNORED
+          # when the tag already exists (REST: target_commitish is "unused if the Git tag already
+          # exists"). A tag that outlived its release — deleting a release leaves the tag behind
+          # unless it is removed separately — would otherwise silently re-point a new release at
+          # stale code, which is the very bug this step exists to prevent. Ask the API rather than
+          # the local clone: checkout is shallow and never fetches other tags.
+          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}" --jq '.object.sha' >/dev/null 2>&1; then
+            # Resolve through /commits so an annotated tag yields its commit, not the tag object.
+            tag_sha="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${TAG}" --jq '.sha')"
+            if [[ "$tag_sha" != "$built_sha" ]]; then
+              echo "::error title=Release tag conflict::Tag ${TAG} already exists at ${tag_sha}, but this run built ${built_sha}. Not moving it. Delete the tag and its release (release immutability may prevent this once published), or release a new version." >&2
+              exit 1
+            fi
+            if gh release view "$TAG" >/dev/null 2>&1; then
+              echo "Release $TAG already exists at $built_sha — nothing to do."
+              exit 0
+            fi
+            # Tag is correct but has no release: adopt it instead of creating a second one.
+            gh release create "$TAG" --verify-tag --title "$TAG" --generate-notes pom.xml
+            echo "Created release $TAG on the existing, correct tag $built_sha"
+            exit 0
+          fi
+
+          gh release create "$TAG" --target "$built_sha" --title "$TAG" --generate-notes pom.xml
+          echo "Created release $TAG at $built_sha"
       # Bind the release to the run that produced it. Registration happens afterwards
       # in a workflow_run context whose only trustworthy identity is this run's id and
       # attempt: a tag cannot say which release a run made when several releases share

--- a/.github/workflows/common-java-maven-release.yml
+++ b/.github/workflows/common-java-maven-release.yml
@@ -150,6 +150,13 @@ jobs:
       # This is checked here, before the build and the publish, because the tagging step
       # runs after artifacts are already on Maven Central. Failing there would leave a
       # version published, immutable, and untagged; failing here costs nothing.
+      #
+      # Deliberately skipped under dry-run, and NOT only to mirror the tagging step: the
+      # octopus-test canary dispatches its smoke releases with `commit-hash: github.sha`
+      # on a `verify/*` branch whose whole purpose is to repoint `uses:` at the octopus-base
+      # commit under test, so its workflow files always differ from the default branch.
+      # Running this check under dry-run would therefore fail every canary run, while
+      # protecting nothing — a dry run creates no tag.
       - name: Fail early if the built commit cannot be tagged
         if: ${{ !inputs.dry-run }}
         env:

--- a/.github/workflows/common-java-maven-release.yml
+++ b/.github/workflows/common-java-maven-release.yml
@@ -222,31 +222,44 @@ jobs:
             exit 0
           fi
 
-          # Any branch head will do, so try the rest, stopping at the first that covers
-          # the built tree. This is the path a maintenance-branch release takes.
-          branch_heads="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/branches" --jq '.[].commit.sha' | sort -u)"
+          # Any branch head will do. Fetch them once, failing closed: an unreadable branch
+          # list must stop the release, not read as "no branch covers this commit".
+          branch_lookup=0
+          branch_heads_raw="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/branches" --jq '.[].commit.sha' 2>&1)" || branch_lookup=$?
+          if [ "$branch_lookup" -ne 0 ]; then
+            printf '%s\n' "$branch_heads_raw" >&2
+            echo "::error title=Branch lookup failed::Could not list branches, so whether ${built_sha} can be tagged is unknown. Refusing to start a release on unverified state; re-run when the API is reachable." >&2
+            exit 1
+          fi
+          branch_heads="$(sort -u <<<"$branch_heads_raw")"
+
+          # A commit that IS a branch head has workflow files trivially identical to that
+          # head's, so it is taggable. Checked before the scan below because it costs no
+          # further API calls and is the ordinary maintenance-branch-tip release.
+          if grep -qxF -- "$built_sha" <<<"$branch_heads"; then
+            echo "Built commit is a branch head: the tag can be created."
+            exit 0
+          fi
+
+          # The remaining question — does some OTHER branch head carry these same workflow
+          # files — costs one call per branch, and only a real release needs the answer: a
+          # dry run neither publishes nor tags, so it stops here rather than scanning. This
+          # matters because the dry-run canary builds a pull-request merge commit, which
+          # heads no branch, and would otherwise scan every branch on every run.
+          if [ "${DRY_RUN}" = "true" ]; then
+            echo "::warning title=Built commit may not be taggable::${built_sha} carries workflow files (${blocking}) that are not on ${default_branch}, and it heads no branch. A REAL release would now scan the other branch heads for a match and refuse the release if none covered it. Skipped here because this is a dry run."
+            exit 0
+          fi
+
           while IFS= read -r branch_head; do
             [ -n "$branch_head" ] || continue
             [ "$branch_head" = "$default_head" ] && continue
-            if [ "$branch_head" = "$built_sha" ]; then
-              echo "Built commit is a branch head: the tag can be created."
-              exit 0
-            fi
             candidate_list="$(list_workflows "$branch_head")"
             if [ -z "$(missing_against "$candidate_list")" ]; then
               echo "Workflow files at ${built_sha} are present unchanged on branch head ${branch_head}: the tag can be created."
               exit 0
             fi
           done <<<"$branch_heads"
-
-          # A dry run publishes nothing and creates no tag, so there is nothing to
-          # protect: report and pass. This keeps the check exercised by the dry-run
-          # canary — whose commit is a pull-request merge commit, and therefore the head
-          # of no branch — without letting branch topology fail a rehearsal.
-          if [ "${DRY_RUN}" = "true" ]; then
-            echo "::warning title=Built commit would not be taggable::${built_sha} carries workflow files (${blocking}) that exist on no branch head, so a REAL release of this commit would be refused a tag. Ignored because this is a dry run."
-            exit 0
-          fi
 
           echo "::error title=Built commit cannot be tagged::This release builds ${built_sha}, which carries workflow files (${blocking}) that exist on no branch head. GitHub refuses to point a tag at such a commit with the Actions GITHUB_TOKEN, so the release would publish and then fail untagged. Release a commit whose .github/workflows match a branch head, or give the release a token authorized to modify workflows." >&2
           exit 1
@@ -364,8 +377,8 @@ jobs:
               # with the asset missing forever. Upload only when it is actually absent:
               # --clobber deletes before uploading, so a flaky upload here would destroy a
               # good asset.
-              assets="$(gh release view "$TAG" --json assets --jq '[.assets[].name] | join(" ")')"
-              if grep -qw "pom.xml" <<<"$assets"; then
+              assets="$(gh release view "$TAG" --json assets --jq '.assets[].name')"
+              if grep -qxF "pom.xml" <<<"$assets"; then
                 echo "Release $TAG already exists at $built_sha with pom.xml attached — nothing to do."
               else
                 gh release upload "$TAG" pom.xml
@@ -390,12 +403,13 @@ jobs:
             exit 1
           fi
 
-          # The tag is ours to create. Create the ref directly at the built commit instead of
-          # `release create --target`: the Create Release endpoint rejects GITHUB_TOKEN when the
-          # target commit differs from the default branch under .github/workflows — exactly the
-          # backport case this fix exists for — and it would fail here, after the artifacts are
-          # already published. Creating a plain ref to an existing commit has no such
-          # restriction; --verify-tag then pins the release to that tag.
+          # The tag is ours to create. The ref is created directly rather than through
+          # `release create --target` because --target is ignored once a tag exists (see
+          # above), and because creating the ref makes the ONE operation that can be
+          # refused explicit and separately reportable. It carries no lesser restriction
+          # than the release endpoint: the workflow-file rule measured in the pre-build
+          # check applies to any ref update, this one included. --verify-tag then pins the
+          # release to the tag that was just created.
           # The pre-build check said this commit was taggable, but branches move: a
           # workflow change merged while the build ran can withdraw that, and by now the
           # artifacts are published and immutable. Say so explicitly rather than leaving a

--- a/.github/workflows/common-java-maven-release.yml
+++ b/.github/workflows/common-java-maven-release.yml
@@ -137,6 +137,64 @@ jobs:
         with:
           ref: ${{ inputs.commit-hash }}
 
+      # A release must be able to tag the commit it builds — but for some commits
+      # GITHUB_TOKEN cannot. GitHub refuses ANY ref update, via REST or git push, that
+      # points a ref at a commit whose `.github/workflows/` files differ from the default
+      # branch, unless the token is authorized to modify workflows — which the
+      # GITHUB_TOKEN of Actions can never be. Verified empirically against a real
+      # repository: the identical request succeeds at the default-branch head and is
+      # refused for an older commit whose workflow files differ, and the REST refusal is
+      # masked as HTTP 404 (`git push` says so plainly: "refusing to allow ... to create
+      # or update workflow ... without `workflow` scope").
+      #
+      # This is checked here, before the build and the publish, because the tagging step
+      # runs after artifacts are already on Maven Central. Failing there would leave a
+      # version published, immutable, and untagged; failing here costs nothing.
+      - name: Fail early if the built commit cannot be tagged
+        if: ${{ !inputs.dry-run }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          built_sha="$(git rev-parse HEAD)"
+          default_branch="$(gh api "repos/${GITHUB_REPOSITORY}" --jq '.default_branch')"
+          default_head="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${default_branch}" --jq '.sha')"
+
+          if [ "$built_sha" = "$default_head" ]; then
+            echo "Built commit is the ${default_branch} head: tagging is unrestricted."
+            exit 0
+          fi
+
+          # Compare blob shas of the workflow directory rather than the commit diff: the
+          # compare API caps `files` at 300 entries, which a wide backport could exceed,
+          # hiding the very file that triggers the refusal. Only files present in the
+          # BUILT tree matter — the refusal is about the tagged commit creating or
+          # updating a workflow, so a workflow that exists only on the default branch is
+          # not a problem. A missing directory (404) yields an empty list.
+          list_workflows() {
+            gh api "repos/${GITHUB_REPOSITORY}/contents/.github/workflows?ref=$1" \
+              --jq '[.[] | select(.type == "file") | .name + " " + .sha] | sort | .[]' 2>/dev/null || true
+          }
+
+          built_list="$(list_workflows "$built_sha")"
+          default_list="$(list_workflows "$default_head")"
+
+          blocking=""
+          while IFS= read -r entry; do
+            [ -n "$entry" ] || continue
+            if ! grep -qxF -- "$entry" <<<"$default_list"; then
+              blocking="${blocking}${blocking:+, }${entry%% *}"
+            fi
+          done <<<"$built_list"
+
+          if [ -n "$blocking" ]; then
+            echo "::error title=Built commit cannot be tagged::This release builds ${built_sha}, whose workflow files differ from ${default_branch} (${blocking}). GitHub refuses to point a tag at such a commit with the Actions GITHUB_TOKEN, so the release could be published and never tagged. Release from a commit whose .github/workflows match ${default_branch}, or give the release a token authorized to modify workflows." >&2
+            exit 1
+          fi
+
+          echo "Workflow files at ${built_sha} match ${default_branch}: the tag can be created."
+
       # determine release version (for public flow)
       - name: Get latest tag
         if: inputs.flow-type == 'public'
@@ -239,9 +297,23 @@ jobs:
               echo "::error title=Release tag conflict::Tag ${TAG} already exists at ${tag_sha}, but this run built ${built_sha}. Not moving it. Delete the tag and its release (release immutability may prevent this once published), or release a new version." >&2
               exit 1
             fi
-            if gh release view "$TAG" >/dev/null 2>&1; then
-              echo "Release $TAG already exists at $built_sha — nothing to do."
+            # Fail closed here too: gh exits non-zero for a missing release and for a
+            # rate limit, auth error or 5xx alike, and reading the latter as "no release"
+            # makes the next line fail with a misleading "release already exists".
+            rel_lookup=0
+            rel_out="$(gh release view "$TAG" 2>&1)" || rel_lookup=$?
+            if [ "$rel_lookup" -eq 0 ]; then
+              # Re-attach pom.xml on this path as well: an attempt interrupted between
+              # release creation and asset upload leaves the release without it, and
+              # this path would otherwise report success with the asset missing forever.
+              gh release upload "$TAG" pom.xml --clobber
+              echo "Release $TAG already exists at $built_sha — pom.xml re-attached, nothing else to do."
               exit 0
+            fi
+            if ! grep -qE 'release not found|HTTP 404|"status": ?"404"' <<<"$rel_out"; then
+              echo "$rel_out" >&2
+              echo "::error title=Release lookup failed::Could not determine whether release ${TAG} exists. Refusing to act on unverified state; re-run when the API is reachable." >&2
+              exit 1
             fi
             # Tag is correct but has no release: adopt it instead of creating a second one.
             gh release create "$TAG" --verify-tag --title "$TAG" --generate-notes pom.xml
@@ -249,7 +321,7 @@ jobs:
             exit 0
           fi
 
-          if ! grep -q "HTTP 404" <<<"$ref_out"; then
+          if ! grep -qE 'HTTP 404|"status": ?"404"' <<<"$ref_out"; then
             echo "$ref_out" >&2
             echo "::error title=Tag lookup failed::Could not determine whether ${TAG} exists (the lookup failed with something other than 404). Refusing to create a release on unverified state; re-run when the API is reachable." >&2
             exit 1

--- a/.github/workflows/common-java-maven-release.yml
+++ b/.github/workflows/common-java-maven-release.yml
@@ -208,7 +208,7 @@ jobs:
       # default-branch head at dispatch time, frozen for the run, regardless of what was
       # checked out. A hybrid release of anything other than the current tip therefore
       # tagged code that was never built. HEAD here is the build's own checkout, so the
-      # tag is correct by construction and the release's target_commitish follows it.
+      # tag is correct by construction and the release is created from that tag.
       - name: Create release
         if: ${{ !inputs.dry-run }}
         env:
@@ -225,7 +225,14 @@ jobs:
           # unless it is removed separately — would otherwise silently re-point a new release at
           # stale code, which is the very bug this step exists to prevent. Ask the API rather than
           # the local clone: checkout is shallow and never fetches other tags.
-          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}" --jq '.object.sha' >/dev/null 2>&1; then
+          #
+          # Fail closed: only a confirmed 404 means the tag does not exist. gh exits non-zero
+          # for auth failures, rate limits, 5xx and network errors alike, and treating any of
+          # those as "no tag" would fall through to creation on unverified state.
+          ref_lookup=0
+          ref_out="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}" 2>&1)" || ref_lookup=$?
+
+          if [ "$ref_lookup" -eq 0 ]; then
             # Resolve through /commits so an annotated tag yields its commit, not the tag object.
             tag_sha="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${TAG}" --jq '.sha')"
             if [[ "$tag_sha" != "$built_sha" ]]; then
@@ -242,8 +249,22 @@ jobs:
             exit 0
           fi
 
-          gh release create "$TAG" --target "$built_sha" --title "$TAG" --generate-notes pom.xml
-          echo "Created release $TAG at $built_sha"
+          if ! grep -q "HTTP 404" <<<"$ref_out"; then
+            echo "$ref_out" >&2
+            echo "::error title=Tag lookup failed::Could not determine whether ${TAG} exists (the lookup failed with something other than 404). Refusing to create a release on unverified state; re-run when the API is reachable." >&2
+            exit 1
+          fi
+
+          # The tag is ours to create. Create the ref directly at the built commit instead of
+          # `release create --target`: the Create Release endpoint rejects GITHUB_TOKEN when the
+          # target commit differs from the default branch under .github/workflows — exactly the
+          # backport case this fix exists for — and it would fail here, after the artifacts are
+          # already published. Creating a plain ref to an existing commit has no such
+          # restriction; --verify-tag then pins the release to that tag.
+          gh api "repos/${GITHUB_REPOSITORY}/git/refs" \
+            -f ref="refs/tags/${TAG}" -f sha="${built_sha}" --jq '.ref' >/dev/null
+          gh release create "$TAG" --verify-tag --title "$TAG" --generate-notes pom.xml
+          echo "Created tag and release $TAG at $built_sha"
       # Bind the release to the run that produced it. Registration happens afterwards
       # in a workflow_run context whose only trustworthy identity is this run's id and
       # attempt: a tag cannot say which release a run made when several releases share

--- a/.github/workflows/common-java-maven-release.yml
+++ b/.github/workflows/common-java-maven-release.yml
@@ -137,30 +137,35 @@ jobs:
         with:
           ref: ${{ inputs.commit-hash }}
 
-      # A release must be able to tag the commit it builds — but for some commits
-      # GITHUB_TOKEN cannot. GitHub refuses ANY ref update, via REST or git push, that
-      # points a ref at a commit whose `.github/workflows/` files differ from the default
-      # branch, unless the token is authorized to modify workflows — which the
-      # GITHUB_TOKEN of Actions can never be. Verified empirically against a real
-      # repository: the identical request succeeds at the default-branch head and is
-      # refused for an older commit whose workflow files differ, and the REST refusal is
-      # masked as HTTP 404 (`git push` says so plainly: "refusing to allow ... to create
-      # or update workflow ... without `workflow` scope").
+      # A release must be able to tag the commit it builds — and for some commits the
+      # Actions GITHUB_TOKEN cannot. GitHub refuses any ref update, REST or git push,
+      # that points a ref at a commit carrying a workflow file that exists on no branch
+      # head, unless the token is authorized to modify workflows, which GITHUB_TOKEN can
+      # never be. Measured against a real repository with a token lacking `workflow`
+      # scope, which is the same authorization GITHUB_TOKEN lacks:
       #
-      # This is checked here, before the build and the publish, because the tagging step
-      # runs after artifacts are already on Maven Central. Failing there would leave a
-      # version published, immutable, and untagged; failing here costs nothing.
+      #   default-branch head                                          -> allowed
+      #   head of another branch, workflows differing from the default  -> allowed
+      #   non-head commit whose workflows equal another branch head's   -> allowed
+      #   commit merely missing a workflow file a branch head has       -> allowed
+      #   non-head commit whose workflows match no branch head          -> REFUSED
       #
-      # Deliberately skipped under dry-run, and NOT only to mirror the tagging step: the
-      # octopus-test canary dispatches its smoke releases with `commit-hash: github.sha`
-      # on a `verify/*` branch whose whole purpose is to repoint `uses:` at the octopus-base
-      # commit under test, so its workflow files always differ from the default branch.
-      # Running this check under dry-run would therefore fail every canary run, while
-      # protecting nothing — a dry run creates no tag.
+      # So the operative rule is "every workflow file this commit carries exists
+      # byte-identical on some branch head"; deleting one does not count as modifying it.
+      # Comparing against the default branch alone would be wrong — it would refuse the
+      # ordinary release of a maintenance-branch tip, which GitHub allows. REST disguises
+      # the refusal as HTTP 404; git push states it outright ("refusing to allow ... to
+      # create or update workflow ... without `workflow` scope").
+      #
+      # Checked before the build and the publish, because the tagging step runs after the
+      # artifacts are on Maven Central: failing there leaves a version published,
+      # immutable and untagged, while failing here costs nothing. It runs under dry-run
+      # too — it is read-only, and dry runs skip the tagging step itself, so this is the
+      # only coverage the logic gets.
       - name: Fail early if the built commit cannot be tagged
-        if: ${{ !inputs.dry-run }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRY_RUN: ${{ inputs.dry-run }}
         run: |
           set -euo pipefail
 
@@ -169,38 +174,82 @@ jobs:
           default_head="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${default_branch}" --jq '.sha')"
 
           if [ "$built_sha" = "$default_head" ]; then
-            echo "Built commit is the ${default_branch} head: tagging is unrestricted."
+            echo "Built commit is the ${default_branch} head: the tag can be created."
             exit 0
           fi
 
-          # Compare blob shas of the workflow directory rather than the commit diff: the
-          # compare API caps `files` at 300 entries, which a wide backport could exceed,
-          # hiding the very file that triggers the refusal. Only files present in the
-          # BUILT tree matter — the refusal is about the tagged commit creating or
-          # updating a workflow, so a workflow that exists only on the default branch is
-          # not a problem. A missing directory (404) yields an empty list.
+          # One "name blob-sha" line per workflow file. Fail closed: only a confirmed 404
+          # (no such directory at that ref) may be read as "no workflow files". Treating a
+          # rate limit, 5xx or auth error as an empty list would wave through exactly the
+          # release this step exists to stop. The directory listing is used rather than a
+          # commit diff because the compare API caps `files` at 300 entries, which a wide
+          # backport can exceed, hiding the one file that triggers the refusal.
           list_workflows() {
-            gh api "repos/${GITHUB_REPOSITORY}/contents/.github/workflows?ref=$1" \
-              --jq '[.[] | select(.type == "file") | .name + " " + .sha] | sort | .[]' 2>/dev/null || true
+            local out rc=0
+            out="$(gh api "repos/${GITHUB_REPOSITORY}/contents/.github/workflows?ref=$1" \
+              --jq '[.[] | select(.type == "file") | .name + " " + .sha] | sort | .[]' 2>&1)" || rc=$?
+            if [ "$rc" -eq 0 ]; then
+              printf '%s\n' "$out"
+              return 0
+            fi
+            if grep -qE 'HTTP 404|"status": ?"404"' <<<"$out"; then
+              return 0
+            fi
+            printf '%s\n' "$out" >&2
+            echo "::error title=Workflow listing failed::Could not list .github/workflows at $1, so whether ${built_sha} can be tagged is unknown. Refusing to start a release on unverified state; re-run when the API is reachable." >&2
+            return 1
           }
 
+          # Names of workflow files the built commit carries that the candidate does not
+          # carry identically. Empty means the candidate covers the built commit.
+          missing_against() {
+            local candidate_list="$1" missing="" entry
+            while IFS= read -r entry; do
+              [ -n "$entry" ] || continue
+              grep -qxF -- "$entry" <<<"$candidate_list" || missing="${missing}${missing:+, }${entry%% *}"
+            done <<<"$built_list"
+            printf '%s' "$missing"
+          }
+
+          # Assign every lookup to a variable: a command substitution that fails inside an
+          # argument list would not trip `set -e`, quietly restoring the fail-open bug.
           built_list="$(list_workflows "$built_sha")"
           default_list="$(list_workflows "$default_head")"
+          blocking="$(missing_against "$default_list")"
 
-          blocking=""
-          while IFS= read -r entry; do
-            [ -n "$entry" ] || continue
-            if ! grep -qxF -- "$entry" <<<"$default_list"; then
-              blocking="${blocking}${blocking:+, }${entry%% *}"
-            fi
-          done <<<"$built_list"
-
-          if [ -n "$blocking" ]; then
-            echo "::error title=Built commit cannot be tagged::This release builds ${built_sha}, whose workflow files differ from ${default_branch} (${blocking}). GitHub refuses to point a tag at such a commit with the Actions GITHUB_TOKEN, so the release could be published and never tagged. Release from a commit whose .github/workflows match ${default_branch}, or give the release a token authorized to modify workflows." >&2
-            exit 1
+          if [ -z "$blocking" ]; then
+            echo "Workflow files at ${built_sha} are present unchanged on ${default_branch}: the tag can be created."
+            exit 0
           fi
 
-          echo "Workflow files at ${built_sha} match ${default_branch}: the tag can be created."
+          # Any branch head will do, so try the rest, stopping at the first that covers
+          # the built tree. This is the path a maintenance-branch release takes.
+          branch_heads="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/branches" --jq '.[].commit.sha' | sort -u)"
+          while IFS= read -r branch_head; do
+            [ -n "$branch_head" ] || continue
+            [ "$branch_head" = "$default_head" ] && continue
+            if [ "$branch_head" = "$built_sha" ]; then
+              echo "Built commit is a branch head: the tag can be created."
+              exit 0
+            fi
+            candidate_list="$(list_workflows "$branch_head")"
+            if [ -z "$(missing_against "$candidate_list")" ]; then
+              echo "Workflow files at ${built_sha} are present unchanged on branch head ${branch_head}: the tag can be created."
+              exit 0
+            fi
+          done <<<"$branch_heads"
+
+          # A dry run publishes nothing and creates no tag, so there is nothing to
+          # protect: report and pass. This keeps the check exercised by the dry-run
+          # canary — whose commit is a pull-request merge commit, and therefore the head
+          # of no branch — without letting branch topology fail a rehearsal.
+          if [ "${DRY_RUN}" = "true" ]; then
+            echo "::warning title=Built commit would not be taggable::${built_sha} carries workflow files (${blocking}) that exist on no branch head, so a REAL release of this commit would be refused a tag. Ignored because this is a dry run."
+            exit 0
+          fi
+
+          echo "::error title=Built commit cannot be tagged::This release builds ${built_sha}, which carries workflow files (${blocking}) that exist on no branch head. GitHub refuses to point a tag at such a commit with the Actions GITHUB_TOKEN, so the release would publish and then fail untagged. Release a commit whose .github/workflows match a branch head, or give the release a token authorized to modify workflows." >&2
+          exit 1
 
       # determine release version (for public flow)
       - name: Get latest tag
@@ -310,11 +359,18 @@ jobs:
             rel_lookup=0
             rel_out="$(gh release view "$TAG" 2>&1)" || rel_lookup=$?
             if [ "$rel_lookup" -eq 0 ]; then
-              # Re-attach pom.xml on this path as well: an attempt interrupted between
-              # release creation and asset upload leaves the release without it, and
-              # this path would otherwise report success with the asset missing forever.
-              gh release upload "$TAG" pom.xml --clobber
-              echo "Release $TAG already exists at $built_sha — pom.xml re-attached, nothing else to do."
+              # An attempt interrupted between release creation and asset upload leaves
+              # the release without pom.xml, and this path would otherwise report success
+              # with the asset missing forever. Upload only when it is actually absent:
+              # --clobber deletes before uploading, so a flaky upload here would destroy a
+              # good asset.
+              assets="$(gh release view "$TAG" --json assets --jq '[.assets[].name] | join(" ")')"
+              if grep -qw "pom.xml" <<<"$assets"; then
+                echo "Release $TAG already exists at $built_sha with pom.xml attached — nothing to do."
+              else
+                gh release upload "$TAG" pom.xml
+                echo "Release $TAG already exists at $built_sha — attached the missing pom.xml."
+              fi
               exit 0
             fi
             if ! grep -qE 'release not found|HTTP 404|"status": ?"404"' <<<"$rel_out"; then
@@ -340,8 +396,18 @@ jobs:
           # backport case this fix exists for — and it would fail here, after the artifacts are
           # already published. Creating a plain ref to an existing commit has no such
           # restriction; --verify-tag then pins the release to that tag.
-          gh api "repos/${GITHUB_REPOSITORY}/git/refs" \
-            -f ref="refs/tags/${TAG}" -f sha="${built_sha}" --jq '.ref' >/dev/null
+          # The pre-build check said this commit was taggable, but branches move: a
+          # workflow change merged while the build ran can withdraw that, and by now the
+          # artifacts are published and immutable. Say so explicitly rather than leaving a
+          # bare masked 404 in the log.
+          ref_create=0
+          ref_create_out="$(gh api "repos/${GITHUB_REPOSITORY}/git/refs" \
+            -f ref="refs/tags/${TAG}" -f sha="${built_sha}" --jq '.ref' 2>&1)" || ref_create=$?
+          if [ "$ref_create" -ne 0 ]; then
+            printf '%s\n' "$ref_create_out" >&2
+            echo "::error title=Tag creation refused::Could not create ${TAG} at ${built_sha}. An HTTP 404 here means GitHub refused the ref update because the commit carries a workflow file that now matches no branch head — the pre-build check passed, so a branch moved while this release was building. The artifacts for this version are already published and cannot be published again: create the tag manually with a token authorized to modify workflows, then re-run to attach the release." >&2
+            exit 1
+          fi
           gh release create "$TAG" --verify-tag --title "$TAG" --generate-notes pom.xml
           echo "Created tag and release $TAG at $built_sha"
       # Bind the release to the run that produced it. Registration happens afterwards

--- a/docs/Octopus Administrator Troubleshooting.md
+++ b/docs/Octopus Administrator Troubleshooting.md
@@ -110,3 +110,46 @@ After testing the updated configuration, add the new key and passphrase to the V
 
 1. Find all repositories with the label ['sonatype-nexus'](https://github.com/octopusden?tab=repositories&q=sonatype-nexus&type=&language=&sort=).
 2. Update the configuration by changing `GPG_PASSPHRASE` and `GPG_PRIVATE_KEY` in the same way as for `octopus-test` in the [Key testing](#test-the-key) section.
+
+# Release refused with "Built commit cannot be tagged"
+
+## Symptoms
+
+A release fails early, before the build, with `Built commit cannot be tagged` and a list of
+workflow file names. Nothing was published.
+
+On repositories still using the older `OctopusCallGitHubAction` metarunner the symptom looks
+completely different: that metarunner only polls for the release tag to appear, so a refused
+release shows up as a wait of `OCTOPUS_RELEASE_TIMEOUT` minutes ending in
+`Number of attempts exceeded`, with no hint of the real cause. The newer
+`CallGitHubRelease.main.kts` reports the failing run and its reason directly. If you see the
+timeout, open the GitHub Actions run for that release and read the failed step.
+
+## Cause
+
+The release tags the commit it builds. GitHub refuses to point a tag at a commit carrying a
+workflow file that exists on no branch head, unless the token may modify workflows — which the
+Actions `GITHUB_TOKEN` never may. **This is not about the code being released:** it is usually
+triggered by someone editing `.github/workflows/` on the default branch after the commit being
+released, including the routine bumps of reusable-workflow pins.
+
+The release checks this before building precisely so the alternative does not happen: publishing
+an immutable version to Maven Central and only then failing with no tag.
+
+## What to do
+
+1. Release from a branch tip instead — any branch head is taggable, including a maintenance
+   branch whose workflow files legitimately differ from the default branch.
+2. Or release a commit whose `.github/workflows` are unchanged relative to some branch head.
+3. If this specific historical commit must be released, an operator can create the tag manually
+   with credentials authorized to modify workflows, then re-run so the release is attached.
+
+For the standing options (a `workflow`-scoped PAT or a GitHub App), see the `octopus-base` issue
+linked from the failing step's error message.
+
+## The rarer variant, after publishing
+
+If instead the release fails at `Tag creation refused` *after* publishing, a workflow change
+landed on a branch while the release was building, withdrawing what the pre-build check had
+confirmed. The artifacts are published and immutable: create the tag manually on the built
+commit, then re-run to attach the release. The error message states this.

--- a/docs/Octopus Administrator Troubleshooting.md
+++ b/docs/Octopus Administrator Troubleshooting.md
@@ -141,15 +141,34 @@ an immutable version to Maven Central and only then failing with no tag.
 1. Release from a branch tip instead — any branch head is taggable, including a maintenance
    branch whose workflow files legitimately differ from the default branch.
 2. Or release a commit whose `.github/workflows` are unchanged relative to some branch head.
-3. If this specific historical commit must be released, an operator can create the tag manually
-   with credentials authorized to modify workflows, then re-run so the release is attached.
+3. Only if this specific historical commit must be released: create the tag manually — but read
+   the credential note below first, because this is not something an ordinary operator can do.
 
-For the standing options (a `workflow`-scoped PAT or a GitHub App), see the `octopus-base` issue
-linked from the failing step's error message.
+### The credential this needs, which the org does not currently provision
+
+Creating a tag on such a commit requires a credential **authorized to modify workflows**: a PAT
+with `workflow` scope, or a GitHub App with `Workflows: write`. The Actions `GITHUB_TOKEN` can
+never have it, and no personal token has it by default — a classic PAT with `repo` scope alone is
+refused exactly like the workflow is.
+
+At the time of writing the org has **not** decided to provision such a credential; that is the
+open question in the `octopus-base` issue linked from the failing step's error message. So treat
+"create the tag manually" as requiring an administrator to mint a suitable token first. Do not
+plan a release around this recovery — prefer options 1 and 2 above.
 
 ## The rarer variant, after publishing
 
-If instead the release fails at `Tag creation refused` *after* publishing, a workflow change
-landed on a branch while the release was building, withdrawing what the pre-build check had
-confirmed. The artifacts are published and immutable: create the tag manually on the built
-commit, then re-run to attach the release. The error message states this.
+If instead the release fails at `Tag creation refused` *after* publishing, the property that made
+the built commit taggable was withdrawn while the release was building. Two ordinary events do
+that:
+
+- a workflow change merged to a branch, so the built commit's workflow files no longer match any
+  branch head;
+- **the branch whose tip was being released was advanced or deleted** — GitHub deletes branches on
+  merge by default, so this is routine rather than a rare race. A commit that was legal *because*
+  it headed a branch stops being legal when that branch goes away.
+
+The artifacts are published and immutable, so the version cannot be republished. The tag has to
+be created on the built commit and the release attached by re-running — which needs the credential
+described above. The error message states the situation; this is the one failure that can leave a
+release stuck with no operator-side way forward, so escalate rather than retrying.

--- a/docs/Octopus Developer Guide.md
+++ b/docs/Octopus Developer Guide.md
@@ -165,6 +165,21 @@ jobs:
       java-version: '21'
 ```
 
+### Which commit a hybrid release can be cut from
+
+A release tags the commit it builds, so it can only release a commit GitHub lets it tag.
+GitHub refuses to point a tag at a commit carrying a workflow file that exists on **no branch
+head**, unless the token may modify workflows — which the Actions `GITHUB_TOKEN` never may. The
+release therefore checks this before building and stops with the offending file names rather
+than publishing a version it cannot tag.
+
+In practice this is unrestrictive. Releasing the default-branch head, the tip of any branch
+(including a maintenance branch whose workflows legitimately differ), or any commit whose
+`.github/workflows` are unchanged relative to some branch head all work. What is refused is a
+release of an older commit that heads no branch and whose workflow files have since changed —
+re-releasing a historical commit after a workflow change landed. Cut it from a branch tip
+instead, or see the token options in the `octopus-base` issue this check links to in its error.
+
 ## Maven Central publishing
 
 Publish to Central only what other projects consume as a **Maven dependency**. Deployables


### PR DESCRIPTION
Fixes #173.

## Why

A hybrid-flow release builds the commit it is told to build and tags a **different** one, so the git tag and the GitHub release describe code that was never necessarily shipped.

`marvinpinto/action-automatic-releases@v1.2.1` has no input for a target commit — it creates the ref from `context.sha`. For the `repository_dispatch` runs every release uses, that is the **default branch's head at dispatch time**, frozen for the run's lifetime regardless of what a later step checks out. So the divergence appears exactly where it matters most: a backport, a re-release of an older commit, or a release dispatched after the default branch moved on. And it is silent — nothing compared the tagged commit with the built one. Both the Gradle and the Maven release workflow had the same shape.

## What

Create the tag **ref** at the commit the job actually built (`git rev-parse HEAD` of the build's own checkout) via `POST /repos/{owner}/{repo}/git/refs`, then create the release from that tag with `gh release create --verify-tag` and no `--target`.

**The tag — not the release — is the authority**, because `target_commitish` is *ignored* when the tag already exists (REST: "unused if the Git tag already exists"). A tag can outlive its release: deleting a release leaves the tag behind unless it is removed separately, and creating a release would then silently adopt that stale tag — reproducing the bug being fixed. Hence five explicit cases:

| State | Behaviour |
|---|---|
| tag exists at a **different** commit | fail, without moving it |
| tag exists at the built commit, release exists | no-op (maven attaches `pom.xml` if it is missing) |
| tag exists at the built commit, no release | adopt it (`--verify-tag`) |
| tag lookup failed for anything other than a confirmed 404 | **fail** — never act on unverified state |
| tag confirmed absent (404) | create the ref at the built commit, then the release from that tag |

That fourth row is the recurring theme of this PR. `gh` exits non-zero identically for a missing ref, an auth failure, a rate limit, a 5xx and a network error, so every lookup here distinguishes a confirmed "absent" from "could not tell", and refuses to act on the latter. The same discipline is applied to the release lookup, to every lookup in the pre-build check, and — see below — to the release-log resolver.

This also replaces the old action's habit of silently **moving** an existing tag (it passed `force: true`): now that is an operator decision, with both shas in the error message.

## Not every commit can be tagged — measured, not assumed

Review doubted that the Actions `GITHUB_TOKEN` can tag an arbitrary commit. It cannot, and the boundary was measured rather than read off the docs, because the docs and the field reports disagree. Every row is a real attempt against a real repository with a token holding `repo` but **not** `workflow` scope — the same authorization `GITHUB_TOKEN` can never have. Crafted commits were created as unreferenced objects through the Git Data API, so no branch was touched, and every tag was deleted afterwards.

| Target commit | Result |
|---|---|
| default-branch head | allowed |
| head of another branch, workflow files differing from the default branch | allowed |
| non-head commit whose workflow files equal another branch head's | allowed |
| commit merely **missing** a workflow file a branch head has (13 of 14, rest identical) | allowed |
| non-head commit whose workflow files match no branch head | **refused — masked as HTTP 404** |

So the operative rule is: **every workflow file the commit carries must exist byte-identical on some branch head**, and deleting one does not count as modifying one. `git push` states the refusal outright — *"refusing to allow an OAuth App to create or update workflow `.github/workflows/check-and-register.yml` without `workflow` scope"* — while REST disguises it as a 404, easily misread as "repository or ref not found".

Two consequences for this change:

- `gh release create --target` was never a way around this. The restriction is on the ref update, not on one endpoint, and it would have surfaced **after** the artifacts were on Maven Central: published, immutable, untagged.
- A first version of this fix compared only against the default branch. That would have refused the ordinary release of a **maintenance-branch tip**, which GitHub allows — the most likely hybrid shape of all. The measurements caught it.

The check therefore compares the built commit's workflow-directory blob shas against the default branch, then asks whether the built commit is itself a branch head (no API call), and only then scans other branch heads, stopping at the first that covers it. It runs **before the build and the publish**. It uses the contents listing rather than the commit diff because the compare API caps `files` at 300 entries, which a wide backport can exceed.

It also runs under `dry-run`, where the verdict is a **warning** and the per-branch scan is skipped: a dry run neither publishes nor tags, and the canary builds a pull-request merge commit that heads no branch, so it would otherwise scan every branch on every run.

**What this cannot do** is close the window. Branch state is read before the build; the tag is created after a Central publish that can take tens of minutes. A workflow change landing meanwhile can withdraw what the check confirmed — including for a release that took the "built commit is the default-branch head" short-circuit. So this catches the common cases early rather than eliminating the late failure; when the late failure does happen, the tagging step now names the cause, says the artifacts are already published and immutable, and says what to do.

**What changes for consumers:** a hybrid release of a commit whose workflow files match no branch head now fails early and loudly instead of publishing and mis-tagging. Releases from the default-branch head, from any branch tip, or from any commit whose workflow files are unchanged relative to some branch head are unaffected. Making the remaining case succeed needs a token authorized to modify workflows — a separate decision, tracked with the measurements in #180.

## The registration hole this opened, and closed

Review caught that the fix creates a **silent wrong-version path** into the release log, and the repo's own stubs reproduce it. `resolve-released-version.sh` resolves what a run released, preferring the run-stamp in the release body (#172) and falling back to the single version tag on the commit the run *reports* — which for a `repository_dispatch` run is the default-branch head, not the built commit.

Before this PR a hybrid release left **two** tags on that reported commit, so the fallback declined on ambiguity. Now it leaves one — the *earlier* release's — which reads as an answer. With the stamp lookup failing transiently, the resolver printed "No release carries this run's stamp" and returned that stale version with exit 0; registration would record a version this run never released, the log's dedup step would skip the version that really shipped, and every job would stay green.

Fixed by the same rule as everything else here: the stamp lookup fails closed, so an unreadable release list stops registration instead of masquerading as "no stamp". That also makes the remaining fallback sound rather than lucky, which the header now records — it is only consulted after the lookup *succeeded* and found nothing, meaning the release predates stamping, and releases from that era were tagged on the reported commit. Two scenarios cover it, and the `gh` stub now separates a failed release *list* from an unreadable *latest release* so the two cannot be conflated. 20 scenarios pass.

## Preserved

- The release stays discoverable by tag, which the following `Stamp the release with this run` step depends on; both success paths of the tagging script still reach it.
- The Maven workflow still attaches `pom.xml` — on every path that creates *or* adopts a release, and on the rerun path only when the asset is genuinely absent, matched per line (`--clobber` deletes before uploading, so a flaky upload could destroy a good asset; and a substring match let `my-pom.xml` count as `pom.xml`).
- Title, `draft`, `prerelease` and assets match what the old action produced; the generated notes are a gain, since sampled release bodies were empty or the marker alone.
- No new permission requirement: `POST /git/refs` needs `Contents: write`, which the action already required to create tags. Neither workflow declares `permissions:`, so callers' inherited scope is unchanged.
- Nothing in `docs/` described how the tag was produced, and the action-ref validator has no allowlist to update. The synced ruleset targets branches, not tags.

## Deliberately not addressed

- `--generate-notes` is used without `--notes-start-tag`, so the generated-notes range for a hybrid release can still be wrong — #173's fourth stated harm. `release-octopus-base.yml` passes that flag for this reason; doing the same here needs the previous released version, which this job does not compute.
- `release.target_commitish` still reads `main`, because `--verify-tag` makes the field moot. Unchanged from the old action, but **#140's provenance work must read the tag ref, never the release field.**
- The check's logic is not unit-tested. It cannot be reached by the canary at all, so the right fix is to extract it into `.github/scripts/` behind the existing stub harness, together with a scheduled probe that GitHub still refuses what we believe it refuses — otherwise a relaxed restriction would leave a gratuitous release blocker in place silently. Filed as #181 rather than bolted onto this PR.

## Verification — and its honest limit

`actionlint` (the CI-pinned `rhysd/actionlint:1.7.12`, shellcheck included) passes; the resolver's 20 scenarios pass; the merge gate is green. The tag-capability step's script was extracted verbatim and driven against the live API: it allows the default head, allows another branch head, blocks the commit GitHub really refused, and warns rather than fails for that same commit under dry-run. Its fail-closed path was checked separately — an auth error aborts the step instead of yielding an empty list, which also confirmed that assigning each lookup to a variable is load-bearing, since a command substitution that fails inside an argument list does not trip `set -e`.

**Dry runs skip release creation**, so the tagging and release-creation path itself still cannot be proven by CI — the issue says as much. It needs a real release. Suggested pilot on `octopus-test` with `publish-to-nexus: false`, which skips the Central publish and exercises only tagging:

- **allowed arm:** dispatch with `commit-hash` set to the tip of any branch — that is taggable by the measured rule.
- **refused arm:** dispatch with `commit-hash` set to a historical commit on the default branch that heads no branch. Note that every one of octopus-test's last 14 default-branch commits differs from its head under `.github/workflows`, so such a commit is easy to pick — and conversely, an "unchanged relative to the default branch" non-tip commit does *not* exist there to select.
- also worth driving: the tag-survives-release-deletion case, and a rerun of a release that already exists.

Four independent review rounds shaped this: the first found `--target` is ignored once the tag exists; the second, that `--target` cannot be relied on for historical commits and the tag check was fail-open; the third, that the pre-build check was itself fail-open on API errors and too strict about which commits are taggable; the fourth, that the change opened the registration hole above and left a comment asserting the disproven mechanism. Reviews also confirmed `git rev-parse HEAD` is the built commit in both flows, that `git/ref/tags/{tag}` is exact-match rather than prefix-match, that annotated-tag resolution via `/commits` is not theoretical, and that consumers pinned to older `check-and-register` versions are unaffected because they resolve versions from the tag list rather than from tag topology.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
