### PR TITLE
fix(release): attach the Maven POM before publishing, and stop the asset lookup gating the job

### DIFF
--- a/.github/workflows/common-java-maven-release.yml
+++ b/.github/workflows/common-java-maven-release.yml
@@ -547,7 +547,12 @@ jobs:
               # with the asset missing forever. Upload only when it is actually absent:
               # --clobber deletes before uploading, so a flaky upload here would destroy a
               # good asset.
-              publish_if_draft
+              # Asset FIRST, publication second — the same order as the create path below,
+              # and for the same reason. A previous attempt can leave a draft with no
+              # pom.xml; publishing it here before the upload would put the release beyond
+              # reach of an asset once immutable releases are enabled on the repository,
+              # permanently. `publish_if_draft` therefore runs after the block below.
+              #
               # This lookup is part of the best-effort asset path, so it must not abort the
               # job either: failing here would skip stamping and registration over a
               # convenience file. When the asset list cannot be read, just try the upload —
@@ -564,6 +569,7 @@ jobs:
               else
                 attach_asset
               fi
+              publish_if_draft
               exit 0
             fi
             if ! grep -qE 'release not found|HTTP 404|"status": ?"404"' <<<"$rel_out"; then

--- a/.github/workflows/common-java-maven-release.yml
+++ b/.github/workflows/common-java-maven-release.yml
@@ -464,11 +464,21 @@ jobs:
           #    `set -e`, so a 5xx from the asset endpoint aborted the step — after an
           #    irreversible publish, and before the stamp step, which skips registration.
           #  * passing files to `gh release create` makes it create a DRAFT, upload, then
-          #    publish. A runner killed mid-upload leaves a draft, which `releases/tags/...`
-          #    does not return, so the stamp fails and every re-run repeats it.
+          #    publish, all inside one command. A runner killed mid-upload leaves a draft,
+          #    which `releases/tags/...` does not return, so the stamp fails and every
+          #    re-run repeats it.
           #
