### PR TITLE
feat(quality): add a publication-set policy so components stop hand-rolling one

### DIFF
--- a/gradle-quality-plugin/build.gradle.kts
+++ b/gradle-quality-plugin/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
 // inside a GradleRunner subprocess during functional tests — Kover's JVM agent cannot instrument
 // code in a different JVM process.  Excluding those classes keeps the gate honest: the threshold
 // applies only to code we can actually measure, not to code that is structurally untestable with
-// in-process instrumentation.  The excluded code IS tested — by the 11 GradleRunner functional
+// in-process instrumentation.  The excluded code IS tested — by the GradleRunner functional
 // tests — just not via Kover.
 kover {
     reports {
@@ -49,6 +49,8 @@ kover {
                     "org.octopusden.octopus.quality.internal.TaskRegistrar\$*",
                     "org.octopusden.octopus.quality.internal.PublicationValidator",
                     "org.octopusden.octopus.quality.internal.PublicationValidator\$*",
+                    "org.octopusden.octopus.quality.internal.CentralPublicationPolicy",
+                    "org.octopusden.octopus.quality.internal.CentralPublicationPolicy\$*",
                     "org.octopusden.octopus.quality.internal.HollowGateGuard",
                     "org.octopusden.octopus.quality.internal.HollowGateGuard\$*",
                 )

--- a/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/OctopusQualityExtension.kt
+++ b/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/OctopusQualityExtension.kt
@@ -105,11 +105,20 @@ open class PublicationExtension
         val validateForMavenCentral = objects.property(Boolean::class.java).convention(true)
 
         /**
-         * The exact set of publications this repository is allowed to send to Maven Central.
+         * The exact set of Maven publications this build is expected to declare.
          *
-         * Opt-in: leave it unset and nothing is enforced. Setting it — including to an EMPTY set,
-         * which means "this repository must publish nothing" — turns on `verifyCentralPublicationPolicy`,
-         * wired into `check` so drift is caught in review rather than at the next release.
+         * Setting this does NOT switch the check on by itself — [enforceCentralPublications] does.
+         * Declaring the set without the flag leaves `verifyCentralPublicationPolicy` skipped.
+         *
+         * An EMPTY set is a meaningful value: "this build must declare no publications", which is
+         * what a deployable wants. Once enforcement is on, the task is wired into `check`, so drift
+         * is caught in review rather than at the next release.
+         *
+         * Note what this does and does not know. It compares the publications the build DECLARES,
+         * not the ones a given repository would receive: it does not inspect publishing
+         * repositories, so a publication aimed only at an internal Artifactory counts here too.
+         * Deciding what may actually reach Maven Central is the release pipeline's job, via
+         * `fat-jar-publication-allowlist`. This check exists to make the declared set stable.
          *
          * Each entry identifies one publication as
          * `projectPath|publicationName|groupId:artifactId|[sorted extension:classifier]`, for example

--- a/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/OctopusQualityExtension.kt
+++ b/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/OctopusQualityExtension.kt
@@ -103,6 +103,41 @@ open class PublicationExtension
          * Root-level / per-repo / all-or-nothing by design.
          */
         val validateForMavenCentral = objects.property(Boolean::class.java).convention(true)
+
+        /**
+         * The exact set of publications this repository is allowed to send to Maven Central.
+         *
+         * Opt-in: leave it unset and nothing is enforced. Setting it — including to an EMPTY set,
+         * which means "this repository must publish nothing" — turns on `verifyCentralPublicationPolicy`,
+         * wired into `check` so drift is caught in review rather than at the next release.
+         *
+         * Each entry identifies one publication as
+         * `projectPath|publicationName|groupId:artifactId|[sorted extension:classifier]`, for example
+         * `":client|maven|org.example:client|[jar, jar:javadoc, jar:sources]"`.
+         *
+         * The composite shape is not decoration. A project path alone cannot distinguish two
+         * publications in the same project, and is constant in a single-module build; without the
+         * coordinate an overridden artifactId or a plugin marker under a different group goes
+         * unnoticed; without the artifact signatures, attaching another classifier to an existing
+         * publication changes nothing. The version is excluded on purpose — every release changes it.
+         *
+         * The easiest way to obtain the values is to enable enforcement with an empty set once and
+         * run the task: the failure message prints the actual set, which can be pasted back.
+         */
+        val centralPublications: SetProperty<String> =
+            objects.setProperty(String::class.java).convention(emptySet())
+
+        /**
+         * Turn the publication-set check on. Off by default, so bumping the plugin never starts
+         * failing a repository that has not opted in.
+         *
+         * This is a separate switch rather than "enforce when the set is non-empty", because an
+         * EMPTY set is itself a meaningful declaration — "this repository must publish nothing" —
+         * and that is exactly the case worth guarding in a deployable. Gradle gives collection
+         * properties an empty-collection convention, so an unset property and a deliberately empty
+         * one are indistinguishable without this flag.
+         */
+        val enforceCentralPublications = objects.property(Boolean::class.java).convention(false)
     }
 
 open class KotlinExtension

--- a/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/OctopusQualityPlugin.kt
+++ b/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/OctopusQualityPlugin.kt
@@ -2,6 +2,7 @@ package org.octopusden.octopus.quality
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.octopusden.octopus.quality.internal.CentralPublicationPolicy
 import org.octopusden.octopus.quality.internal.LanguageDetector
 import org.octopusden.octopus.quality.internal.PublicationValidator
 import org.octopusden.octopus.quality.internal.SubprojectConfigurer
@@ -98,5 +99,9 @@ class OctopusQualityPlugin : Plugin<Project> {
         // opts out via octopusQuality { publication { validateForMavenCentral.set(false) } }
         // (root-level / per-repo / all-or-nothing) — then the task is skipped on `check`.
         project.allprojects.forEach { PublicationValidator.register(it, extension) }
+
+        // Registered once on the root: unlike validatePublications, which judges each publication
+        // on its own, this one judges the SET across the whole build, so it needs a single owner.
+        CentralPublicationPolicy.register(project, extension)
     }
 }

