### PR TITLE
fix(release): give the Central publish wait 2700s, not 1800s

### DIFF
--- a/.github/scripts/portal-publish.sh
+++ b/.github/scripts/portal-publish.sh
@@ -44,9 +44,20 @@ AUTH="Authorization: Bearer $(printf '%s' "${MAVEN_USERNAME}:${MAVEN_PASSWORD}" 
 NET=(-sS --connect-timeout 15 --max-time 120)
 
 # Deadlines (seconds) — overridable for the canary.
+#
+# PUBLISH_DEADLINE is the one measured against real Sonatype behaviour rather than
+# guessed: octopus-components-registry-service 3.0.9 sat in PUBLISHING for ~32 minutes
+# (deployment b8df3ec1, 2026-07-30) and reached Maven Central two minutes AFTER the
+# then-current 1800s deadline expired. The publish had succeeded; only the waiting gave
+# up, which cost the tag, the release and the release-log entry and left a state the
+# pipeline cannot recover from on its own. 2700s covers that observation with headroom.
+#
+# Do not raise it past ~2700 without also raising TeamCity's OCTOPUS_RELEASE_TIMEOUT
+# (60 minutes): that poller waits on the whole release run, so build + this wait + tag
+# must fit inside it, or TeamCity reports a failure for a release that is still working.
 SEARCH_DEADLINE="${SEARCH_DEADLINE:-600}"
 VALIDATE_DEADLINE="${VALIDATE_DEADLINE:-1800}"
-PUBLISH_DEADLINE="${PUBLISH_DEADLINE:-1800}"
+PUBLISH_DEADLINE="${PUBLISH_DEADLINE:-2700}"
 CENTRAL_DEADLINE="${CENTRAL_DEADLINE:-1800}"
 # Settling window before re-reading state after an inconclusive publish response.
 SETTLE_SECONDS="${SETTLE_SECONDS:-45}"

--- a/.github/scripts/portal-publish.sh
+++ b/.github/scripts/portal-publish.sh
@@ -45,16 +45,29 @@ NET=(-sS --connect-timeout 15 --max-time 120)
 
 # Deadlines (seconds) — overridable for the canary.
 #
-# PUBLISH_DEADLINE is the one measured against real Sonatype behaviour rather than
-# guessed: octopus-components-registry-service 3.0.9 sat in PUBLISHING for ~32 minutes
-# (deployment b8df3ec1, 2026-07-30) and reached Maven Central two minutes AFTER the
-# then-current 1800s deadline expired. The publish had succeeded; only the waiting gave
-# up, which cost the tag, the release and the release-log entry and left a state the
-# pipeline cannot recover from on its own. 2700s covers that observation with headroom.
+# PUBLISH_DEADLINE is set from an observation rather than guessed. In
+# octopus-components-registry-service 3.0.9 (deployment b8df3ec1, run 30552430027,
+# 2026-07-30) the publish was accepted at 14:38:33 and this script gave up at 15:08:35 —
+# exactly the 1800s then in force, with the deployment still PUBLISHING. Central did
+# finish shortly afterwards, at about 15:10, so roughly 32 minutes in total; that last
+# figure comes from the release notes written by hand afterwards, NOT from the run, which
+# had already stopped and so recorded no PUBLISHED state. 2700s covers the ~32 minutes
+# with about 13 minutes to spare. Note it is one data point: no second slow publish has
+# been observed.
 #
-# Do not raise it past ~2700 without also raising TeamCity's OCTOPUS_RELEASE_TIMEOUT
-# (60 minutes): that poller waits on the whole release run, so build + this wait + tag
-# must fit inside it, or TeamCity reports a failure for a release that is still working.
+# The publish had succeeded; only the waiting gave up. Because that happens after the
+# upload, the tag, the GitHub release and the release-log entry were all skipped, leaving
+# a state the pipeline cannot finish by itself (see octopus-base#189).
+#
+# Before raising this further, check the OUTER budget, which this script cannot see.
+# TeamCity's poller waits on the whole release run; its OCTOPUS_RELEASE_TIMEOUT is
+# configured in TeamCity, not declared here, and was 60 minutes when this was written.
+# 2700s does NOT by itself guarantee the run fits: the deadlines below are sequential, so
+# this wait plus CENTRAL_DEADLINE alone permit 75 minutes, and all four permit 115 —
+# before any build, tagging or registration time. In practice the phases after PUBLISHED
+# cost seconds (measured: 6s in octopus-dms-service run 30597896298), which is why the
+# arithmetic has not bitten. Treat 2700 as "covers the observed publish", not as
+# "provably inside the TeamCity budget".
 SEARCH_DEADLINE="${SEARCH_DEADLINE:-600}"
 VALIDATE_DEADLINE="${VALIDATE_DEADLINE:-1800}"
 PUBLISH_DEADLINE="${PUBLISH_DEADLINE:-2700}"


### PR DESCRIPTION
## What

`PUBLISH_DEADLINE` in `.github/scripts/portal-publish.sh` goes from 1800s to 2700s, with a comment recording the measurement behind it and the TeamCity budget it must stay inside.

## Why

`octopus-components-registry-service` 3.0.9, run [30552430027](https://github.com/octopusden/octopus-components-registry-service/actions/runs/30552430027):

```
14:38:32  POST /deployment/b8df3ec1… -> HTTP 204   Publish accepted.
14:38:33  state=PUBLISHING
   … ~90 polls, all PUBLISHING …
15:08:35  ##[error] Deployment b8df3ec1… did not reach PUBLISHED within 1800s
```

Central finished at **15:10:36** — two minutes after the helper gave up. The publish had succeeded; only the waiting failed.

The cost is not a red run. Because the failure lands *past* the upload, `Tag and release` and `Register release` never run, and the repository is left with:

- Maven Central: 3.0.9 published (all nine coordinates verified resolvable)
- git: no `v3.0.9` tag
- GitHub: no release
- `octopus-release-log`: no entry

The pipeline cannot recover from that by itself. A plain re-dispatch recomputes 3.0.9 from the last tag and dies on `Component with package url … already exists`. `octopus-cve-automation` is in the same state for 2.0.3 (different first cause, same end state), and both were finished by hand.

## Why 2700 and not more

TeamCity's `Call GitHub Release` step polls the whole release run and fails it on timeout. `OCTOPUS_RELEASE_TIMEOUT` is 60 minutes, so build + this wait + tag must fit inside that. 2700s leaves room for both; raising the helper further without raising TeamCity would just move the red from one system to the other. The constraint is written next to the value so the next person changing it sees it.

## Scope

This makes the failure rarer, not impossible — Sonatype can be slower than any deadline. The recovery path for "Central published, bookkeeping missing" is tracked separately.

## Testing

`bash -n` passes. `.github/scripts/test/portal-publish-scenarios.sh` sets every deadline explicitly (`PUBLISH_DEADLINE=6`), so the default is not exercised by it and the change cannot alter its outcome. The suite could not be run locally: it needs `mapfile`, and macOS ships bash 3.2 — it runs on the ubuntu runners in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the default publishing timeout to better accommodate delays during release publishing.
  * Added guidance documenting publishing delays and timeout constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Recovery path for the "Central published, bookkeeping missing" state: #189. Docker tag overwrite seen alongside it: #190.
