### PR TITLE
docs: declare the public API boundary and version increment rules

### DIFF
--- a/docs/Octopus JVM Style Guidelines.md
+++ b/docs/Octopus JVM Style Guidelines.md
@@ -262,14 +262,16 @@ Consequence: a component whose API boundary is not declared cannot have its vers
 
 ### What counts as API, per component type
 
-| Component type | Its public API is | Everything else | Applicable check |
-|----------------|-------------------|-----------------|------------------|
-| **Library** (consumed via `dependencies { }`) | Public types and members in non-internal packages | Implementation classes | API diff against the previous release (`japicmp`, or `binary-compatibility-validator` for Kotlin) |
-| **Gradle convention plugin** | Plugin ID, extension DSL (properties, nested blocks, `fun`s), **`convention(...)` default values**, registered task names, what is wired into `check` | All classes, including the extension's implementation | No bytecode tool covers this — DSL and defaults must be reviewed by hand or pinned by functional tests |
-| **Service / application** (no downstream library consumers) | REST contract (`/rest/api/{api-version}` + generated OpenAPI), configuration keys and their defaults, DB schema and migrations, message/event payloads, Docker contract (ports, volumes, healthcheck) | **All code — may be fully internal** | OpenAPI spec diff against the previous release (`oasdiff`, `openapi-diff`) |
-| **BOM / version catalog / parent POM** | Declared coordinates and version constraints | — | Removed or narrowed constraint is breaking |
+| Component type | Its public API is | Everything else | What must be compared against the previous release |
+|----------------|-------------------|-----------------|-----------------------------------------------------|
+| **Library** (consumed via `dependencies { }`) | Public types and members in non-internal packages | Implementation classes | The published bytecode API surface |
+| **Gradle convention plugin** | Plugin ID, extension DSL (properties, nested blocks, `fun`s), **`convention(...)` default values**, registered task names, what is wired into `check` | All classes, including the extension's implementation | The DSL and its defaults — not the bytecode |
+| **Service / application** (no downstream library consumers) | REST contract (`/rest/api/{api-version}` + generated OpenAPI), configuration keys and their defaults, DB schema and migrations, message/event payloads, Docker contract (ports, volumes, healthcheck) | **All code — may be fully internal** | The generated OpenAPI spec and the config key set |
+| **BOM / version catalog / parent POM** | Declared coordinates and version constraints | — | The declared constraints |
 
 A service having no downstream services does **not** mean it has no public API — it means the API is not in the bytecode. Marking all of its code internal is correct; judging its version by an API diff of that code is not.
+
+The last column states *what* must be compared, not *how*. No comparison is automated in any Octopus release workflow today, so all of it is currently a review responsibility. Tool selection per component type is a separate decision.
 
 ### Increment level, per API plane
 
@@ -285,14 +287,12 @@ Changing a `convention(...)` default or a config default alters consumer behavio
 
 ### Marking internals
 
-The only mechanism that works identically in Java, Kotlin and Groovy is the **package name**. Language modifiers reinforce it where the language has them.
+Octopus marks internals by **package name**, because it is the only mechanism that works identically in Java, Kotlin and Groovy. Where the language has a visibility modifier, it is required in addition.
 
 | Mechanism | Java | Kotlin | Groovy |
 |-----------|:----:|:------:|:------:|
-| `*.internal.*` package name (**required**) | yes | yes | yes |
-| `internal` modifier | not in the language | yes (**required** in `*.internal.*`) | not in the language |
-| `@ApiStatus.Internal` (`org.jetbrains:annotations`) | yes | yes | yes |
-| `module-info.java` `exports` (strongest, when JPMS is used) | yes | yes | — |
+| `*.internal.*` package name | required | required | required |
+| `internal` modifier | not in the language | required | not in the language |
 
 Rules:
 