--- a/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/CentralPublicationPolicy.kt
+++ b/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/CentralPublicationPolicy.kt
@@ -1,0 +1,156 @@
+package org.octopusden.octopus.quality.internal
+
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven
+import org.octopusden.octopus.quality.OctopusQualityExtension
+
+/**
+ * Registers `verifyCentralPublicationPolicy`, which fails when the set of publications a build
+ * would send to Maven Central differs from the set the repository declared.
+ *
+ * [PublicationValidator] already checks that each publication is *well formed* — POM metadata,
+ * sources and javadoc. This checks something different and complementary: that the *set itself*
+ * has not drifted. A perfectly well-formed new coordinate passes the former and is caught here.
+ *
+ * Opt-in, behind an explicit switch. Bumping the plugin never starts failing a repository that
+ * has not asked for this:
+ *
+ * ```
+ * octopusQuality {
+ *     publication {
+ *         enforceCentralPublications.set(true)
+ *         centralPublications.set(
+ *             setOf(":client|maven|org.example:client|[jar, jar:javadoc, jar:sources]"),
+ *         )
+ *     }
+ * }
+ * ```
+ *
+ * The switch is separate from the set rather than inferred from it, because an EMPTY set is a
+ * legitimate declaration — "this repository must publish nothing", which is exactly what a
+ * deployable wants. Gradle gives collection properties an empty-collection convention, so an unset
+ * property and a deliberately empty one cannot be told apart; inferring intent from emptiness would
+ * have silently enforced "publish nothing" on every consumer at the next bump.
+ *
+ * ### Why the identity is a composite key
+ *
+ * Each entry is `projectPath|publicationName|groupId:artifactId|[sorted extension:classifier]`.
+ * Every part was added because a simpler key silently missed a real change:
+ *
+ * - **project path alone** cannot tell two publications in the same project apart, and in a
+ *   single-module repository the set is `{":"}` no matter what happens;
+ * - **without the coordinate**, an overridden `artifactId` or `groupId` goes unnoticed — and a
+ *   plugin marker published by `java-gradle-plugin` sits under a *different* group from the
+ *   project's own;
+ * - **without the artifact signatures**, attaching another classifier to an existing publication
+ *   changes nothing. That matters most where a release-time allowlist exempts an artifactId
+ *   wholesale: a second oversized artifact under an exempted coordinate would pass every check.
+ *
+ * The version is deliberately excluded, since every release changes it.
+ *
+ * ### Why it is wired into `check`
+ *
+ * Being a dependency of the publish tasks is not enough: no pull-request check runs those, so
+ * drift would be merged and surface at the next release instead of in review. It is therefore
+ * wired into `check` as well — the same way ktlint and detekt are ordinary gates rather than
+ * special cases. It is a task action, never a configuration-time failure, so a violation fails
+ * its own gate rather than breaking `build`, `dependencies` and IDE sync.
+ */
+internal object CentralPublicationPolicy {
+    private const val TASK_NAME = "verifyCentralPublicationPolicy"
+
+    /**
+     * `publishToSonatype` only exists with the nexus plugin and `publish` is per-project, so these
+     * are matched by name rather than forced into existence.
+     */
+    private val AGGREGATE_PUBLISH_TASKS = setOf("publishToSonatype", "publish", "publishToMavenLocal")
+
+    fun register(
+        project: Project,
+        rootExtension: OctopusQualityExtension,
+    ) {
+        val declared = rootExtension.publication.centralPublications
+        val enforce = rootExtension.publication.enforceCentralPublications
+
+        val verifyTask =
+            project.tasks.register(TASK_NAME) { task ->
+                task.group = "verification"
+                task.description =
+                    "Fails if the set of publications reaching Maven Central drifts from the declared set"
+
+                // Off unless the repository opted in: register the task so it can be invoked and
+                // wired, but stay inert. `declared.isPresent` cannot serve here — Gradle gives
+                // collection properties an empty-collection convention, so it is true even when
+                // nothing was declared, and an empty set is a legitimate declaration in its own right.
+                task.onlyIf { enforce.get() }
+
+                task.doLast {
+                    val expected = declared.get()
+                    val actual = actualPublications(project)
+                    if (actual != expected) {
+                        throw GradleException(
+                            buildString {
+                                appendLine("Maven Central publication set drifted.")
+                                appendLine("  declared:   ${expected.sorted()}")
+                                appendLine("  publishing: ${actual.sorted()}")
+                                append(
+                                    "Update octopusQuality { publication { centralPublications } } " +
+                                        "only if the change is intentional. A coordinate that is not " +
+                                        "declared here is also not covered by the release-time " +
+                                        "fat-jar-publication-allowlist, so it would either fail the " +
+                                        "release or reach Central unnoticed.",
+                                )
+                            },
+                        )
+                    }
+                }
+            }
+
+        // `check` — the gate a pull request actually runs. Matched lazily so plugin application
+        // order does not matter, and on every project because `check` is per-project.
+        project.allprojects.forEach { candidate ->
+            candidate.tasks.matching { it.name == "check" }.configureEach {
+                it.dependsOn(verifyTask)
+            }
+        }
+
+        // The publish path, so a direct `./gradlew publish…` cannot bypass the policy. The task
+        // TYPE is hooked as well as the aggregate names: matching names alone leaves every
+        // concrete `publish<Pub>PublicationTo<Repo>Repository` task unguarded.
+        project.gradle.projectsEvaluated {
+            project.allprojects.forEach { candidate ->
+                candidate.tasks.withType(AbstractPublishToMaven::class.java).configureEach {
+                    it.dependsOn(verifyTask)
+                }
+                candidate.tasks
+                    .matching { it.name in AGGREGATE_PUBLISH_TASKS }
+                    .configureEach { it.dependsOn(verifyTask) }
+            }
+        }
+    }
+
+    private fun actualPublications(root: Project): Set<String> =
+        root.allprojects
+            .filter { it.plugins.hasPlugin("maven-publish") }
+            .flatMap { proj ->
+                proj.extensions
+                    .getByType(PublishingExtension::class.java)
+                    .publications
+                    .withType(MavenPublication::class.java)
+                    .map { pub -> identity(proj, pub) }
+            }.toSet()
+
+    private fun identity(
+        project: Project,
+        publication: MavenPublication,
+    ): String {
+        val signatures =
+            publication.artifacts
+                .map { artifact -> listOfNotNull(artifact.extension, artifact.classifier).joinToString(":") }
+                .sorted()
+        return "${project.path}|${publication.name}|${publication.groupId}:${publication.artifactId}|$signatures"
+    }
+}