-          # So the release is always created WITHOUT assets — no draft phase exists — and the
-          # asset is attached afterwards by a helper that cannot fail the job.
+          # The draft phase is now deliberate rather than avoided: every path creates the
+          # release as a draft, attaches the asset, then publishes. Attaching after
+          # publication is not an option, because GitHub refuses asset uploads to a
+          # published release once immutable releases are enabled on the repository, which
+          # would lose the pom.xml permanently and silently.
+          #
+          # What makes the draft safe here — and did not hold for the single-command form
+          # above — is that the draft is never the last word. The attach helper cannot fail
+          # the job, and publication happens unconditionally afterwards, so a refused or
+          # impossible upload still yields a published release; `publish_if_draft` finishes
+          # off a draft stranded by an earlier interrupted attempt.
           note_missing_asset() {
             echo "::warning title=Release asset missing::$1 The tag, the release and its run stamp are unaffected; only the attached pom.xml is missing."
             {

--- a/.github/workflows/common-java-maven-release.yml
+++ b/.github/workflows/common-java-maven-release.yml
@@ -502,6 +502,20 @@ jobs:
             fi
           }
 
+          # Draft, then asset, then publish. GitHub's immutable releases refuse an asset
+          # added after publication, so attaching afterwards would silently stop working
+          # the day immutability is enabled on a consumer repository. Publication happens
+          # unconditionally, so a refused upload cannot strand the draft — and a runner
+          # killed mid-sequence leaves one that the existing-release path above publishes
+          # on the next attempt. This is why `gh release create` is not given the file
+          # directly: doing that makes it draft, upload and publish as one step, where an
+          # interrupted upload leaves a draft nothing ever finishes.
+          create_release_with_asset() {
+            gh release create "$TAG" --verify-tag --draft --title "$TAG" --generate-notes
+            attach_asset
+            gh release edit "$TAG" --draft=false
+          }
+
           # The TAG is the authority, not the release: `gh release create --target` is IGNORED
           # when the tag already exists (REST: target_commitish is "unused if the Git tag already
           # exists"). A tag that outlived its release — deleting a release leaves the tag behind
@@ -534,8 +548,18 @@ jobs:
               # --clobber deletes before uploading, so a flaky upload here would destroy a
               # good asset.
               publish_if_draft
-              existing_assets="$(gh release view "$TAG" --json assets --jq '.assets[].name')"
-              if grep -qxF "pom.xml" <<<"$existing_assets"; then
+              # This lookup is part of the best-effort asset path, so it must not abort the
+              # job either: failing here would skip stamping and registration over a
+              # convenience file. When the asset list cannot be read, just try the upload —
+              # attach_asset never fails, and an upload of an asset that already exists is
+              # refused harmlessly rather than clobbering the good one.
+              assets_lookup=0
+              existing_assets="$(gh release view "$TAG" --json assets --jq '.assets[].name' 2>&1)" || assets_lookup=$?
+              if [ "$assets_lookup" -ne 0 ]; then
+                printf '%s\n' "$existing_assets" >&2
+                echo "::warning title=Release assets unreadable::Could not list the assets already on ${TAG}, so the upload is attempted without knowing. The tag, the release and its run stamp are unaffected."
+                attach_asset
+              elif grep -qxF "pom.xml" <<<"$existing_assets"; then
                 echo "Release $TAG already exists at $built_sha with pom.xml attached — nothing to do."
               else
                 attach_asset
@@ -548,9 +572,8 @@ jobs:
               exit 1
             fi
             # Tag is correct but has no release: adopt it instead of creating a second one.
-            gh release create "$TAG" --verify-tag --title "$TAG" --generate-notes
+            create_release_with_asset
             echo "Created release $TAG on the existing, correct tag $built_sha"
-            attach_asset
             exit 0
           fi
 
@@ -579,9 +602,8 @@ jobs:
             echo "::error title=Tag creation refused::Could not create ${TAG} at ${built_sha}. An HTTP 404 here means GitHub refused the ref update because the commit carries a workflow file that now matches no branch head — the pre-build check passed, so a branch moved while this release was building. The artifacts for this version are already published and cannot be published again, so do NOT re-dispatch the release. Recovery: create ${TAG} manually on ${built_sha} with a credential authorized to modify workflows, then use GitHub's 're-run failed jobs' on this run — that repeats only this job, which will adopt the tag and attach the release, and leaves the publish untouched." >&2
             exit 1
           fi
-          gh release create "$TAG" --verify-tag --title "$TAG" --generate-notes
+          create_release_with_asset
           echo "Created tag and release $TAG at $built_sha"
-          attach_asset
       # Bind the release to the run that produced it. Registration happens afterwards
       # in a workflow_run context whose only trustworthy identity is this run's id and
       # attempt: a tag cannot say which release a run made when several releases share


### PR DESCRIPTION
Two `[P2]` findings from the combined review of #179 + #183, split out so they did not hold up `v2.6.2`. Both are in the Maven asset path; neither affects Gradle, which attaches no assets.

## 1. The asset lookup could still abort the release

`#183` made attaching the POM best-effort by guarding the *upload*. It did not guard the *lookup*: `gh release view "$TAG" --json assets` ran bare under `set -euo pipefail`, so a transient failure reading which assets a release already carries aborted the tagging job — before stamping, and therefore skipping registration, because `register-release-in-log` depends on that job. Over a convenience file, after an irreversible publish.

**Fix:** when the asset list cannot be read, warn and attempt the upload anyway. `attach_asset` cannot fail, and uploading an asset that already exists is refused harmlessly — notably *without* `--clobber`, so a good asset is never destroyed by a blind retry.

## 2. Publish-then-attach is incompatible with immutable releases

Every Maven path published the release and then attached the POM. GitHub's [immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases) refuse assets added after publication, so this would stop working **silently** the day immutability is enabled on a consumer repository — a release that looks fine but quietly lacks its promised file. It is not urgent only because immutability is not currently enabled for these repositories.

**Fix:** draft → asset → publish, with publication **unconditional**:

```
gh release create "$TAG" --verify-tag --draft --title "$TAG" --generate-notes
attach_asset          # never fails
gh release edit "$TAG" --draft=false
```

Two things this deliberately is **not**:

- It is not `gh release create <file>`, which drafts, uploads and publishes as a single step — an upload interrupted there leaves a draft that nothing ever finishes. That was one of the defects #183 fixed, and reintroducing it would be a regression.
- The publish is not conditional on the upload succeeding, so a refused asset cannot strand the draft. And if a runner is killed mid-sequence, the existing-release path still publishes the draft it finds on the next attempt.

## Verification

`actionlint` (CI-pinned `rhysd/actionlint:1.7.12`, shellcheck included) passes, and both paths were driven directly rather than reasoned about:

- asset upload refused → the sequence completes and the draft is published, so the release is never left unpublished because of an asset;
- asset lookup fails → the step warns and continues past the lookup instead of aborting.

**Not covered by CI, unchanged from #183:** the canary is entirely dry-run, so `Tag and release` still executes nowhere. A throwaway real consumer release with `publish-to-nexus: false` remains the outstanding check, and it now also covers this ordering.

## Related

- #179, #183 — the change set these were found in.
- #181 — extracting this logic behind the stub harness, which is what would let the ordering be tested rather than driven by hand.
- #185 — Maven still has no concurrency group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Release creation now uses draft releases while assets are processed, reducing the risk of inaccessible or incomplete releases.
  * Improved handling of asset uploads and existing releases, including fallback behavior when asset listings are unavailable.
  * Releases are published after asset processing is complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->