### PR TITLE
fix(release): make the post-publish recovery executable, and page the stamp lookup

### DIFF
--- a/.github/scripts/resolve-released-version.sh
+++ b/.github/scripts/resolve-released-version.sh
@@ -83,13 +83,26 @@ if [ -n "$RELEASE_RUN_ID" ] && [ -n "$RELEASE_RUN_ATTEMPT" ] && [ -n "$GITHUB_RE
   # stamp", and conflating them is how a transient blip turns into a wrongly registered
   # version: the run falls through to source 3, finds the one tag an EARLIER release left
   # on the commit this run reports, and registers that version with every job green.
+  # Every page, not just the first: three consumer repositories already hold more than 50
+  # releases (95, 59 and 54 at the time of writing), so a single page can miss a stamp that
+  # exists and then be mistaken for "this release predates stamping" — the same silent
+  # wrong-version outcome the fail-closed handling below exists to prevent. With --paginate
+  # the jq filter runs per page, so output is one line per page plus empty lines for the
+  # pages with no match; take the first non-empty one.
   stamp_lookup=0
-  stamped="$(gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=50" \
+  stamped_pages="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
     --jq "map(select((.body // \"\") | contains(\"${marker}\"))) | first | .tag_name // empty" 2>&1)" || stamp_lookup=$?
   if [ "$stamp_lookup" -ne 0 ]; then
-    printf '%s\n' "$stamped" >&2
+    printf '%s\n' "$stamped_pages" >&2
     die "Could not read this repository's releases, so the release stamped by run ${RELEASE_RUN_ID}/${RELEASE_RUN_ATTEMPT} cannot be identified. Refusing to fall back to tag topology, which can name a version an earlier run released. Re-run when the API is reachable, or pass release-version explicitly."
   fi
+  stamped=""
+  while IFS= read -r page_result; do
+    if [ -n "$page_result" ]; then
+      stamped="$page_result"
+      break
+    fi
+  done <<<"$stamped_pages"
   if [ -n "$stamped" ] && [ "$stamped" != "null" ]; then
     version="${stamped#v}"
     if grep -qE "$SEMVER" <<<"$version"; then

--- a/.github/scripts/resolve-released-version.sh
+++ b/.github/scripts/resolve-released-version.sh
@@ -86,9 +86,12 @@ if [ -n "$RELEASE_RUN_ID" ] && [ -n "$RELEASE_RUN_ATTEMPT" ] && [ -n "$GITHUB_RE
   # Every page, not just the first: three consumer repositories already hold more than 50
   # releases (95, 59 and 54 at the time of writing), so a single page can miss a stamp that
   # exists and then be mistaken for "this release predates stamping" — the same silent
-  # wrong-version outcome the fail-closed handling below exists to prevent. With --paginate
-  # the jq filter runs per page, so output is one line per page plus empty lines for the
-  # pages with no match; take the first non-empty one.
+  # wrong-version outcome the fail-closed handling below exists to prevent.
+  #
+  # gh applies --jq per page (without --slurp each page is filtered separately), and this
+  # filter yields `empty` for a page with no match, so measured output is exactly one line
+  # or nothing at all — NOT a blank line per page. The loop below still takes the first
+  # non-empty line rather than the first line, so it holds if that ever changes.
   stamp_lookup=0
   stamped_pages="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
     --jq "map(select((.body // \"\") | contains(\"${marker}\"))) | first | .tag_name // empty" 2>&1)" || stamp_lookup=$?

--- a/.github/scripts/test/gh
+++ b/.github/scripts/test/gh
@@ -6,10 +6,11 @@
 #   STAMPED_FOR_RUN      run id/attempt that stamp belongs to, e.g. 555/1; a query about
 #                        any other run or attempt gets nothing, so a script that ignores
 #                        either cannot pass
-#   STAMP_ON_LATER_PAGE  when non-empty, the stamped release is NOT on the first page: the
-#                        stub answers the way gh --paginate does, one filtered result per
-#                        page, so the first line is empty and the tag comes later. A lookup
-#                        that reads only the first line, or omits --paginate, cannot pass
+#   STAMP_ON_LATER_PAGE  when non-empty, feed the tolerated-but-not-observed shape: leading
+#                        empty lines before the tag. Real gh yields `empty` for a page with
+#                        no match, so it emits one line or nothing; this fixture exists to
+#                        pin the parser's tolerance, so a lookup that reads only the FIRST
+#                        line fails here even though today's gh would not expose that bug
 #   STAMP_LOOKUP_FAILS   when non-empty, the release LIST call fails like a rate limit or
 #                        5xx would; kept separate from LATEST_RELEASE_FAILS so a failed
 #                        stamp lookup can be told apart from an unreadable latest release