--- a/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/CentralPublicationPolicy.kt
+++ b/gradle-quality-plugin/src/main/kotlin/org/octopusden/octopus/quality/internal/CentralPublicationPolicy.kt
@@ -8,8 +8,16 @@ import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven
 import org.octopusden.octopus.quality.OctopusQualityExtension
 
 /**
- * Registers `verifyCentralPublicationPolicy`, which fails when the set of publications a build
- * would send to Maven Central differs from the set the repository declared.
+ * Registers `verifyCentralPublicationPolicy`, which fails when the set of Maven publications a
+ * build DECLARES differs from the set the repository declared it should have.
+ *
+ * Scope, stated precisely because the task name is broader than its knowledge: it enumerates every
+ * `MavenPublication` in every project applying `maven-publish`. It does not inspect publishing
+ * repositories, task enablement or predicates, so it cannot tell a Central-bound publication from
+ * one aimed only at an internal repository, and it counts a publication that no repository would
+ * receive at all. Deciding what may actually reach Central is the release pipeline's job, through
+ * `fat-jar-publication-allowlist`. This task's purpose is narrower and complementary: keep the
+ * declared set from drifting unnoticed.
  *
  * [PublicationValidator] already checks that each publication is *well formed* — POM metadata,
  * sources and javadoc. This checks something different and complementary: that the *set itself*
@@ -79,7 +87,7 @@ internal object CentralPublicationPolicy {
             project.tasks.register(TASK_NAME) { task ->
                 task.group = "verification"
                 task.description =
-                    "Fails if the set of publications reaching Maven Central drifts from the declared set"
+                    "Fails if the set of Maven publications this build declares drifts from the declared set"
 
                 // Off unless the repository opted in: register the task so it can be invoked and
                 // wired, but stay inert. `declared.isPresent` cannot serve here — Gradle gives
@@ -98,10 +106,11 @@ internal object CentralPublicationPolicy {
                                 appendLine("  publishing: ${actual.sorted()}")
                                 append(
                                     "Update octopusQuality { publication { centralPublications } } " +
-                                        "only if the change is intentional. A coordinate that is not " +
-                                        "declared here is also not covered by the release-time " +
-                                        "fat-jar-publication-allowlist, so it would either fail the " +
-                                        "release or reach Central unnoticed.",
+                                        "only if the change is intentional. This compares DECLARED " +
+                                        "publications and does not inspect publishing repositories, " +
+                                        "so a publication aimed elsewhere appears here too. Whether a " +
+                                        "coordinate may reach Maven Central is enforced separately by " +
+                                        "the release pipeline's fat-jar-publication-allowlist.",
                                 )
                             },
                         )

--- a/gradle-quality-plugin/src/test/kotlin/org/octopusden/octopus/quality/OctopusQualityPluginFunctionalTest.kt
+++ b/gradle-quality-plugin/src/test/kotlin/org/octopusden/octopus/quality/OctopusQualityPluginFunctionalTest.kt
@@ -475,6 +475,153 @@ class OctopusQualityPluginFunctionalTest {
     }
 
     // ---------------------------------------------------------------
+    // 5b. Central publication policy — the SET, not each publication
+    // ---------------------------------------------------------------
+
+    /** Shared preamble: one well-formed publication, so validatePublications is happy. */
+    private fun publishingProject(policy: String) =
+        """
+        plugins {
+            kotlin("jvm") version "1.9.25"
+            `maven-publish`
+            id("org.octopusden.octopus-quality")
+        }
+        repositories { mavenCentral() }
+        group = "org.example"
+        version = "1.0.0"
+        java { withSourcesJar(); withJavadocJar() }
+        publishing {
+            publications {
+                create<MavenPublication>("mavenJava") {
+                    from(components["java"])
+                    pom {
+                        name.set("example")
+                        description.set("example")
+                        url.set("https://example.org")
+                        licenses { license { name.set("Apache-2.0"); url.set("https://example.org/l") } }
+                        scm { url.set("https://example.org") }
+                        developers { developer { id.set("dev"); name.set("dev") } }
+                    }
+                }
+            }
+        }
+        $policy
+        """.trimIndent() + "\n"
+
+    /**
+     * The regression test for the defect this task was written to prevent, and then reproduced:
+     * being a dependency of the publish tasks is useless on a pull request, because no PR check
+     * runs those. If this assertion ever fails, drift can be merged unnoticed again.
+     */
+    @Test
+    fun `verifyCentralPublicationPolicy is scheduled by check`() {
+        settingsFile(kotlinSettings("test-policy-in-check"))
+        buildFile(
+            publishingProject(
+                """
+                octopusQuality { publication { enforceCentralPublications.set(true); centralPublications.set(setOf("whatever")) } }
+                """.trimIndent(),
+            ),
+        )
+        writeKotlinFile("src/main/kotlin/com/example/App.kt", "package com.example\nfun main() = Unit\n")
+
+        val result = runner("check", "--dry-run").build()
+        assertTrue(
+            result.output.contains(":verifyCentralPublicationPolicy"),
+            "check must schedule the policy task; it is the only gate a pull request runs",
+        )
+    }
+
+    @Test
+    fun `verifyCentralPublicationPolicy does nothing when the set is not declared`() {
+        settingsFile(kotlinSettings("test-policy-unset"))
+        buildFile(publishingProject(""))
+        writeKotlinFile("src/main/kotlin/com/example/App.kt", "package com.example\nfun main() = Unit\n")
+
+        // A publication exists and nothing is declared: the task must stay inert rather than
+        // failing every consumer that has not opted in.
+        val result = runner("verifyCentralPublicationPolicy").build()
+        assertTrue(result.output.contains("BUILD SUCCESSFUL"))
+    }
+
+    @Test
+    fun `verifyCentralPublicationPolicy fails when a publication is not declared`() {
+        settingsFile(kotlinSettings("test-policy-drift"))
+        buildFile(
+            publishingProject(
+                """
+                octopusQuality { publication { enforceCentralPublications.set(true); centralPublications.set(emptySet<String>()) } }
+                """.trimIndent(),
+            ),
+        )
+        writeKotlinFile("src/main/kotlin/com/example/App.kt", "package com.example\nfun main() = Unit\n")
+
+        val result = runner("verifyCentralPublicationPolicy").buildAndFail()
+        val output = result.output.replace(ansiEscape, "")
+        assertTrue(output.contains("publication set drifted"), output)
+        // The message must print the actual set, so the fix is a copy-paste rather than a guess.
+        assertTrue(output.contains(":|mavenJava|org.example:test-policy-drift"), output)
+    }
+
+    @Test
+    fun `verifyCentralPublicationPolicy passes when the declared set matches`() {
+        settingsFile(kotlinSettings("test-policy-match"))
+        buildFile(
+            publishingProject(
+                """
+                octopusQuality {
+                    publication {
+                        enforceCentralPublications.set(true)
+                        centralPublications.set(
+                            setOf(
+                                ":|mavenJava|org.example:test-policy-match|[jar, jar:javadoc, jar:sources]",
+                            ),
+                        )
+                    }
+                }
+                """.trimIndent(),
+            ),
+        )
+        writeKotlinFile("src/main/kotlin/com/example/App.kt", "package com.example\nfun main() = Unit\n")
+
+        val result = runner("verifyCentralPublicationPolicy").build()
+        assertTrue(result.output.contains("BUILD SUCCESSFUL"))
+    }
+
+    /**
+     * The artifact signatures are part of the identity precisely so this case is caught: the
+     * coordinate and the publication name are unchanged, only an extra classifier appears.
+     */
+    @Test
+    fun `verifyCentralPublicationPolicy detects an added classifier`() {
+        settingsFile(kotlinSettings("test-policy-classifier"))
+        buildFile(
+            publishingProject(
+                """
+                val extraJar by tasks.registering(Jar::class) { archiveClassifier.set("extra") }
+                publishing.publications.named<MavenPublication>("mavenJava") { artifact(extraJar) }
+                octopusQuality {
+                    publication {
+                        enforceCentralPublications.set(true)
+                        centralPublications.set(
+                            setOf(
+                                ":|mavenJava|org.example:test-policy-classifier|[jar, jar:javadoc, jar:sources]",
+                            ),
+                        )
+                    }
+                }
+                """.trimIndent(),
+            ),
+        )
+        writeKotlinFile("src/main/kotlin/com/example/App.kt", "package com.example\nfun main() = Unit\n")
+
+        val result = runner("verifyCentralPublicationPolicy").buildAndFail()
+        val output = result.output.replace(ansiEscape, "")
+        assertTrue(output.contains("publication set drifted"), output)
+        assertTrue(output.contains("jar:extra"), output)
+    }
+
+    // ---------------------------------------------------------------
     // 6. Publication validator: valid jar publication passes
     // ---------------------------------------------------------------
     @Test