@@ -301,7 +301,9 @@ Rules:
 - In Kotlin, declarations in `*.internal.*` must also carry the `internal` modifier. Note that Kotlin `internal` compiles to `public` in bytecode — the compiler mangles internal *member* names, but **public members of an internal class are not mangled** and stay callable from Java ([Calling Kotlin from Java](https://kotlinlang.org/docs/java-to-kotlin-interop.html)). The modifier documents intent; it does not hide anything from bytecode tooling.
 - Therefore any API-diff tool must be configured with the boundary explicitly, e.g. `japicmp -e 'org.octopusden.octopus.<module>.internal'`. Without it, japicmp's default access level treats every `public`/`protected` bytecode member as API and reports internal refactors as breaking changes.
 
-This convention follows established practice: the JDK identifies its own internals by namespace (`sun.*`, `jdk.internal.*`) in [JEP 260](https://openjdk.org/jeps/260), strongly encapsulated by default since [JEP 396](https://openjdk.org/jeps/396); `@ApiStatus.Internal` is documented for exactly this purpose, including package-level marking.
+Why by namespace: the JDK identifies its own internals the same way (`sun.*`, `jdk.internal.*`, [JEP 260](https://openjdk.org/jeps/260)), strongly encapsulated by default since [JEP 396](https://openjdk.org/jeps/396).
+
+Not part of this standard: `@ApiStatus.Internal` (would add an `org.jetbrains:annotations` dependency) and JPMS `module-info.java` `exports` (not used in any Octopus component today). Both are valid ways to declare the boundary and are cited here only so the choice is not re-argued — adopting either is a separate decision.
 
 ## Baseline Strategy
 

--- a/docs/Octopus JVM Style Guidelines.md
+++ b/docs/Octopus JVM Style Guidelines.md
@@ -254,6 +254,55 @@ publishing {
 
 With this setup, `./gradlew check` includes `validatePublications` automatically. If any required field is missing or sources/javadoc JARs are absent, the build fails with a clear error message listing exactly what is wrong.
 
+## Public API Boundary And Version Increments
+
+Semantic Versioning requires a declared API as a precondition, not as an optional extra: *"Software using Semantic Versioning MUST declare a public API. This API could be declared in the code itself or exist strictly in documentation."* ([semver.org](https://semver.org/), rule 1). All three increment rules are defined **relative to that API** — rule 6 (patch: backward compatible bug fixes), rule 7 (minor: new backward compatible functionality **to the public API**), rule 8 (major: backward incompatible changes **to the public API**).
+
+Consequence: a component whose API boundary is not declared cannot have its version level checked at all. Declaring the boundary is therefore the first step, and it differs by component role.
+
+### What counts as API, per component type
+
+| Component type | Its public API is | Everything else | Applicable check |
+|----------------|-------------------|-----------------|------------------|
+| **Library** (consumed via `dependencies { }`) | Public types and members in non-internal packages | Implementation classes | API diff against the previous release (`japicmp`, or `binary-compatibility-validator` for Kotlin) |
+| **Gradle convention plugin** | Plugin ID, extension DSL (properties, nested blocks, `fun`s), **`convention(...)` default values**, registered task names, what is wired into `check` | All classes, including the extension's implementation | No bytecode tool covers this — DSL and defaults must be reviewed by hand or pinned by functional tests |
+| **Service / application** (no downstream library consumers) | REST contract (`/rest/api/{api-version}` + generated OpenAPI), configuration keys and their defaults, DB schema and migrations, message/event payloads, Docker contract (ports, volumes, healthcheck) | **All code — may be fully internal** | OpenAPI spec diff against the previous release (`oasdiff`, `openapi-diff`) |
+| **BOM / version catalog / parent POM** | Declared coordinates and version constraints | — | Removed or narrowed constraint is breaking |
+
+A service having no downstream services does **not** mean it has no public API — it means the API is not in the bytecode. Marking all of its code internal is correct; judging its version by an API diff of that code is not.
+
+### Increment level, per API plane
+
+| Change | Level |
+|--------|-------|
+| New endpoint, new config key with a safe default, new DSL property, new public type | minor |
+| Behavior fix with no contract change | patch |
+| Removed or renamed endpoint, config key, DSL property, or public member | major |
+| Changed default value that alters existing consumers' behavior | major |
+| Internal refactor, no contract change | patch |
+
+Changing a `convention(...)` default or a config default alters consumer behavior without changing any signature. This is invisible to every API-diff tool and must be classified manually.
+
+### Marking internals
+
+The only mechanism that works identically in Java, Kotlin and Groovy is the **package name**. Language modifiers reinforce it where the language has them.
+
+| Mechanism | Java | Kotlin | Groovy |
+|-----------|:----:|:------:|:------:|
+| `*.internal.*` package name (**required**) | yes | yes | yes |
+| `internal` modifier | not in the language | yes (**required** in `*.internal.*`) | not in the language |
+| `@ApiStatus.Internal` (`org.jetbrains:annotations`) | yes | yes | yes |
+| `module-info.java` `exports` (strongest, when JPMS is used) | yes | yes | — |
+
+Rules:
+
+- Anything under a `*.internal.*` package is **not** a contract and may change in a patch release.
+- Anything outside it in a published artifact **is** a contract.
+- In Kotlin, declarations in `*.internal.*` must also carry the `internal` modifier. Note that Kotlin `internal` compiles to `public` in bytecode — the compiler mangles internal *member* names, but **public members of an internal class are not mangled** and stay callable from Java ([Calling Kotlin from Java](https://kotlinlang.org/docs/java-to-kotlin-interop.html)). The modifier documents intent; it does not hide anything from bytecode tooling.
+- Therefore any API-diff tool must be configured with the boundary explicitly, e.g. `japicmp -e 'org.octopusden.octopus.<module>.internal'`. Without it, japicmp's default access level treats every `public`/`protected` bytecode member as API and reports internal refactors as breaking changes.
+
+This convention follows established practice: the JDK identifies its own internals by namespace (`sun.*`, `jdk.internal.*`) in [JEP 260](https://openjdk.org/jeps/260), strongly encapsulated by default since [JEP 396](https://openjdk.org/jeps/396); `@ApiStatus.Internal` is documented for exactly this purpose, including package-level marking.
+
 ## Baseline Strategy
 
 - Baseline/suppressions are allowed only for existing violations.

--- a/docs/Octopus Kotlin Style Guide.md
+++ b/docs/Octopus Kotlin Style Guide.md
@@ -289,6 +289,14 @@ Catch the narrowest exception type that you can handle.
 
 Do not ignore exceptions silently. Handle with context, log, or rethrow.
 
+## Visibility And The API Boundary
+
+Declarations under a `*.internal.*` package must carry the `internal` modifier; declarations outside it in a published artifact are a contract and may only change with the matching version increment.
+
+`internal` documents intent but does not hide anything from bytecode: it compiles to `public`, and public members of an `internal` class are not even name-mangled. Any API-diff check must be told the boundary explicitly.
+
+For the full rules — what counts as API per component type, the increment level per change, and the Java/Groovy equivalents — see the shared contract in `docs/Octopus JVM Style Guidelines.md`, section *Public API Boundary And Version Increments*.
+
 ## Baseline Strategy
 
 1. Enable new rules in report mode first.


### PR DESCRIPTION
## Why

SemVer requires a declared public API as a **precondition**, not an optional extra — [semver.org](https://semver.org/) rule 1: *"Software using Semantic Versioning MUST declare a public API."* Rules 6/7/8 then define patch/minor/major **relative to that API**.

Consequence: without a declared boundary, a component's version level cannot be checked at all. This came out of investigating why releases here almost always bump only the patch index even when functionality is added.

The convention was **already followed de facto** in `gradle-quality-plugin` — `*.internal.*` package plus Kotlin `internal`, consistent across all 8 internal declarations, and encoded a third time in the `kover` exclusion list. It was just written down nowhere: neither style guide mentioned visibility or API surface. And it does not transfer verbatim to Java or Groovy, which have no `internal` modifier.

## What this adds

`docs/Octopus JVM Style Guidelines.md` — new section *Public API Boundary And Version Increments*:

1. **What counts as API per component type** — library / Gradle convention plugin / service / BOM, and what must be compared against the previous release for each. Notably: a service with no downstream library consumers **may mark all of its code internal**; its API is the REST contract, config keys, DB schema and Docker contract, so a bytecode diff cannot judge its version. For a Gradle plugin the contract includes `convention(...)` default values.
2. **Increment level per change** — including that changing a `convention(...)` or config default is **major**: it alters existing consumers' behavior without changing any signature, and is invisible to every API-diff tool.
3. **How to mark internals** — the `*.internal.*` package name, required in all three languages because it is the only mechanism that works identically in Java, Kotlin and Groovy, plus the Kotlin `internal` modifier where the language has one.

`docs/Octopus Kotlin Style Guide.md` — the Kotlin-specific rule plus a pointer to the shared contract, rather than duplicating it.

## Scope of the standard

This documents **what Octopus does**, not a survey of what is possible. Two mechanisms are named only in an explicit *"not part of this standard"* note so the choice is not re-argued later: `@ApiStatus.Internal` (would add an `org.jetbrains:annotations` dependency — used nowhere in the codebase today) and JPMS `module-info.java` `exports` (no `module-info.java` in any component). Adopting either is a separate decision.

Likewise, the component-type table states *what* must be compared against the previous release, not *how*. **No comparison is automated in any release workflow today**, so all of it is currently a review responsibility, and tool selection per component type is a separate decision.

## Verified while writing this

Ran `japicmp 0.26.1 --semantic-versioning` against published `octopus-quality-plugin` releases from Maven Central. For `2.4.0 → 2.4.1` it reported **`1.0.0` (major required)** on a release shipped as patch, because `internal.PublicationValidator.register()` was removed — Kotlin `internal` compiles to `public` bytecode, and public members of an internal class are not even name-mangled.

Excluding the internal package flips the same comparison to `0.0.1` (patch, clean):

```
japicmp -s --ignore-missing-classes \
  -e 'org.octopusden.octopus.quality.internal' \
  -o 2.4.0.jar -n 2.4.1.jar
→ 0.0.1
```

One exclusion changes the verdict from "breaking change shipped as patch" to "clean" — which is precisely why the boundary has to be declared before any tool is wired in.

## Not enforced yet

Documentation only. No workflow, action, or plugin changes, so `consumer-verify` should noop. The rules are stated but not automated — the *"declarations in `*.internal.*` must be `internal`"* rule is prose, not a check.

## Follow-ups not in this PR

- Express the `*.internal.*` → `internal` rule as a `detekt` rule in `gradle-quality-plugin` so it is enforced rather than remembered.
- `docs/Octopus REST API Guidelines.md` has `{api-version}` in the base path but no rule for when it increments, and no stated relation to the component version — two independent version numbers with nothing connecting them.

## Sources

[semver.org](https://semver.org/) · [JEP 260](https://openjdk.org/jeps/260) · [JEP 396](https://openjdk.org/jeps/396) · [Calling Kotlin from Java](https://kotlinlang.org/docs/java-to-kotlin-interop.html)

🤖 Generated with [Claude Code](https://claude.com/claude-code)