@@ -32,7 +33,7 @@ if [ "${1:-}" = "api" ] && [[ "$*" == *repos/*/releases\?per_page=* ]]; then
   # that marker names the run these fixtures belong to.
   if [ -n "${STAMPED_RELEASE_TAG:-}" ] && [ -n "${STAMPED_FOR_RUN:-}" ] \
      && [[ "$*" == *"octopus-release-run: ${STAMPED_FOR_RUN}"* ]]; then
-    # gh --paginate applies --jq per page, so a miss contributes an empty line.
+    # Not what gh emits for a miss (that is nothing at all) — see STAMP_ON_LATER_PAGE.
     if [ -n "${STAMP_ON_LATER_PAGE:-}" ]; then
       printf '\n\n%s\n' "$STAMPED_RELEASE_TAG"
     else

--- a/.github/scripts/test/gh
+++ b/.github/scripts/test/gh
@@ -6,6 +6,10 @@
 #   STAMPED_FOR_RUN      run id/attempt that stamp belongs to, e.g. 555/1; a query about
 #                        any other run or attempt gets nothing, so a script that ignores
 #                        either cannot pass
+#   STAMP_ON_LATER_PAGE  when non-empty, the stamped release is NOT on the first page: the
+#                        stub answers the way gh --paginate does, one filtered result per
+#                        page, so the first line is empty and the tag comes later. A lookup
+#                        that reads only the first line, or omits --paginate, cannot pass
 #   STAMP_LOOKUP_FAILS   when non-empty, the release LIST call fails like a rate limit or
 #                        5xx would; kept separate from LATEST_RELEASE_FAILS so a failed
 #                        stamp lookup can be told apart from an unreadable latest release
@@ -13,16 +17,27 @@
 #   LATEST_RELEASE_FAILS when non-empty, repos/<repo>/releases/latest fails
 set -u
 
-if [ "${1:-}" = "api" ] && [[ "${2:-}" == repos/*/releases\?per_page=* ]]; then
+# The path is no longer $2: --paginate precedes it, so match the whole argument list.
+if [ "${1:-}" = "api" ] && [[ "$*" == *repos/*/releases\?per_page=* ]]; then
   if [ -n "${STAMP_LOOKUP_FAILS:-}" ]; then
     echo "gh: could not list releases (HTTP 502)" >&2
     exit 1
+  fi
+  # Every release page must be requested, or a stamp beyond the first page reads as absent.
+  if [[ "$*" != *--paginate* ]]; then
+    echo "stub gh: the release list must be paginated, or a stamp past the first page is missed: $*" >&2
+    exit 99
   fi
   # The script embeds the marker it is looking for in the jq filter; only answer when
   # that marker names the run these fixtures belong to.
   if [ -n "${STAMPED_RELEASE_TAG:-}" ] && [ -n "${STAMPED_FOR_RUN:-}" ] \
      && [[ "$*" == *"octopus-release-run: ${STAMPED_FOR_RUN}"* ]]; then
-    printf '%s\n' "$STAMPED_RELEASE_TAG"
+    # gh --paginate applies --jq per page, so a miss contributes an empty line.
+    if [ -n "${STAMP_ON_LATER_PAGE:-}" ]; then
+      printf '\n\n%s\n' "$STAMPED_RELEASE_TAG"
+    else
+      printf '%s\n' "$STAMPED_RELEASE_TAG"
+    fi
   fi
   exit 0
 fi

--- a/.github/scripts/test/resolve-released-version-scenarios.sh
+++ b/.github/scripts/test/resolve-released-version-scenarios.sh
@@ -39,6 +39,7 @@ run() { # name expected_status expected_stdout_or_stderr_regex [stderr_regex] en
     EXPLICIT_VERSION= RELEASE_RUN_ID= RELEASE_RUN_ATTEMPT= RELEASE_RUN_SHA= \
     GITHUB_REPOSITORY= GH_TOKEN= \
     TAGS_AT_SHA= TAGS_FOR_SHA= LATEST_RELEASE_TAG= LATEST_RELEASE_FAILS= STAMP_LOOKUP_FAILS= \
+    STAMP_ON_LATER_PAGE= \
     STAMPED_RELEASE_TAG= STAMPED_FOR_RUN= \
     "$@" bash "$script" >"$outfile" 2>"$errfile"
   status=$?
@@ -127,6 +128,16 @@ run 'several tags on one commit fall back' 0 '2.2.36' 'several version tags' \
   RELEASE_RUN_SHA=cdfdd24d TAGS_FOR_SHA=cdfdd24d TAGS_AT_SHA='v2.2.35 v2.2.36' LATEST_RELEASE_TAG=v2.2.36 "${common[@]}"
 run 'fallback explains itself' 0 '2.2.37' 'most recently created release' \
   RELEASE_RUN_SHA=deadbeef TAGS_FOR_SHA=deadbeef TAGS_AT_SHA='' LATEST_RELEASE_TAG=v2.2.37 "${common[@]}"
+
+# A stamp that exists but sits past the first page must still be found: three consumer
+# repositories already hold more than 50 releases. Reading one page and calling the miss
+# "predates stamping" hands the answer to the tag/latest fallback, which can name a version
+# another run released. The stub rejects an unpaginated list call outright, and puts the
+# match behind two empty page results here.
+run 'stamp on a later page is still found' 0 '2.2.38' 'stamped with run 555' \
+  RELEASE_RUN_ID=555 RELEASE_RUN_ATTEMPT=1 STAMPED_FOR_RUN=555/1 STAMPED_RELEASE_TAG=v2.2.38 \
+  STAMP_ON_LATER_PAGE=1 \
+  RELEASE_RUN_SHA=178e83a0 TAGS_FOR_SHA=178e83a0 TAGS_AT_SHA='v2.2.37' LATEST_RELEASE_TAG=v2.2.37 "${common[@]}"
 
 # A failed stamp lookup is not an unstamped release. Falling through would let the tag an
 # EARLIER release left on the commit this run reports answer for this one — silently, and

--- a/.github/workflows/common-java-gradle-release.yml
+++ b/.github/workflows/common-java-gradle-release.yml
@@ -80,22 +80,30 @@ on:
       GPG_PRIVATE_KEY:
         required: false
 
+# Serialize REAL releases per repository: two overlapping ones would compute the same next
+# version and upload it twice. This sits at WORKFLOW level, not on the publish job, so the
+# lease spans publish -> tag/release -> registration. On the job it ended when publishing
+# ended, which left a window in which the next public-flow release could read
+# `find-latest-tag` before the previous run's tag existed and compute a version that was
+# already released. Workflow level is also the only placement that works for a reusable
+# workflow: a group set by the caller on the job that calls it does not gate the called
+# workflow's own jobs.
+#
+# Dry runs must NOT share the group. A repository can run several release variants at once
+# (octopus-test's release-smoke matrix), and GitHub keeps only one PENDING member per
+# group, so a third variant would cancel a waiting one. Dry runs therefore get a key that
+# is unique per run and variant; real publishes get the shared per-repository one.
+concurrency:
+  group: >-
+    release-${{ github.repository }}-${{ inputs.dry-run
+      && format('dry-{0}-{1}-{2}-{3}', github.run_id, github.run_attempt, inputs.flow-type, inputs.docker-image)
+      || 'publish' }}
+  cancel-in-progress: false
+
 jobs:
   prepare-build-publish-release:
     runs-on: ubuntu-latest
     environment: Prod
-    # Serialize REAL releases per repository: two overlapping ones would compute the
-    # same next version and upload it twice. Dry runs must NOT share that group —
-    # a repository can run several release variants at once (octopus-test's
-    # release-smoke matrix), and since GitHub keeps only one pending member per
-    # group, the extra variants would be cancelled. So dry runs get a key that is
-    # unique per run and variant, real publishes get the shared per-repository one.
-    concurrency:
-      group: >-
-        release-${{ github.repository }}-${{ inputs.dry-run
-          && format('dry-{0}-{1}-{2}-{3}', github.run_id, github.run_attempt, inputs.flow-type, inputs.docker-image)
-          || 'publish' }}
-      cancel-in-progress: false
     # The version is an input only for the hybrid flow; the public flow computes it
     # here. Publishing it as an output is what lets registration receive the version
     # that was actually released instead of an empty string.
@@ -223,7 +231,12 @@ jobs:
 
       - name: Record the built commit
         id: built-commit
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+        run: |
+          # Assign first: `echo "sha=$(git rev-parse HEAD)"` succeeds even when rev-parse
+          # fails, writing an empty sha that is only caught after the publish.
+          set -euo pipefail
+          sha="$(git rev-parse HEAD)"
+          echo "sha=${sha}" >> "$GITHUB_OUTPUT"
 
       # A release must be able to tag the commit it builds — and for some commits the
       # Actions GITHUB_TOKEN cannot. GitHub refuses any ref update, REST or git push,
@@ -760,6 +773,12 @@ jobs:
       - name: Create release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # This job has no checkout, and `gh release …` resolves the repository from the
+          # git remote — GITHUB_REPOSITORY is not consulted, GH_REPO is the only documented
+          # override. Without it every release subcommand dies with "failed to run git:
+          # not a git repository", after the artifacts are published. The sibling `gh api`
+          # calls are unaffected because they name the repository in the path.
+          GH_REPO: ${{ github.repository }}
           TAG: v${{ needs.prepare-build-publish-release.outputs.build-version }}
           BUILT_SHA: ${{ needs.prepare-build-publish-release.outputs.built-sha }}
         run: |
@@ -850,6 +869,10 @@ jobs:
       - name: Stamp the release with this run
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Set for the same reason as above. This step only uses `gh api` with explicit
+          # repository paths, so it does not need it today — but a future `gh release` call
+          # added here would fail in a way that is hard to read.
+          GH_REPO: ${{ github.repository }}
           TAG: v${{ needs.prepare-build-publish-release.outputs.build-version }}
           MARKER: "<!-- octopus-release-run: ${{ github.run_id }}/${{ github.run_attempt }} -->"
         run: |

--- a/.github/workflows/common-java-gradle-release.yml
+++ b/.github/workflows/common-java-gradle-release.yml
@@ -101,6 +101,9 @@ jobs:
     # that was actually released instead of an empty string.
     outputs:
       build-version: ${{ inputs.build-version || steps.new-version.outputs.version }}
+      # The commit this job actually built. Published so the tagging job tags exactly
+      # that, instead of re-resolving a ref that may have moved in the meantime.
+      built-sha: ${{ steps.built-commit.outputs.sha }}
     env:
       SKIP_TESTS: ''
       BUILD_VERSION: ''
@@ -217,6 +220,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.commit-hash }}
+
+      - name: Record the built commit
+        id: built-commit
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       # A release must be able to tag the commit it builds — and for some commits the
       # Actions GITHUB_TOKEN cannot. GitHub refuses any ref update, REST or git push,
@@ -728,22 +735,41 @@ jobs:
             esac
           fi
 
-      # github release — create the tag ourselves, at the commit that was actually built.
-      # marvinpinto/action-automatic-releases has no target-commit input: it tags
-      # `context.sha`, which for the repository_dispatch runs every release uses is the
-      # default-branch head at dispatch time, frozen for the run, regardless of what was
-      # checked out. A hybrid release of anything other than the current tip therefore
-      # tagged code that was never built. HEAD here is the build's own checkout, so the
-      # tag is correct by construction and the release is created from that tag.
+  # Tagging and release creation are a separate job deliberately. They run after the
+  # artifacts are published, and publishing is irreversible: Maven Central refuses a
+  # version that already exists. Were these steps in the publish job, GitHub's "re-run
+  # failed jobs" would restart the publish and die there, so the recovery this job's own
+  # error message describes could never be reached. Split, a re-run repeats only this
+  # job — it finds the tag (created by hand if the refusal persists) and attaches the
+  # release to it, while the successful publish stays untouched.
+  #
+  # No `environment:` here on purpose: this job needs only GITHUB_TOKEN, and inheriting
+  # the publish job's environment would ask a protected environment to approve twice.
+  tag-and-release:
+    name: Tag and release
+    if: ${{ !inputs.dry-run }}
+    needs: prepare-build-publish-release
+    runs-on: ubuntu-latest
+    steps:
+      # The tag is created at the commit the build job actually built. The replaced
+      # action, marvinpinto/action-automatic-releases, had no target-commit input: it
+      # tagged `context.sha`, which for the repository_dispatch runs every release uses
+      # is the default-branch head at dispatch time, frozen for the run, regardless of
+      # what was checked out. A hybrid release of anything other than the current tip
+      # therefore tagged code that was never built.
       - name: Create release
-        if: ${{ !inputs.dry-run }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: v${{ env.BUILD_VERSION }}
+          TAG: v${{ needs.prepare-build-publish-release.outputs.build-version }}
+          BUILT_SHA: ${{ needs.prepare-build-publish-release.outputs.built-sha }}
         run: |
           set -euo pipefail
 
-          built_sha="$(git rev-parse HEAD)"
+          built_sha="${BUILT_SHA}"
+          if [ -z "$built_sha" ]; then
+            echo "::error title=Built commit unknown::The build job did not report the commit it built, so there is nothing safe to tag." >&2
+            exit 1
+          fi
 
           # The TAG is the authority, not the release: `gh release create --target` is IGNORED
           # when the tag already exists (REST: target_commitish is "unused if the Git tag already
@@ -807,7 +833,7 @@ jobs:
             -f ref="refs/tags/${TAG}" -f sha="${built_sha}" --jq '.ref' 2>&1)" || ref_create=$?
           if [ "$ref_create" -ne 0 ]; then
             printf '%s\n' "$ref_create_out" >&2
-            echo "::error title=Tag creation refused::Could not create ${TAG} at ${built_sha}. An HTTP 404 here means GitHub refused the ref update because the commit carries a workflow file that now matches no branch head — the pre-build check passed, so a branch moved while this release was building. The artifacts for this version are already published and cannot be published again: create the tag manually with a token authorized to modify workflows, then re-run to attach the release." >&2
+            echo "::error title=Tag creation refused::Could not create ${TAG} at ${built_sha}. An HTTP 404 here means GitHub refused the ref update because the commit carries a workflow file that now matches no branch head — the pre-build check passed, so a branch moved while this release was building. The artifacts for this version are already published and cannot be published again, so do NOT re-dispatch the release. Recovery: create ${TAG} manually on ${built_sha} with a credential authorized to modify workflows, then use GitHub's 're-run failed jobs' on this run — that repeats only this job, which will adopt the tag and attach the release, and leaves the publish untouched." >&2
             exit 1
           fi
           gh release create "$TAG" --verify-tag --title "$TAG" --generate-notes
@@ -822,10 +848,9 @@ jobs:
       # The marker is a delimited HTML comment: invisible in the rendered notes, and
       # not a prefix of another run's marker (555/1 vs 555/10).
       - name: Stamp the release with this run
-        if: ${{ !inputs.dry-run }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: v${{ env.BUILD_VERSION }}
+          TAG: v${{ needs.prepare-build-publish-release.outputs.build-version }}
           MARKER: "<!-- octopus-release-run: ${{ github.run_id }}/${{ github.run_attempt }} -->"
         run: |
           set -euo pipefail
@@ -839,7 +864,8 @@ jobs:
   register-release-in-log:
       # register release in octopus-release-log
       if: inputs.register-release-immediately && !inputs.dry-run
-      needs: prepare-build-publish-release
+      # Both: the version comes from the build job, but the release must exist first.
+      needs: [prepare-build-publish-release, tag-and-release]
       uses: ./.github/workflows/common-register-release.yml
       name: Register release
       with:

--- a/.github/workflows/common-java-gradle-release.yml
+++ b/.github/workflows/common-java-gradle-release.yml
@@ -819,6 +819,12 @@ jobs:
             rel_lookup=0
             rel_out="$(gh release view "$TAG" 2>&1)" || rel_lookup=$?
             if [ "$rel_lookup" -eq 0 ]; then
+              # A draft is invisible to the stamp step's `releases/tags/...` lookup, so
+              # finish it rather than reporting success and leaving registration blocked.
+              if [ "$(gh release view "$TAG" --json isDraft --jq '.isDraft')" = "true" ]; then
+                echo "Release ${TAG} exists as a draft — publishing it."
+                gh release edit "$TAG" --draft=false
+              fi
               echo "Release $TAG already exists at $built_sha — nothing to do."
               exit 0
             fi

--- a/.github/workflows/common-java-gradle-release.yml
+++ b/.github/workflows/common-java-gradle-release.yml
@@ -91,12 +91,15 @@ on:
 #
 # Dry runs must NOT share the group. A repository can run several release variants at once
 # (octopus-test's release-smoke matrix), and GitHub keeps only one PENDING member per
-# group, so a third variant would cancel a waiting one. Dry runs therefore get a key that
-# is unique per run and variant; real publishes get the shared per-repository one.
+# group, so a third variant sharing a key would be cancelled outright rather than queued.
+# The key must therefore separate every variant the caller actually varies: two smoke
+# variants differing only in publish-to-nexus were colliding and serializing needlessly,
+# one more such variant away from cancelling each other. Add any new distinguishing input
+# here as well. Real publishes get the shared per-repository key.
 concurrency:
   group: >-
     release-${{ github.repository }}-${{ inputs.dry-run
-      && format('dry-{0}-{1}-{2}-{3}', github.run_id, github.run_attempt, inputs.flow-type, inputs.docker-image)
+      && format('dry-{0}-{1}-{2}-{3}-{4}', github.run_id, github.run_attempt, inputs.flow-type, inputs.docker-image, inputs.publish-to-nexus)
       || 'publish' }}
   cancel-in-progress: false
 

--- a/.github/workflows/common-java-maven-release.yml
+++ b/.github/workflows/common-java-maven-release.yml
@@ -57,6 +57,9 @@ jobs:
     # that was actually released instead of an empty string.
     outputs:
       build-version: ${{ inputs.build-version || steps.new-version.outputs.version }}
+      # The commit this job actually built. Published so the tagging job tags exactly
+      # that, instead of re-resolving a ref that may have moved in the meantime.
+      built-sha: ${{ steps.built-commit.outputs.sha }}
     env:
       BUILD_VERSION: ''
 
@@ -136,6 +139,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.commit-hash }}
+
+      - name: Record the built commit
+        id: built-commit
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       # A release must be able to tag the commit it builds — and for some commits the
       # Actions GITHUB_TOKEN cannot. GitHub refuses any ref update, REST or git push,
@@ -321,6 +328,23 @@ jobs:
       - name: Set new version for maven
         run: mvn --batch-mode org.codehaus.mojo:versions-maven-plugin:2.13.0:set -DnewVersion=${{ env.BUILD_VERSION }}
 
+      # The published pom.xml is the one `versions:set` rewrote, not the one in the tree,
+      # and it is attached to the GitHub release. Hand it to the tagging job rather than
+      # letting it re-checkout, which would attach the pre-release version.
+      - name: Keep the released pom.xml for the release asset
+        if: ${{ !inputs.dry-run }}
+        uses: actions/upload-artifact@v4
+        with:
+          # Deliberately NOT keyed by run attempt. Recovery from a failed tagging step is
+          # "re-run failed jobs", which does NOT re-run this publish job, so the tagging
+          # job on attempt 2 must find the artifact uploaded on attempt 1. overwrite keeps
+          # a full re-run — which does repeat this job — from colliding with itself.
+          name: released-pom-${{ github.run_id }}
+          path: pom.xml
+          retention-days: 1
+          if-no-files-found: error
+          overwrite: true
+
       - name: Publish to Sonatype Nexus
         if: ${{ !inputs.dry-run }}
         run: mvn --batch-mode deploy -P gpg ${{ inputs.release-mvn-parameters }}
@@ -329,22 +353,47 @@ jobs:
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
-      # github release — create the tag ourselves, at the commit that was actually built.
-      # marvinpinto/action-automatic-releases has no target-commit input: it tags
-      # `context.sha`, which for the repository_dispatch runs every release uses is the
-      # default-branch head at dispatch time, frozen for the run, regardless of what was
-      # checked out. A hybrid release of anything other than the current tip therefore
-      # tagged code that was never built. HEAD here is the build's own checkout, so the
-      # tag is correct by construction and the release is created from that tag.
+  # Tagging and release creation are a separate job deliberately. They run after the
+  # artifacts are published, and publishing is irreversible: Maven Central refuses a
+  # version that already exists. Were these steps in the publish job, GitHub's "re-run
+  # failed jobs" would restart the publish and die there, so the recovery this job's own
+  # error message describes could never be reached. Split, a re-run repeats only this
+  # job — it finds the tag (created by hand if the refusal persists) and attaches the
+  # release to it, while the successful publish stays untouched.
+  #
+  # No `environment:` here on purpose: this job needs only GITHUB_TOKEN, and inheriting
+  # the publish job's environment would ask a protected environment to approve twice.
+  tag-and-release:
+    name: Tag and release
+    if: ${{ !inputs.dry-run }}
+    needs: prepare-build-publish-release
+    runs-on: ubuntu-latest
+    steps:
+      # The pom.xml the publish job actually released, restored as the release asset.
+      - name: Restore the released pom.xml
+        uses: actions/download-artifact@v4
+        with:
+          name: released-pom-${{ github.run_id }}
+
+      # The tag is created at the commit the build job actually built. The replaced
+      # action, marvinpinto/action-automatic-releases, had no target-commit input: it
+      # tagged `context.sha`, which for the repository_dispatch runs every release uses
+      # is the default-branch head at dispatch time, frozen for the run, regardless of
+      # what was checked out. A hybrid release of anything other than the current tip
+      # therefore tagged code that was never built.
       - name: Create release
-        if: ${{ !inputs.dry-run }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: v${{ env.BUILD_VERSION }}
+          TAG: v${{ needs.prepare-build-publish-release.outputs.build-version }}
+          BUILT_SHA: ${{ needs.prepare-build-publish-release.outputs.built-sha }}
         run: |
           set -euo pipefail
 
-          built_sha="$(git rev-parse HEAD)"
+          built_sha="${BUILT_SHA}"
+          if [ -z "$built_sha" ]; then
+            echo "::error title=Built commit unknown::The build job did not report the commit it built, so there is nothing safe to tag." >&2
+            exit 1
+          fi
 
           # The TAG is the authority, not the release: `gh release create --target` is IGNORED
           # when the tag already exists (REST: target_commitish is "unused if the Git tag already
@@ -419,7 +468,7 @@ jobs:
             -f ref="refs/tags/${TAG}" -f sha="${built_sha}" --jq '.ref' 2>&1)" || ref_create=$?
           if [ "$ref_create" -ne 0 ]; then
             printf '%s\n' "$ref_create_out" >&2
-            echo "::error title=Tag creation refused::Could not create ${TAG} at ${built_sha}. An HTTP 404 here means GitHub refused the ref update because the commit carries a workflow file that now matches no branch head — the pre-build check passed, so a branch moved while this release was building. The artifacts for this version are already published and cannot be published again: create the tag manually with a token authorized to modify workflows, then re-run to attach the release." >&2
+            echo "::error title=Tag creation refused::Could not create ${TAG} at ${built_sha}. An HTTP 404 here means GitHub refused the ref update because the commit carries a workflow file that now matches no branch head — the pre-build check passed, so a branch moved while this release was building. The artifacts for this version are already published and cannot be published again, so do NOT re-dispatch the release. Recovery: create ${TAG} manually on ${built_sha} with a credential authorized to modify workflows, then use GitHub's 're-run failed jobs' on this run — that repeats only this job, which will adopt the tag and attach the release, and leaves the publish untouched." >&2
             exit 1
           fi
           gh release create "$TAG" --verify-tag --title "$TAG" --generate-notes pom.xml
@@ -433,10 +482,9 @@ jobs:
       # The marker is a delimited HTML comment: invisible in the rendered notes, and
       # not a prefix of another run's marker (555/1 vs 555/10).
       - name: Stamp the release with this run
-        if: ${{ !inputs.dry-run }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: v${{ env.BUILD_VERSION }}
+          TAG: v${{ needs.prepare-build-publish-release.outputs.build-version }}
           MARKER: "<!-- octopus-release-run: ${{ github.run_id }}/${{ github.run_attempt }} -->"
         run: |
           set -euo pipefail
@@ -450,7 +498,8 @@ jobs:
   register-release-in-log:
       # register release in octopus-release-log
       if: inputs.register-release-immediately && !inputs.dry-run
-      needs: prepare-build-publish-release
+      # Both: the version comes from the build job, but the release must exist first.
+      needs: [prepare-build-publish-release, tag-and-release]
       uses: ./.github/workflows/common-register-release.yml
       name: Register release
       with:

--- a/.github/workflows/common-java-maven-release.yml
+++ b/.github/workflows/common-java-maven-release.yml
@@ -344,7 +344,13 @@ jobs:
           # "re-run failed jobs", which does NOT re-run this publish job, so the tagging
           # job on attempt 2 must find the artifact uploaded on attempt 1. overwrite keeps
           # a full re-run — which does repeat this job — from colliding with itself.
-          name: released-pom-${{ github.run_id }}
+          # Keyed by flow and version as well as run: one caller run can invoke this
+          # workflow several times (a public and a hybrid release), and every call would
+          # otherwise upload the same artifact name — with overwrite:true the later one
+          # replaces the earlier, and a tagging job could attach the other release's pom.
+          # Deliberately NOT keyed by run attempt: recovery re-runs only the tagging job,
+          # which must find what this job uploaded on the earlier attempt.
+          name: released-pom-${{ github.run_id }}-${{ inputs.flow-type }}-${{ env.BUILD_VERSION }}
           path: pom.xml
           # Long enough to cover a recovery days later, not just the same afternoon.
           retention-days: 7
@@ -390,7 +396,7 @@ jobs:
         continue-on-error: true
         uses: actions/download-artifact@v4
         with:
-          name: released-pom-${{ github.run_id }}
+          name: released-pom-${{ github.run_id }}-${{ inputs.flow-type }}-${{ needs.prepare-build-publish-release.outputs.build-version }}
           # Into its own directory: at the workspace root a `-f pom.xml` probe could not
           # tell the released file from a checked-out one, and would silently attach the
           # pre-release version if a checkout is ever added to this job.
@@ -409,12 +415,14 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FLOW_TYPE: ${{ inputs.flow-type }}
+          BUILD_VERSION: ${{ needs.prepare-build-publish-release.outputs.build-version }}
         run: |
           set -uo pipefail
           for attempt in 1 2 3; do
             if gh run download "${GITHUB_RUN_ID}" \
                  --repo "${GITHUB_REPOSITORY}" \
-                 --name "released-pom-${GITHUB_RUN_ID}" \
+                 --name "released-pom-${GITHUB_RUN_ID}-${FLOW_TYPE}-${BUILD_VERSION}" \
                  --dir released-pom; then
               echo "Restored the released pom.xml on retry ${attempt}."
               exit 0
@@ -450,26 +458,49 @@ jobs:
             exit 1
           fi
 
-          # Attach the released pom.xml when it was restored; never fail the release over it.
-          asset=()
-          if [ -f released-pom/pom.xml ]; then
-            asset=(released-pom/pom.xml)
-          else
-            echo "::warning title=Release asset missing::The released pom.xml could not be restored, so the release is created without it. The tag, the release and its run stamp are unaffected; only the attached file is missing."
-            # Also on the run summary: an annotation is easy to scroll past, and a release
-            # that quietly lacks its promised asset is what a reviewer objected to here.
-            # Deliberately NOT a step failure: this step runs after an irreversible publish,
-            # so failing it would either strand a published version untagged (if it failed
-            # before tagging) or skip registration (if after) — both far worse outcomes than
-            # a missing convenience file. Attach it by hand, or re-run this job.
+          # The asset must never gate the release. Two reasons it previously could:
+          #
+          #  * `gh release create <files>` and `gh release upload` were run bare under
+          #    `set -e`, so a 5xx from the asset endpoint aborted the step — after an
+          #    irreversible publish, and before the stamp step, which skips registration.
+          #  * passing files to `gh release create` makes it create a DRAFT, upload, then
+          #    publish. A runner killed mid-upload leaves a draft, which `releases/tags/...`
+          #    does not return, so the stamp fails and every re-run repeats it.
+          #
+          # So the release is always created WITHOUT assets — no draft phase exists — and the
+          # asset is attached afterwards by a helper that cannot fail the job.
+          note_missing_asset() {
+            echo "::warning title=Release asset missing::$1 The tag, the release and its run stamp are unaffected; only the attached pom.xml is missing."
             {
               echo "### Release ${TAG}: pom.xml asset missing"
               echo ""
-              echo "The published pom.xml could not be restored from the build job's artifact."
+              echo "$1"
               echo "The tag, the release and the run stamp are correct; only the attached file is absent."
               echo "Attach it manually, or re-run this job while the artifact is still retained."
             } >> "$GITHUB_STEP_SUMMARY"
-          fi
+          }
+
+          attach_asset() {
+            if [ ! -f released-pom/pom.xml ]; then
+              note_missing_asset "The released pom.xml could not be restored from the build job's artifact."
+              return 0
+            fi
+            if gh release upload "$TAG" released-pom/pom.xml; then
+              echo "Attached the released pom.xml to ${TAG}."
+              return 0
+            fi
+            note_missing_asset "The released pom.xml was restored but GitHub refused the asset upload."
+            return 0
+          }
+
+          # A draft left behind by an interrupted attempt is invisible to the stamp step's
+          # `releases/tags/...` lookup, so publish it rather than treating it as done.
+          publish_if_draft() {
+            if [ "$(gh release view "$TAG" --json isDraft --jq '.isDraft')" = "true" ]; then
+              echo "Release ${TAG} exists as a draft — publishing it."
+              gh release edit "$TAG" --draft=false
+            fi
+          }
 
           # The TAG is the authority, not the release: `gh release create --target` is IGNORED
           # when the tag already exists (REST: target_commitish is "unused if the Git tag already
@@ -502,14 +533,12 @@ jobs:
               # with the asset missing forever. Upload only when it is actually absent:
               # --clobber deletes before uploading, so a flaky upload here would destroy a
               # good asset.
+              publish_if_draft
               existing_assets="$(gh release view "$TAG" --json assets --jq '.assets[].name')"
               if grep -qxF "pom.xml" <<<"$existing_assets"; then
                 echo "Release $TAG already exists at $built_sha with pom.xml attached — nothing to do."
-              elif [ "${#asset[@]}" -gt 0 ]; then
-                gh release upload "$TAG" released-pom/pom.xml
-                echo "Release $TAG already exists at $built_sha — attached the missing pom.xml."
               else
-                echo "Release $TAG already exists at $built_sha without pom.xml, and the released pom.xml is not available to attach."
+                attach_asset
               fi
               exit 0
             fi
@@ -519,8 +548,9 @@ jobs:
               exit 1
             fi
             # Tag is correct but has no release: adopt it instead of creating a second one.
-            gh release create "$TAG" --verify-tag --title "$TAG" --generate-notes ${asset[@]+"${asset[@]}"}
+            gh release create "$TAG" --verify-tag --title "$TAG" --generate-notes
             echo "Created release $TAG on the existing, correct tag $built_sha"
+            attach_asset
             exit 0
           fi
 
@@ -549,8 +579,9 @@ jobs:
             echo "::error title=Tag creation refused::Could not create ${TAG} at ${built_sha}. An HTTP 404 here means GitHub refused the ref update because the commit carries a workflow file that now matches no branch head — the pre-build check passed, so a branch moved while this release was building. The artifacts for this version are already published and cannot be published again, so do NOT re-dispatch the release. Recovery: create ${TAG} manually on ${built_sha} with a credential authorized to modify workflows, then use GitHub's 're-run failed jobs' on this run — that repeats only this job, which will adopt the tag and attach the release, and leaves the publish untouched." >&2
             exit 1
           fi
-          gh release create "$TAG" --verify-tag --title "$TAG" --generate-notes ${asset[@]+"${asset[@]}"}
+          gh release create "$TAG" --verify-tag --title "$TAG" --generate-notes
           echo "Created tag and release $TAG at $built_sha"
+          attach_asset
       # Bind the release to the run that produced it. Registration happens afterwards
       # in a workflow_run context whose only trustworthy identity is this run's id and
       # attempt: a tag cannot say which release a run made when several releases share

--- a/.github/workflows/common-java-maven-release.yml
+++ b/.github/workflows/common-java-maven-release.yml
@@ -370,7 +370,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # The pom.xml the publish job actually released, restored as the release asset.
+      #
+      # continue-on-error, and every use of the file below is guarded, because whether a
+      # previous attempt's artifact is visible to a re-run of only the FAILED jobs is not
+      # documented by either artifact action, and it could not be tested here: pushing a
+      # probe workflow needs the `workflow` token scope that this whole change is about.
+      # So the recovery path must not hinge on it. If the artifact is there the asset is
+      # attached exactly as before; if it is not, the release is still created, tagged and
+      # stamped — which is what registration depends on — and the missing asset is
+      # reported rather than silently dropped.
       - name: Restore the released pom.xml
+        id: restore-pom
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           name: released-pom-${{ github.run_id }}
@@ -393,6 +404,14 @@ jobs:
           if [ -z "$built_sha" ]; then
             echo "::error title=Built commit unknown::The build job did not report the commit it built, so there is nothing safe to tag." >&2
             exit 1
+          fi
+
+          # Attach the released pom.xml when it was restored; never fail the release over it.
+          asset=()
+          if [ -f pom.xml ]; then
+            asset=(pom.xml)
+          else
+            echo "::warning title=Release asset missing::The released pom.xml could not be restored, so the release is created without it. The tag, the release and its run stamp are unaffected; only the attached file is missing."
           fi
 
           # The TAG is the authority, not the release: `gh release create --target` is IGNORED
@@ -426,12 +445,14 @@ jobs:
               # with the asset missing forever. Upload only when it is actually absent:
               # --clobber deletes before uploading, so a flaky upload here would destroy a
               # good asset.
-              assets="$(gh release view "$TAG" --json assets --jq '.assets[].name')"
-              if grep -qxF "pom.xml" <<<"$assets"; then
+              existing_assets="$(gh release view "$TAG" --json assets --jq '.assets[].name')"
+              if grep -qxF "pom.xml" <<<"$existing_assets"; then
                 echo "Release $TAG already exists at $built_sha with pom.xml attached — nothing to do."
-              else
+              elif [ "${#asset[@]}" -gt 0 ]; then
                 gh release upload "$TAG" pom.xml
                 echo "Release $TAG already exists at $built_sha — attached the missing pom.xml."
+              else
+                echo "Release $TAG already exists at $built_sha without pom.xml, and the released pom.xml is not available to attach."
               fi
               exit 0
             fi
@@ -441,7 +462,7 @@ jobs:
               exit 1
             fi
             # Tag is correct but has no release: adopt it instead of creating a second one.
-            gh release create "$TAG" --verify-tag --title "$TAG" --generate-notes pom.xml
+            gh release create "$TAG" --verify-tag --title "$TAG" --generate-notes ${asset[@]+"${asset[@]}"}
             echo "Created release $TAG on the existing, correct tag $built_sha"
             exit 0
           fi
@@ -471,7 +492,7 @@ jobs:
             echo "::error title=Tag creation refused::Could not create ${TAG} at ${built_sha}. An HTTP 404 here means GitHub refused the ref update because the commit carries a workflow file that now matches no branch head — the pre-build check passed, so a branch moved while this release was building. The artifacts for this version are already published and cannot be published again, so do NOT re-dispatch the release. Recovery: create ${TAG} manually on ${built_sha} with a credential authorized to modify workflows, then use GitHub's 're-run failed jobs' on this run — that repeats only this job, which will adopt the tag and attach the release, and leaves the publish untouched." >&2
             exit 1
           fi
-          gh release create "$TAG" --verify-tag --title "$TAG" --generate-notes pom.xml
+          gh release create "$TAG" --verify-tag --title "$TAG" --generate-notes ${asset[@]+"${asset[@]}"}
           echo "Created tag and release $TAG at $built_sha"
       # Bind the release to the run that produced it. Registration happens afterwards
       # in a workflow_run context whose only trustworthy identity is this run's id and

--- a/.github/workflows/common-java-maven-release.yml
+++ b/.github/workflows/common-java-maven-release.yml
@@ -399,6 +399,11 @@ jobs:
       # A flaky artifact service should cost a retry, not the asset. This is what makes the
       # step above best-effort rather than lax: the common failure it tolerates is transient,
       # and transient failures are retried here instead of degrading the release.
+      #
+      # It also hedges the one thing that could not be verified: whether download-artifact
+      # sees an artifact uploaded by a job that did NOT re-run. This path asks
+      # `GET /repos/{owner}/{repo}/actions/runs/{run_id}/artifacts`, which is scoped to the
+      # RUN, so if the action turns out to be attempt-scoped the retry still finds it.
       - name: Retry restoring the released pom.xml
         if: ${{ steps.restore-pom.outcome == 'failure' }}
         continue-on-error: true

--- a/.github/workflows/common-java-maven-release.yml
+++ b/.github/workflows/common-java-maven-release.yml
@@ -142,7 +142,12 @@ jobs:
 
       - name: Record the built commit
         id: built-commit
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+        run: |
+          # Assign first: `echo "sha=$(git rev-parse HEAD)"` succeeds even when rev-parse
+          # fails, writing an empty sha that is only caught after the publish.
+          set -euo pipefail
+          sha="$(git rev-parse HEAD)"
+          echo "sha=${sha}" >> "$GITHUB_OUTPUT"
 
       # A release must be able to tag the commit it builds — and for some commits the
       # Actions GITHUB_TOKEN cannot. GitHub refuses any ref update, REST or git push,
@@ -341,7 +346,8 @@ jobs:
           # a full re-run — which does repeat this job — from colliding with itself.
           name: released-pom-${{ github.run_id }}
           path: pom.xml
-          retention-days: 1
+          # Long enough to cover a recovery days later, not just the same afternoon.
+          retention-days: 7
           if-no-files-found: error
           overwrite: true
 
@@ -385,6 +391,33 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: released-pom-${{ github.run_id }}
+          # Into its own directory: at the workspace root a `-f pom.xml` probe could not
+          # tell the released file from a checked-out one, and would silently attach the
+          # pre-release version if a checkout is ever added to this job.
+          path: released-pom
+
+      # A flaky artifact service should cost a retry, not the asset. This is what makes the
+      # step above best-effort rather than lax: the common failure it tolerates is transient,
+      # and transient failures are retried here instead of degrading the release.
+      - name: Retry restoring the released pom.xml
+        if: ${{ steps.restore-pom.outcome == 'failure' }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+          for attempt in 1 2 3; do
+            if gh run download "${GITHUB_RUN_ID}" \
+                 --repo "${GITHUB_REPOSITORY}" \
+                 --name "released-pom-${GITHUB_RUN_ID}" \
+                 --dir released-pom; then
+              echo "Restored the released pom.xml on retry ${attempt}."
+              exit 0
+            fi
+            echo "Retry ${attempt} could not fetch the released pom.xml; waiting."
+            sleep $(( attempt * 10 ))
+          done
+          echo "Could not fetch the released pom.xml after 3 retries." >&2
 
       # The tag is created at the commit the build job actually built. The replaced
       # action, marvinpinto/action-automatic-releases, had no target-commit input: it
@@ -395,6 +428,12 @@ jobs:
       - name: Create release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # This job has no checkout, and `gh release …` resolves the repository from the
+          # git remote — GITHUB_REPOSITORY is not consulted, GH_REPO is the only documented
+          # override. Without it every release subcommand dies with "failed to run git:
+          # not a git repository", after the artifacts are published. The sibling `gh api`
+          # calls are unaffected because they name the repository in the path.
+          GH_REPO: ${{ github.repository }}
           TAG: v${{ needs.prepare-build-publish-release.outputs.build-version }}
           BUILT_SHA: ${{ needs.prepare-build-publish-release.outputs.built-sha }}
         run: |
@@ -408,10 +447,23 @@ jobs:
 
           # Attach the released pom.xml when it was restored; never fail the release over it.
           asset=()
-          if [ -f pom.xml ]; then
-            asset=(pom.xml)
+          if [ -f released-pom/pom.xml ]; then
+            asset=(released-pom/pom.xml)
           else
             echo "::warning title=Release asset missing::The released pom.xml could not be restored, so the release is created without it. The tag, the release and its run stamp are unaffected; only the attached file is missing."
+            # Also on the run summary: an annotation is easy to scroll past, and a release
+            # that quietly lacks its promised asset is what a reviewer objected to here.
+            # Deliberately NOT a step failure: this step runs after an irreversible publish,
+            # so failing it would either strand a published version untagged (if it failed
+            # before tagging) or skip registration (if after) — both far worse outcomes than
+            # a missing convenience file. Attach it by hand, or re-run this job.
+            {
+              echo "### Release ${TAG}: pom.xml asset missing"
+              echo ""
+              echo "The published pom.xml could not be restored from the build job's artifact."
+              echo "The tag, the release and the run stamp are correct; only the attached file is absent."
+              echo "Attach it manually, or re-run this job while the artifact is still retained."
+            } >> "$GITHUB_STEP_SUMMARY"
           fi
 
           # The TAG is the authority, not the release: `gh release create --target` is IGNORED
@@ -449,7 +501,7 @@ jobs:
               if grep -qxF "pom.xml" <<<"$existing_assets"; then
                 echo "Release $TAG already exists at $built_sha with pom.xml attached — nothing to do."
               elif [ "${#asset[@]}" -gt 0 ]; then
-                gh release upload "$TAG" pom.xml
+                gh release upload "$TAG" released-pom/pom.xml
                 echo "Release $TAG already exists at $built_sha — attached the missing pom.xml."
               else
                 echo "Release $TAG already exists at $built_sha without pom.xml, and the released pom.xml is not available to attach."
@@ -505,6 +557,10 @@ jobs:
       - name: Stamp the release with this run
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Set for the same reason as above. This step only uses `gh api` with explicit
+          # repository paths, so it does not need it today — but a future `gh release` call
+          # added here would fail in a way that is hard to read.
+          GH_REPO: ${{ github.repository }}
           TAG: v${{ needs.prepare-build-publish-release.outputs.build-version }}
           MARKER: "<!-- octopus-release-run: ${{ github.run_id }}/${{ github.run_attempt }} -->"
         run: |

--- a/docs/Octopus Administrator Troubleshooting.md
+++ b/docs/Octopus Administrator Troubleshooting.md
@@ -168,7 +168,20 @@ that:
   merge by default, so this is routine rather than a rare race. A commit that was legal *because*
   it headed a branch stops being legal when that branch goes away.
 
-The artifacts are published and immutable, so the version cannot be republished. The tag has to
-be created on the built commit and the release attached by re-running — which needs the credential
-described above. The error message states the situation; this is the one failure that can leave a
-release stuck with no operator-side way forward, so escalate rather than retrying.
+The artifacts are published and immutable, so the version cannot be republished. **Do not
+re-dispatch the release** — that would start a fresh run which tries to publish the same version
+and fails.
+
+Recovery, in this order:
+
+1. Create the tag on the commit the run built — the failing step prints both the tag name and the
+   commit sha. This needs the credential described above, so unless an administrator has minted
+   one, escalate here.
+2. On the same run, use GitHub's **"Re-run failed jobs"**. Tagging and release creation live in
+   their own job (`Tag and release`), downstream of the publish, so a re-run repeats only that
+   job: it finds the tag now present on the built commit, attaches the release to it, and leaves
+   the successful publish untouched.
+
+That job split is what makes step 2 work at all. Before it existed, publishing and tagging shared
+one job, so any re-run replayed the publish and failed on Central's immutability before ever
+reaching the tag — the recovery was undocumentable in practice.

--- a/docs/Octopus GitHub Actions Guide.md
+++ b/docs/Octopus GitHub Actions Guide.md
@@ -258,7 +258,9 @@ Real check names from `octopus-test`:
 If the repository uses a unified merge contract, require only:
 - `gate/merge`
 
-Do not mark disabled or intentionally skipped jobs as required in branch protection.
+Do not mark disabled or intentionally skipped jobs as required in branch protection. The release
+workflows' `Tag and release` job is one of these: it runs only for a real release, so in a
+consumer's dry-run smoke matrix it is always skipped and must never be a required check.
 
 This keeps branch protection independent from implementation details (Gradle, Maven, Python, etc.).
 


### PR DESCRIPTION
Follow-up to #179, which fixed the wrong-tag defect but shipped two problems of its own, plus three found while fixing them. Nothing here is in a release yet — `dac2cf1` is in no tag, the latest release is `v2.6.1` from the commit before it — so no consumer pinned to a tag has seen any of it.

## 1. The documented recovery could not be executed

When tagging fails *after* the publish, the error message and `docs/Octopus Administrator Troubleshooting.md` both told the operator to create the tag manually and re-run.

That was impossible. Tagging shared a job with the publish, and a re-run restarts a job from its first step, so it replayed the Sonatype publish. Maven Central refuses a version that already exists, so the job died there and never reached the branch that adopts an existing tag.

**Fix:** tagging, release creation and stamping move into their own `Tag and release` job, downstream of the publish. "Re-run failed jobs" now repeats only that job, so the recovery is real: create the tag, re-run failed jobs, the job adopts it and attaches the release.

Consequences that had to be handled with it:

- **`gh` cannot resolve the repository without a checkout.** The new job has none, and `gh release view/create/upload` resolve from the git remote — `GITHUB_REPOSITORY` is not consulted and `GH_REPO` is the only documented override. Measured with gh 2.96.0 in a non-git directory: every release subcommand dies with `failed to run git: not a git repository`, and the same call with `GH_REPO` set works. Unfixed this would have broken **the happy path of every real release** — tag created, release never created — and every re-run would have failed identically, because that git error matches none of the not-found patterns. Fixed with `GH_REPO`, deliberately **not** a checkout: a checkout would put a pre-release `pom.xml` where the asset probe looks, turning a loud absence into a silently wrong attachment. The restored file therefore lands in `released-pom/`.
- The built commit is published as a job **output** rather than re-derived, so the tagging job tags exactly what was built.
- Maven attaches the `pom.xml` that `versions:set` rewrote, so it travels as an artifact, keyed by run id only (**not** attempt — the recovery re-runs just the tagging job and must find what the publish job uploaded on the earlier attempt), with `overwrite: true` for the full-re-run case and 7-day retention so a later recovery can still find it.
- That asset is attached **best-effort**: a `gh run download` retry runs before degrading, and a degraded release says so in an annotation and on the run summary. It is deliberately not fatal — the step runs after an irreversible publish, so failing it would either strand a published version untagged (before tagging) or skip registration (after), both worse than a missing convenience file. The retry also hedges the one thing that could not be verified here: it reads the **run**-scoped artifacts endpoint, so it still finds the file if `download-artifact` turns out to be attempt-scoped.
- `register-release-in-log` now waits for the release to exist, not merely for the publish.

## 2. The stamp lookup read only the first page of releases

`resolve-released-version.sh` asked for `releases?per_page=50` without `--paginate`. A successful first page without the run's stamp was then treated as "predates stamping", handing the answer to the tag or latest-release fallback — which can name a version another run released. Same silent wrong-version class the previous round closed, by another route.

Not hypothetical: octopus-components-registry-service holds 95 releases, octopus-dms-service 59, octopus-vcs-facade 54.

**Fix:** `--paginate` with `per_page=100`, taking the first non-empty page result. The `gh` stub now **refuses** an unpaginated list call, so dropping `--paginate` fails the suite instead of passing quietly.

## 3. The release lock ended before the tag existed

Raised in review: splitting the jobs moved the tag outside the `concurrency` lease, which the publish job held. A public-flow release starting in that window reads `find-latest-tag` and can compute a version that was just released.

**Fix:** the group moves to **workflow level**, so the lease spans publish → tag/release → registration.

Extending the job-level group to the tagging job instead was considered and rejected: a publish job already pending on the group acquires it first, so it *still* computes its version before the earlier tag exists, while the tagging job waits behind a full publish and a third release cancels it outright under the one-pending-member rule. That reasoning is recorded in the workflow so it is not "fixed" back.

Also hardened while there: two smoke variants differing only in `publish-to-nexus` shared a dry-run key, so they serialized needlessly and were one variant away from cancelling each other. The key now includes that input.

## Verification

- 21 resolver scenarios; `actionlint` (CI-pinned `rhysd/actionlint:1.7.12`, shellcheck included); workflow-naming and external-action-ref validators; asserted mechanically that the publish job creates no releases, the tagging job publishes nothing, and registration depends on both.
- **Job outputs survive a partial re-run — measured, not assumed.** Not stated by the re-run docs or the syntax reference, but run `30449808701` shows it: on attempt 2 `consumer-verify-scope` did not re-run (its start time is attempt 1's) while `consumer-verify / verify` did, and inside it the steps gated on `inputs.enabled` all succeeded while `Skip verification (disabled)` was skipped. `enabled` is `needs.consumer-verify-scope.outputs.run_verify == 'true'`, so the value crossed the attempt boundary intact. That is the mechanism `built-sha` relies on.
- **Workflow-level concurrency is honored for a called workflow — measured too.** In the canary for this branch, the two smoke variants sharing a dry-run key ran 9 s apart while the other four started together, and at that tip the publish job has no group of its own, so the serialization came from the workflow-level one. Both halves confirmed: the key is evaluated and `inputs.*` resolves there.
- Verified the guarded asset expansion under `set -u` with the list empty and populated, on bash 3.2 — stricter here than the runners' bash 5.
- Merge contract per `AGENTS.md`: required checks are `gate/merge` and the GitGuardian check, neither affected. `Tag and release` is gated on `!dry-run`, so it is always skipped in a consumer's dry-run smoke matrix — documented in the actions guide next to the real check names, because a permanently skipped job must never be required.

**The blind spot, stated plainly:** the canary is all dry-run, so `Tag and release` has never executed anywhere and the extended lease has never been exercised. That is exactly what hid the `GH_REPO` defect from CI. The first real release after this merges is the actual test and is worth watching. A cheaper deliberate check first: publish a throwaway version on `octopus-test` with `publish-to-nexus: false`, delete the tag it created, then re-run failed jobs and confirm the job re-attaches the release without republishing.

## Related

- #179 — introduced the first two defects.
- #180 — the credential decision; step 1 of the recovery still needs it.
- #181 — extracting this logic behind the stub harness, which would have caught the pagination defect.
- #184 — the generated-notes range, still open from #173.
- #185 — Maven has no concurrency group at all, and this split widened its window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