### PR DESCRIPTION
## What

Adds `verifyCentralPublicationPolicy` to the quality convention plugin: a check that fails when the set of publications a build would send to Maven Central differs from the set the repository declared.

Part of the organisation's Maven Central limits work (#163).

## Why in the plugin rather than in each repository

Twelve repositories in the current cleanup grew this guard **by hand**, and the copies drifted:

- one identified publications by **project path**, which is constant in a single-module build — a second publication added to the root changed nothing;
- another missed a **classifier added to an existing publication**, because the key stopped at the coordinate;
- and **every one of them** was wired only to the publish tasks. No pull-request check runs those, so `./gradlew check --dry-run` scheduled the task zero times: drift could be merged and would surface at the next release rather than in review.

That last one is the argument for this PR. In a convention plugin the wiring cannot be forgotten.

## How it differs from `validatePublications`

Deliberately registered next to it, because they answer different questions:

| | judges |
|---|---|
| `validatePublications` | is each publication **well formed** — POM metadata, sources, javadoc |
| `verifyCentralPublicationPolicy` | has the **set** changed |

A perfectly well-formed new coordinate passes the first and is caught by the second.

One correction to an earlier version of this text: it claimed the tests here show `validatePublications` failing first. They do not — the drift tests invoke `verifyCentralPublicationPolicy` directly, so the validator is not in that task graph. The ordering was observed in a consumer repository while verifying the same guard by hand, not in this suite.

## What it knows, and what it does not

It enumerates every `MavenPublication` in every `maven-publish` project. It does **not** inspect publishing repositories, task enablement or predicates — so it cannot tell a Central-bound publication from one aimed at an internal repository, and it counts a publication that no repository would receive. The functional fixtures are exactly that shape: they declare a publication and no publishing repository.

Deciding what may actually reach Central stays with the release pipeline's `fat-jar-publication-allowlist`. This task's job is narrower and complementary: keep the declared set from drifting unnoticed. The KDoc, task description and failure message now say that rather than claiming Central-specific knowledge.

## The identity is a composite key, and each part earned its place

```
projectPath|publicationName|groupId:artifactId|[sorted extension:classifier]
```

- **path alone** cannot tell two publications in the same project apart, and is `":"` forever in a single-module build;
- **without the coordinate**, an overridden `artifactId` goes unnoticed — and the marker that `java-gradle-plugin` publishes sits under a *different* group from the project's own;
- **without the artifact signatures**, attaching a classifier to an existing publication changes nothing. That matters most where the release-time `fat-jar-publication-allowlist` exempts an artifactId wholesale: a second oversized artifact under an exempted coordinate would otherwise pass every check.

The **version is excluded** on purpose, since every release changes it. Tested: a build with `-Pversion=...` still passes.

## Opt-in, and why the switch is separate from the set

```kotlin
octopusQuality {
    publication {
        enforceCentralPublications.set(true)
        centralPublications.set(setOf(":client|maven|org.example:client|[jar, jar:javadoc, jar:sources]"))
    }
}
```

Off by default, so the *check* never starts enforcing on a repository that has not asked for it.

That is narrower than "bumping cannot fail a repository", and the difference matters: the twelve repositories that already define a task with this name **will** fail at configuration time when they bump, flag or no flag — `Cannot add task 'verifyCentralPublicationPolicy' as a task with that name already exists`. The failure is loud and points at the consumer's own script, and the migration order below covers it, but it is a real cost of this PR rather than a case the default protects.

The switch is **not** inferred from the set being non-empty, because an **empty set is a legitimate declaration** — "this repository must publish nothing", which is exactly what a deployable wants to state. Gradle gives collection properties an empty-collection convention, so an unset property and a deliberately empty one cannot be distinguished.

Worth recording: the first version *did* infer intent from `isPresent`, which meant it enforced "publish nothing" on every consumer. The functional tests caught it here — two of them failed, including a pre-existing `validatePublications` test — rather than after a release.

## Getting the values

Set `enforceCentralPublications` to `true` with an empty set and run the task once. The failure prints the actual set, which can be pasted back:

```
> Maven Central publication set drifted.
    declared:   []
    publishing: [:|mavenJava|org.example:demo|[jar, jar:javadoc, jar:sources]]
```

## Tests

Five functional tests. One of them is a regression test for the defect above:

```kotlin
fun `verifyCentralPublicationPolicy is scheduled by check`()
```

If that assertion ever fails, drift can be merged unnoticed again. The others cover: inert when not enabled, passing on a matching set, failing on an undeclared publication with the actual set printed, and detecting an added classifier.

## Coverage

The new class joins the Kover exclusion list already documented in `build.gradle.kts` — Gradle-lifecycle code runs in a GradleRunner subprocess that the coverage agent cannot instrument.

Checked that this is the repository's established convention rather than a workaround invented to pass the gate: `PublicationValidator`, `TaskRegistrar`, `SubprojectConfigurer` and `HollowGateGuard` are all excluded for the same stated reason, and `koverVerify` passes on `origin/main`. Also dropped a stale "the 11 GradleRunner functional tests" count from that comment, since the suite is larger now.

## Verified

`./gradlew clean build` green from scratch — tests executed, `koverVerify` passed. Both ktlint findings this change introduced (import order, script indentation) are fixed rather than baselined.

**What that green does not cover**, so it is not read as more than it is: the suite runs on Gradle 8.9 only, and proves nothing about the configuration cache, the task-name collision above, multi-project isolation, or a Gradle 9.x consumer. The configuration-cache gap is real and now tracked in #192 — it affects the already-released `validatePublications` in the same way, so this PR adds an instance rather than a category, and no repository in the organisation currently enables the cache.

## Follow-up, not in this PR

Consumers keep their hand-written guards until they bump to the release that carries this. The order is: release, then bump per repository, then delete the local copy and move the allowlist into `octopusQuality { }`. Switching the version alone is not enough — leaving both in place would register two tasks with the same name.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional validation of Maven Central publications across multi-project builds.
  * Builds can declare expected publications and enable enforcement.
  * Validation detects missing, unexpected, or mismatched publication artifacts.

* **Bug Fixes**
  * Publication consistency checks now run with standard verification and publishing tasks when enabled.

* **Tests**
  * Added coverage for disabled enforcement, publication mismatches, classifier changes, and successful validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->