### PR TITLE
fix(release): wait for the tag to be readable before creating the release

### DIFF
--- a/.github/scripts/test-wait-for-tag-ref.local.sh
+++ b/.github/scripts/test-wait-for-tag-ref.local.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Local runner for the same cases the CI workflow asserts. Uses a stub `gh` on PATH so no
+# network and no real repository are involved; the stub decides how many lookups fail first.
+set -uo pipefail
+S="$PWD/.github/scripts/wait-for-tag-ref.sh"
+stub_dir=$(mktemp -d); trap 'rm -rf "$stub_dir"' EXIT
+cat > "$stub_dir/gh" <<'STUB'
+#!/usr/bin/env bash
+# Fails FAIL_TIMES times, then succeeds. Counts attempts in a file so state survives calls.
+n=$(( $(cat "$COUNTER" 2>/dev/null || echo 0) + 1 )); echo "$n" > "$COUNTER"
+[ "$n" -le "${FAIL_TIMES:-0}" ] && { echo "gh: HTTP 404" >&2; exit 1; }
+echo '{"ref":"refs/tags/v1.2.3"}'
+STUB
+chmod +x "$stub_dir/gh"; export PATH="$stub_dir:$PATH"
+export WAIT_ATTEMPTS=5 WAIT_INTERVAL=0
+
+pass=0; fail=0
+check() { # name expected_rc actual_rc
+  if [ "$2" = "$3" ]; then echo "  ok   $1"; pass=$((pass+1));
+  else echo "  FAIL $1 — expected rc=$2, got rc=$3"; fail=$((fail+1)); fi
+}
+run() { COUNTER=$(mktemp) FAIL_TIMES=$1 bash "$S" octopusden/x v1.2.3 >/dev/null 2>&1; echo $?; }
+
+echo "case: visible immediately";        check "rc 0" 0 "$(run 0)"
+echo "case: visible on 3rd attempt";     check "rc 0" 0 "$(run 2)"
+echo "case: never visible within budget";check "rc 1" 1 "$(run 99)"
+echo "--- passed=$pass failed=$fail"
+[ "$fail" -eq 0 ]

--- a/.github/scripts/test-wait-for-tag-ref.local.sh
+++ b/.github/scripts/test-wait-for-tag-ref.local.sh
@@ -22,6 +22,15 @@ printf '%s\n' "$@" | grep -q 'ref(qualifiedName:' || {
 printf '%s\n' "$@" | grep -qx "tagName=refs/tags/${EXPECT_TAG}" || {
     echo "stub: tagName is not refs/tags/${EXPECT_TAG}: $*" >&2; exit 1
 }
+# ...and about the right repository. Querying the wrong owner/name returns repository:null, which
+# `// empty` turns into "not visible" — so it fails closed rather than releasing wrongly, but it
+# fails closed on EVERY release. Asserting the values is what makes swapping them detectable.
+printf '%s\n' "$@" | grep -qx "owner=${EXPECT_OWNER}" || {
+    echo "stub: owner is not ${EXPECT_OWNER}: $*" >&2; exit 1
+}
+printf '%s\n' "$@" | grep -qx "name=${EXPECT_NAME}" || {
+    echo "stub: name is not ${EXPECT_NAME}: $*" >&2; exit 1
+}
 # Emit a realistic response and apply the caller's own --jq filter to it, rather than emitting
 # what a correct filter would have produced. Otherwise the filter is never under test: an
 # absent tag yields the JSON below, and it is the filter's job to turn that into nothing.
@@ -41,7 +50,7 @@ fi
 if [ -n "$filter" ]; then printf '%s' "$body" | jq -r "$filter"; else printf '%s' "$body"; fi
 STUB
 chmod +x "$stub_dir/gh"; export PATH="$stub_dir:$PATH"
-export WAIT_ATTEMPTS=5 WAIT_INTERVAL=0 EXPECT_TAG=v1.2.3
+export WAIT_ATTEMPTS=5 WAIT_INTERVAL=0 EXPECT_TAG=v1.2.3 EXPECT_OWNER=octopusden EXPECT_NAME=x
 
 pass=0; fail=0
 check() { # name expected_rc actual_rc
@@ -55,5 +64,16 @@ echo "case: visible on 3rd attempt";      check "rc 0" 0 "$(run 2)"
 echo "case: never visible within budget"; check "rc 1" 1 "$(run 99)"
 echo "case: empty ref is not visible";    check "rc 1" 1 "$(FAIL_MODE=null run 99)"
 echo "case: empty ref then visible";      check "rc 0" 0 "$(FAIL_MODE=null run 2)"
+
+# The wait must actually WAIT. With the sleep removed, ten attempts finish in milliseconds and the
+# retry cannot outlast any real propagation gap — while every case above still passes, because they
+# run with WAIT_INTERVAL=0 and so carry no timing signal at all.
+start=$SECONDS
+COUNTER=$(mktemp) FAIL_TIMES=2 WAIT_INTERVAL=1 bash "$S" octopusden/x v1.2.3 >/dev/null 2>&1
+elapsed=$((SECONDS - start))
+echo "case: honours the interval between attempts"
+if [ "$elapsed" -ge 2 ]; then echo "  ok   waited ${elapsed}s for 2 failed attempts"; pass=$((pass+1))
+else echo "  FAIL waited only ${elapsed}s — expected >=2s"; fail=$((fail+1)); fi
+
 echo "--- passed=$pass failed=$fail"
 [ "$fail" -eq 0 ]

--- a/.github/scripts/test-wait-for-tag-ref.local.sh
+++ b/.github/scripts/test-wait-for-tag-ref.local.sh
@@ -6,10 +6,24 @@ S="$PWD/.github/scripts/wait-for-tag-ref.sh"
 stub_dir=$(mktemp -d); trap 'rm -rf "$stub_dir"' EXIT
 cat > "$stub_dir/gh" <<'STUB'
 #!/usr/bin/env bash
-# Fails FAIL_TIMES times, then succeeds. Counts attempts in a file so state survives calls.
+# Stands in for `gh`. Accepts ONLY the lookup that `gh release create --verify-tag` itself
+# performs — the GraphQL repository.ref(qualifiedName:) query (cli/cli pkg/cmd/release/create/
+# http.go, remoteTagExists). Any other lookup, the REST ref endpoint included, is rejected on
+# every attempt: REST can answer while GraphQL is still stale, so polling it proves nothing.
+if [ "${1:-}" != "api" ] || [ "${2:-}" != "graphql" ] || ! printf '%s\n' "$@" | grep -q 'ref(qualifiedName:'; then
+    echo "stub: refusing non-GraphQL lookup: $*" >&2; exit 1
+fi
 n=$(( $(cat "$COUNTER" 2>/dev/null || echo 0) + 1 )); echo "$n" > "$COUNTER"
-[ "$n" -le "${FAIL_TIMES:-0}" ] && { echo "gh: HTTP 404" >&2; exit 1; }
-echo '{"ref":"refs/tags/v1.2.3"}'
+if [ "$n" -le "${FAIL_TIMES:-0}" ]; then
+    case "${FAIL_MODE:-error}" in
+        # GraphQL reports an absent tag as a SUCCESSFUL response carrying a null ref, so a
+        # script that trusts the exit status alone declares victory while the tag is missing.
+        null) echo "" ;;
+        *)    echo "gh: HTTP 502" >&2; exit 1 ;;
+    esac
+    exit 0
+fi
+echo "REF_kwDOabcdef"
 STUB
 chmod +x "$stub_dir/gh"; export PATH="$stub_dir:$PATH"
 export WAIT_ATTEMPTS=5 WAIT_INTERVAL=0
@@ -21,8 +35,10 @@ check() { # name expected_rc actual_rc
 }
 run() { COUNTER=$(mktemp) FAIL_TIMES=$1 bash "$S" octopusden/x v1.2.3 >/dev/null 2>&1; echo $?; }
 
-echo "case: visible immediately";        check "rc 0" 0 "$(run 0)"
-echo "case: visible on 3rd attempt";     check "rc 0" 0 "$(run 2)"
-echo "case: never visible within budget";check "rc 1" 1 "$(run 99)"
+echo "case: visible immediately";         check "rc 0" 0 "$(run 0)"
+echo "case: visible on 3rd attempt";      check "rc 0" 0 "$(run 2)"
+echo "case: never visible within budget"; check "rc 1" 1 "$(run 99)"
+echo "case: empty ref is not visible";    check "rc 1" 1 "$(FAIL_MODE=null run 99)"
+echo "case: empty ref then visible";      check "rc 0" 0 "$(FAIL_MODE=null run 2)"
 echo "--- passed=$pass failed=$fail"
 [ "$fail" -eq 0 ]

--- a/.github/scripts/test-wait-for-tag-ref.local.sh
+++ b/.github/scripts/test-wait-for-tag-ref.local.sh
@@ -10,23 +10,38 @@ cat > "$stub_dir/gh" <<'STUB'
 # performs — the GraphQL repository.ref(qualifiedName:) query (cli/cli pkg/cmd/release/create/
 # http.go, remoteTagExists). Any other lookup, the REST ref endpoint included, is rejected on
 # every attempt: REST can answer while GraphQL is still stale, so polling it proves nothing.
-if [ "${1:-}" != "api" ] || [ "${2:-}" != "graphql" ] || ! printf '%s\n' "$@" | grep -q 'ref(qualifiedName:'; then
+[ "${1:-}" = "api" ] && [ "${2:-}" = "graphql" ] || {
     echo "stub: refusing non-GraphQL lookup: $*" >&2; exit 1
-fi
+}
+printf '%s\n' "$@" | grep -q 'ref(qualifiedName:' || {
+    echo "stub: query does not resolve a ref: $*" >&2; exit 1
+}
+# The tag must be asked for as a FULLY QUALIFIED ref. GraphQL matches qualifiedName literally,
+# so "v1.2.3" instead of "refs/tags/v1.2.3" would never resolve — and without this assertion a
+# script that dropped the prefix would pass every case here while never working in production.
+printf '%s\n' "$@" | grep -qx "tagName=refs/tags/${EXPECT_TAG}" || {
+    echo "stub: tagName is not refs/tags/${EXPECT_TAG}: $*" >&2; exit 1
+}
+# Emit a realistic response and apply the caller's own --jq filter to it, rather than emitting
+# what a correct filter would have produced. Otherwise the filter is never under test: an
+# absent tag yields the JSON below, and it is the filter's job to turn that into nothing.
+filter=""; prev=""
+for a in "$@"; do [ "$prev" = "--jq" ] && filter="$a"; prev="$a"; done
 n=$(( $(cat "$COUNTER" 2>/dev/null || echo 0) + 1 )); echo "$n" > "$COUNTER"
 if [ "$n" -le "${FAIL_TIMES:-0}" ]; then
     case "${FAIL_MODE:-error}" in
-        # GraphQL reports an absent tag as a SUCCESSFUL response carrying a null ref, so a
-        # script that trusts the exit status alone declares victory while the tag is missing.
-        null) echo "" ;;
+        # GraphQL reports an absent tag as a SUCCESSFUL response carrying a null ref, so the
+        # exit status says nothing about whether the tag is there.
+        null) body='{"data":{"repository":{"ref":null}}}' ;;
         *)    echo "gh: HTTP 502" >&2; exit 1 ;;
     esac
-    exit 0
+else
+    body='{"data":{"repository":{"ref":{"id":"REF_kwDOabcdef"}}}}'
 fi
-echo "REF_kwDOabcdef"
+if [ -n "$filter" ]; then printf '%s' "$body" | jq -r "$filter"; else printf '%s' "$body"; fi
 STUB
 chmod +x "$stub_dir/gh"; export PATH="$stub_dir:$PATH"
-export WAIT_ATTEMPTS=5 WAIT_INTERVAL=0
+export WAIT_ATTEMPTS=5 WAIT_INTERVAL=0 EXPECT_TAG=v1.2.3
 
 pass=0; fail=0
 check() { # name expected_rc actual_rc

--- a/.github/scripts/wait-for-tag-ref.sh
+++ b/.github/scripts/wait-for-tag-ref.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Wait until a freshly created tag ref is READABLE, then exit 0.
+#
+# Why this exists as its own script rather than inline in the release workflow: it is the one
+# piece of that step with a failure mode worth testing, and a 900-line reusable workflow cannot
+# be invoked from a test. See .github/workflows/test-wait-for-tag-ref.yml.
+#
+# The problem it solves, observed on octopus-api-gateway 2.0.19: `gh api .../git/refs` created
+# the tag and returned success, and the very next command — `gh release create --verify-tag` —
+# reported `tag v2.0.19 doesn't exist`. The tag was there afterwards, at the built commit. That
+# command performs its OWN lookup, and the read missed a ref committed milliseconds earlier.
+# Losing that race leaves a half-release: artifacts already published, tag created, no release.
+#
+# Usage: wait-for-tag-ref.sh <owner/repo> <tag>
+# Env:   WAIT_ATTEMPTS (default 10), WAIT_INTERVAL seconds (default 2)
+#
+# Deliberately NOT `set -e`: the lookup is expected to fail on early attempts, and the whole
+# point is to keep going. Failure is reported by exit status, once, at the end.
+set -uo pipefail
+
+repo=${1:?usage: wait-for-tag-ref.sh <owner/repo> <tag>}
+tag=${2:?usage: wait-for-tag-ref.sh <owner/repo> <tag>}
+attempts=${WAIT_ATTEMPTS:-10}
+interval=${WAIT_INTERVAL:-2}
+
+i=0
+while [ "$i" -lt "$attempts" ]; do
+    i=$((i + 1))
+    if gh api "repos/${repo}/git/ref/tags/${tag}" >/dev/null 2>&1; then
+        [ "$i" -gt 1 ] && echo "Tag ${tag} became readable on attempt ${i}."
+        exit 0
+    fi
+    [ "$i" -lt "$attempts" ] && sleep "$interval"
+done
+
+echo "::error title=Tag not readable after creation::Created ${tag} but it was still not readable after ${attempts} attempts. The artifacts for this version are already published, so do NOT re-dispatch the release — that would try to publish a version that already exists. Use GitHub's 're-run failed jobs' on this run once the ref is visible: that repeats only this job, which adopts the existing tag and attaches the release." >&2
+exit 1

--- a/.github/scripts/wait-for-tag-ref.sh
+++ b/.github/scripts/wait-for-tag-ref.sh
@@ -12,6 +12,11 @@
 # command performs its OWN lookup, and the read missed a ref committed milliseconds earlier.
 # Losing that race leaves a half-release: artifacts already published, tag created, no release.
 #
+# It waits on the EXACT lookup that command performs: remoteTagExists in cli/cli
+# pkg/cmd/release/create/http.go queries GraphQL `repository.ref(qualifiedName:)`. Polling the
+# REST ref endpoint instead would prove nothing — the two are separate read paths, and REST can
+# answer while GraphQL is still stale, which is the staleness that actually breaks the release.
+#
 # Usage: wait-for-tag-ref.sh <owner/repo> <tag>
 # Env:   WAIT_ATTEMPTS (default 10), WAIT_INTERVAL seconds (default 2)
 #
@@ -23,11 +28,30 @@ repo=${1:?usage: wait-for-tag-ref.sh <owner/repo> <tag>}
 tag=${2:?usage: wait-for-tag-ref.sh <owner/repo> <tag>}
 attempts=${WAIT_ATTEMPTS:-10}
 interval=${WAIT_INTERVAL:-2}
+owner=${repo%%/*}
+name=${repo##*/}
+
+read -r -d '' query <<'GQL'
+query($owner: String!, $name: String!, $tagName: String!) {
+  repository(owner: $owner, name: $name) {
+    ref(qualifiedName: $tagName) { id }
+  }
+}
+GQL
 
 i=0
 while [ "$i" -lt "$attempts" ]; do
     i=$((i + 1))
-    if gh api "repos/${repo}/git/ref/tags/${tag}" >/dev/null 2>&1; then
+    # An absent tag is NOT an error here: GraphQL answers 200 with a null ref, so the exit
+    # status says nothing. `// empty` makes that case print nothing, and emptiness — not the
+    # status — is what decides, exactly as gh's own `Ref.ID != ""` does.
+    ref_id=$(gh api graphql \
+        -f query="${query}" \
+        -f owner="${owner}" \
+        -f name="${name}" \
+        -f tagName="refs/tags/${tag}" \
+        --jq '.data.repository.ref.id // empty' 2>/dev/null)
+    if [ -n "${ref_id}" ]; then
         [ "$i" -gt 1 ] && echo "Tag ${tag} became readable on attempt ${i}."
         exit 0
     fi

--- a/.github/workflows/common-java-gradle-release.yml
+++ b/.github/workflows/common-java-gradle-release.yml
@@ -864,6 +864,30 @@ jobs:
             echo "::error title=Tag creation refused::Could not create ${TAG} at ${built_sha}. An HTTP 404 here means GitHub refused the ref update because the commit carries a workflow file that now matches no branch head — the pre-build check passed, so a branch moved while this release was building. The artifacts for this version are already published and cannot be published again, so do NOT re-dispatch the release. Recovery: create ${TAG} manually on ${built_sha} with a credential authorized to modify workflows, then use GitHub's 're-run failed jobs' on this run — that repeats only this job, which will adopt the tag and attach the release, and leaves the publish untouched." >&2
             exit 1
           fi
+          # Wait for the ref to become readable before creating the release. The create
+          # above returned success, so the tag exists — but `gh release create --verify-tag`
+          # performs its OWN lookup, and that read can miss a ref committed milliseconds
+          # earlier. Observed on octopus-api-gateway 2.0.19: the ref was created at the built
+          # commit, the very next command reported "tag v2.0.19 doesn't exist", and the tag was
+          # there afterwards. Cost of losing that race is a half-release — artifacts published,
+          # tag created, no release and no registration — recoverable only by re-running.
+          #
+          # `--verify-tag` is deliberately KEPT rather than dropped as redundant: without it,
+          # `gh release create` on a tag it cannot see would create the tag ITSELF at the
+          # default branch head, which is the stale-code release this whole step exists to
+          # prevent. So the fix is to make the read succeed, not to stop checking.
+          tag_visible=0
+          for _ in 1 2 3 4 5 6 7 8 9 10; do
+            if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}" >/dev/null 2>&1; then
+              tag_visible=1
+              break
+            fi
+            sleep 2
+          done
+          if [ "$tag_visible" -ne 1 ]; then
+            echo "::error title=Tag not readable after creation::Created ${TAG} at ${built_sha}, but it was still not readable after 10 attempts over ~20s. The artifacts for this version are already published, so do NOT re-dispatch the release. Use GitHub's 're-run failed jobs' on this run once the ref is visible — that repeats only this job, adopts the tag and attaches the release." >&2
+            exit 1
+          fi
           gh release create "$TAG" --verify-tag --title "$TAG" --generate-notes
           echo "Created tag and release $TAG at $built_sha"
 

--- a/.github/workflows/common-java-gradle-release.yml
+++ b/.github/workflows/common-java-gradle-release.yml
@@ -859,6 +859,11 @@ jobs:
               exit 1
             fi
             # Tag is correct but has no release: adopt it instead of creating a second one.
+            # The same wait applies here. This path is reached from the REST lookup above, and
+            # --verify-tag resolves the tag through GraphQL, so "REST sees it" does not mean
+            # "the release command will". Usually warm on this path — the tag predates the run —
+            # but the failure shape is identical, so it is not left to luck.
+            bash .octopus-base-tagwait/.github/scripts/wait-for-tag-ref.sh "${GITHUB_REPOSITORY}" "${TAG}"
             gh release create "$TAG" --verify-tag --title "$TAG" --generate-notes
             echo "Created release $TAG on the existing, correct tag $built_sha"
             exit 0
@@ -901,15 +906,11 @@ jobs:
           # `gh release create` on a tag it cannot see would create the tag ITSELF at the
           # default branch head, which is the stale-code release this whole step exists to
           # prevent. So the fix is to make the read succeed, not to stop checking.
-          # The create above returned success, so the tag exists — but
-          # `gh release create --verify-tag` performs its OWN lookup, and that read can miss a
-          # ref committed milliseconds earlier. Waiting for it is extracted into a script so the
-          # retry can actually be tested; see .github/workflows/test-wait-for-tag-ref.yml.
           #
-          # `--verify-tag` is deliberately KEPT rather than dropped as redundant: without it,
-          # `gh release create` on a tag it cannot see would create the tag ITSELF at the default
-          # branch head, releasing whatever code sits there. So the read is made to succeed, not
-          # skipped.
+          # Extracted into a script so the retry is testable; see
+          # .github/workflows/test-wait-for-tag-ref.yml. It polls the GraphQL ref query that
+          # --verify-tag itself uses, NOT the REST endpoint above: the two are separate read
+          # paths and REST can answer while GraphQL is still stale.
           bash .octopus-base-tagwait/.github/scripts/wait-for-tag-ref.sh "${GITHUB_REPOSITORY}" "${TAG}"
           gh release create "$TAG" --verify-tag --title "$TAG" --generate-notes
           echo "Created tag and release $TAG at $built_sha"

--- a/.github/workflows/common-java-gradle-release.yml
+++ b/.github/workflows/common-java-gradle-release.yml
@@ -773,6 +773,31 @@ jobs:
       # is the default-branch head at dispatch time, frozen for the run, regardless of
       # what was checked out. A hybrid release of anything other than the current tip
       # therefore tagged code that was never built.
+      # This job otherwise has no checkout. The retry below is a script rather than an inline
+      # loop so it can be tested (see .github/workflows/test-wait-for-tag-ref.yml), and a script
+      # has to be fetched. Pinned to job.workflow_sha — the same commit as this workflow — so the
+      # helper can never drift from the logic that calls it. Same mechanism the publish helper
+      # already uses in the build job.
+      - name: Resolve tag-wait helper ref
+        id: tagwait-ref
+        env:
+          HELPER_SHA: ${{ job.workflow_sha }}
+        run: |
+          set -euo pipefail
+          if [[ ! "${HELPER_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error title=Cannot pin the tag-wait helper::job.workflow_sha resolved to '${HELPER_SHA}', which is not a full commit SHA." >&2
+            exit 1
+          fi
+          echo "sha=${HELPER_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch tag-wait helper
+        uses: actions/checkout@v4
+        with:
+          repository: octopusden/octopus-base
+          ref: ${{ steps.tagwait-ref.outputs.sha }}
+          path: .octopus-base-tagwait
+          sparse-checkout: .github/scripts
+
       - name: Create release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -876,18 +901,16 @@ jobs:
           # `gh release create` on a tag it cannot see would create the tag ITSELF at the
           # default branch head, which is the stale-code release this whole step exists to
           # prevent. So the fix is to make the read succeed, not to stop checking.
-          tag_visible=0
-          for _ in 1 2 3 4 5 6 7 8 9 10; do
-            if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}" >/dev/null 2>&1; then
-              tag_visible=1
-              break
-            fi
-            sleep 2
-          done
-          if [ "$tag_visible" -ne 1 ]; then
-            echo "::error title=Tag not readable after creation::Created ${TAG} at ${built_sha}, but it was still not readable after 10 attempts over ~20s. The artifacts for this version are already published, so do NOT re-dispatch the release. Use GitHub's 're-run failed jobs' on this run once the ref is visible — that repeats only this job, adopts the tag and attaches the release." >&2
-            exit 1
-          fi
+          # The create above returned success, so the tag exists — but
+          # `gh release create --verify-tag` performs its OWN lookup, and that read can miss a
+          # ref committed milliseconds earlier. Waiting for it is extracted into a script so the
+          # retry can actually be tested; see .github/workflows/test-wait-for-tag-ref.yml.
+          #
+          # `--verify-tag` is deliberately KEPT rather than dropped as redundant: without it,
+          # `gh release create` on a tag it cannot see would create the tag ITSELF at the default
+          # branch head, releasing whatever code sits there. So the read is made to succeed, not
+          # skipped.
+          bash .octopus-base-tagwait/.github/scripts/wait-for-tag-ref.sh "${GITHUB_REPOSITORY}" "${TAG}"
           gh release create "$TAG" --verify-tag --title "$TAG" --generate-notes
           echo "Created tag and release $TAG at $built_sha"
 

--- a/.github/workflows/common-java-maven-release.yml
+++ b/.github/workflows/common-java-maven-release.yml
@@ -546,6 +546,11 @@ jobs:
           # directly: doing that makes it draft, upload and publish as one step, where an
           # interrupted upload leaves a draft nothing ever finishes.
           create_release_with_asset() {
+            # Wait for the tag to be readable by the lookup --verify-tag performs before asking
+            # for the release. Inside the function so BOTH call sites are covered: the path that
+            # just created the ref, and the path that adopts a tag found by the REST lookup below
+            # — REST answering does not mean the GraphQL query --verify-tag uses will.
+            bash .octopus-base-tagwait/.github/scripts/wait-for-tag-ref.sh "${GITHUB_REPOSITORY}" "${TAG}"
             gh release create "$TAG" --verify-tag --draft --title "$TAG" --generate-notes
             attach_asset
             gh release edit "$TAG" --draft=false
@@ -655,16 +660,11 @@ jobs:
           # `gh release create` on a tag it cannot see would create the tag ITSELF at the
           # default branch head, which is the stale-code release this whole step exists to
           # prevent. So the fix is to make the read succeed, not to stop checking.
-          # The create above returned success, so the tag exists — but
-          # `gh release create --verify-tag` performs its OWN lookup, and that read can miss a
-          # ref committed milliseconds earlier. Waiting for it is extracted into a script so the
-          # retry can actually be tested; see .github/workflows/test-wait-for-tag-ref.yml.
           #
-          # `--verify-tag` is deliberately KEPT rather than dropped as redundant: without it,
-          # `gh release create` on a tag it cannot see would create the tag ITSELF at the default
-          # branch head, releasing whatever code sits there. So the read is made to succeed, not
-          # skipped.
-          bash .octopus-base-tagwait/.github/scripts/wait-for-tag-ref.sh "${GITHUB_REPOSITORY}" "${TAG}"
+          # Extracted into a script so the retry is testable; see
+          # .github/workflows/test-wait-for-tag-ref.yml. It polls the GraphQL ref query that
+          # --verify-tag itself uses, NOT a REST ref endpoint: the two are separate read paths
+          # and REST can answer while GraphQL is still stale.
           create_release_with_asset
           echo "Created tag and release $TAG at $built_sha"
       # Bind the release to the run that produced it. Registration happens afterwards

--- a/.github/workflows/common-java-maven-release.yml
+++ b/.github/workflows/common-java-maven-release.yml
@@ -438,6 +438,31 @@ jobs:
       # is the default-branch head at dispatch time, frozen for the run, regardless of
       # what was checked out. A hybrid release of anything other than the current tip
       # therefore tagged code that was never built.
+      # This job otherwise has no checkout. The retry below is a script rather than an inline
+      # loop so it can be tested (see .github/workflows/test-wait-for-tag-ref.yml), and a script
+      # has to be fetched. Pinned to job.workflow_sha — the same commit as this workflow — so the
+      # helper can never drift from the logic that calls it. Same mechanism the publish helper
+      # already uses in the build job.
+      - name: Resolve tag-wait helper ref
+        id: tagwait-ref
+        env:
+          HELPER_SHA: ${{ job.workflow_sha }}
+        run: |
+          set -euo pipefail
+          if [[ ! "${HELPER_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error title=Cannot pin the tag-wait helper::job.workflow_sha resolved to '${HELPER_SHA}', which is not a full commit SHA." >&2
+            exit 1
+          fi
+          echo "sha=${HELPER_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch tag-wait helper
+        uses: actions/checkout@v4
+        with:
+          repository: octopusden/octopus-base
+          ref: ${{ steps.tagwait-ref.outputs.sha }}
+          path: .octopus-base-tagwait
+          sparse-checkout: .github/scripts
+
       - name: Create release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -630,18 +655,16 @@ jobs:
           # `gh release create` on a tag it cannot see would create the tag ITSELF at the
           # default branch head, which is the stale-code release this whole step exists to
           # prevent. So the fix is to make the read succeed, not to stop checking.
-          tag_visible=0
-          for _ in 1 2 3 4 5 6 7 8 9 10; do
-            if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}" >/dev/null 2>&1; then
-              tag_visible=1
-              break
-            fi
-            sleep 2
-          done
-          if [ "$tag_visible" -ne 1 ]; then
-            echo "::error title=Tag not readable after creation::Created ${TAG} at ${built_sha}, but it was still not readable after 10 attempts over ~20s. The artifacts for this version are already published, so do NOT re-dispatch the release. Use GitHub's 're-run failed jobs' on this run once the ref is visible — that repeats only this job, adopts the tag and attaches the release." >&2
-            exit 1
-          fi
+          # The create above returned success, so the tag exists — but
+          # `gh release create --verify-tag` performs its OWN lookup, and that read can miss a
+          # ref committed milliseconds earlier. Waiting for it is extracted into a script so the
+          # retry can actually be tested; see .github/workflows/test-wait-for-tag-ref.yml.
+          #
+          # `--verify-tag` is deliberately KEPT rather than dropped as redundant: without it,
+          # `gh release create` on a tag it cannot see would create the tag ITSELF at the default
+          # branch head, releasing whatever code sits there. So the read is made to succeed, not
+          # skipped.
+          bash .octopus-base-tagwait/.github/scripts/wait-for-tag-ref.sh "${GITHUB_REPOSITORY}" "${TAG}"
           create_release_with_asset
           echo "Created tag and release $TAG at $built_sha"
       # Bind the release to the run that produced it. Registration happens afterwards

--- a/.github/workflows/common-java-maven-release.yml
+++ b/.github/workflows/common-java-maven-release.yml
@@ -618,6 +618,30 @@ jobs:
             echo "::error title=Tag creation refused::Could not create ${TAG} at ${built_sha}. An HTTP 404 here means GitHub refused the ref update because the commit carries a workflow file that now matches no branch head — the pre-build check passed, so a branch moved while this release was building. The artifacts for this version are already published and cannot be published again, so do NOT re-dispatch the release. Recovery: create ${TAG} manually on ${built_sha} with a credential authorized to modify workflows, then use GitHub's 're-run failed jobs' on this run — that repeats only this job, which will adopt the tag and attach the release, and leaves the publish untouched." >&2
             exit 1
           fi
+          # Wait for the ref to become readable before creating the release. The create
+          # above returned success, so the tag exists — but `gh release create --verify-tag`
+          # performs its OWN lookup, and that read can miss a ref committed milliseconds
+          # earlier. Observed on octopus-api-gateway 2.0.19: the ref was created at the built
+          # commit, the very next command reported "tag v2.0.19 doesn't exist", and the tag was
+          # there afterwards. Cost of losing that race is a half-release — artifacts published,
+          # tag created, no release and no registration — recoverable only by re-running.
+          #
+          # `--verify-tag` is deliberately KEPT rather than dropped as redundant: without it,
+          # `gh release create` on a tag it cannot see would create the tag ITSELF at the
+          # default branch head, which is the stale-code release this whole step exists to
+          # prevent. So the fix is to make the read succeed, not to stop checking.
+          tag_visible=0
+          for _ in 1 2 3 4 5 6 7 8 9 10; do
+            if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}" >/dev/null 2>&1; then
+              tag_visible=1
+              break
+            fi
+            sleep 2
+          done
+          if [ "$tag_visible" -ne 1 ]; then
+            echo "::error title=Tag not readable after creation::Created ${TAG} at ${built_sha}, but it was still not readable after 10 attempts over ~20s. The artifacts for this version are already published, so do NOT re-dispatch the release. Use GitHub's 're-run failed jobs' on this run once the ref is visible — that repeats only this job, adopts the tag and attaches the release." >&2
+            exit 1
+          fi
           create_release_with_asset
           echo "Created tag and release $TAG at $built_sha"
       # Bind the release to the run that produced it. Registration happens afterwards

--- a/.github/workflows/test-wait-for-tag-ref.yml
+++ b/.github/workflows/test-wait-for-tag-ref.yml
@@ -29,23 +29,38 @@ jobs:
           # performs — the GraphQL repository.ref(qualifiedName:) query (cli/cli pkg/cmd/release/create/
           # http.go, remoteTagExists). Any other lookup, the REST ref endpoint included, is rejected on
           # every attempt: REST can answer while GraphQL is still stale, so polling it proves nothing.
-          if [ "${1:-}" != "api" ] || [ "${2:-}" != "graphql" ] || ! printf '%s\n' "$@" | grep -q 'ref(qualifiedName:'; then
+          [ "${1:-}" = "api" ] && [ "${2:-}" = "graphql" ] || {
               echo "stub: refusing non-GraphQL lookup: $*" >&2; exit 1
-          fi
+          }
+          printf '%s\n' "$@" | grep -q 'ref(qualifiedName:' || {
+              echo "stub: query does not resolve a ref: $*" >&2; exit 1
+          }
+          # The tag must be asked for as a FULLY QUALIFIED ref. GraphQL matches qualifiedName literally,
+          # so "v1.2.3" instead of "refs/tags/v1.2.3" would never resolve — and without this assertion a
+          # script that dropped the prefix would pass every case here while never working in production.
+          printf '%s\n' "$@" | grep -qx "tagName=refs/tags/${EXPECT_TAG}" || {
+              echo "stub: tagName is not refs/tags/${EXPECT_TAG}: $*" >&2; exit 1
+          }
+          # Emit a realistic response and apply the caller's own --jq filter to it, rather than emitting
+          # what a correct filter would have produced. Otherwise the filter is never under test: an
+          # absent tag yields the JSON below, and it is the filter's job to turn that into nothing.
+          filter=""; prev=""
+          for a in "$@"; do [ "$prev" = "--jq" ] && filter="$a"; prev="$a"; done
           n=$(( $(cat "$COUNTER" 2>/dev/null || echo 0) + 1 )); echo "$n" > "$COUNTER"
           if [ "$n" -le "${FAIL_TIMES:-0}" ]; then
               case "${FAIL_MODE:-error}" in
-                  # GraphQL reports an absent tag as a SUCCESSFUL response carrying a null ref, so a
-                  # script that trusts the exit status alone declares victory while the tag is missing.
-                  null) echo "" ;;
+                  # GraphQL reports an absent tag as a SUCCESSFUL response carrying a null ref, so the
+                  # exit status says nothing about whether the tag is there.
+                  null) body='{"data":{"repository":{"ref":null}}}' ;;
                   *)    echo "gh: HTTP 502" >&2; exit 1 ;;
               esac
-              exit 0
+          else
+              body='{"data":{"repository":{"ref":{"id":"REF_kwDOabcdef"}}}}'
           fi
-          echo "REF_kwDOabcdef"
+          if [ -n "$filter" ]; then printf '%s' "$body" | jq -r "$filter"; else printf '%s' "$body"; fi
           STUB
           chmod +x "$stub/gh"
-          export PATH="$stub:$PATH" WAIT_ATTEMPTS=5 WAIT_INTERVAL=0
+          export PATH="$stub:$PATH" WAIT_ATTEMPTS=5 WAIT_INTERVAL=0 EXPECT_TAG=v1.2.3
 
           fail=0
           run() { COUNTER=$(mktemp) FAIL_TIMES=$1 bash "$S" octopusden/x v1.2.3 >/dev/null 2>&1; echo $?; }

--- a/.github/workflows/test-wait-for-tag-ref.yml
+++ b/.github/workflows/test-wait-for-tag-ref.yml
@@ -1,0 +1,50 @@
+name: Test wait-for-tag-ref script
+
+on:
+  pull_request:
+    paths:
+      - '.github/scripts/wait-for-tag-ref.sh'
+      - '.github/workflows/test-wait-for-tag-ref.yml'
+  workflow_dispatch:
+
+# Same shape as test-merge-gate-action.yml: synthetic cases with explicit assertions, no real
+# repository and no network. A stub `gh` on PATH decides how many lookups fail before one
+# succeeds, which is the only behaviour worth pinning here — the retry either survives early
+# failures or it does not.
+
+jobs:
+  test:
+    name: test wait-for-tag-ref
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run cases
+        run: |
+          set -uo pipefail
+          S=".github/scripts/wait-for-tag-ref.sh"
+          stub=$(mktemp -d)
+          cat > "$stub/gh" <<'STUB'
+          #!/usr/bin/env bash
+          n=$(( $(cat "$COUNTER" 2>/dev/null || echo 0) + 1 )); echo "$n" > "$COUNTER"
+          [ "$n" -le "${FAIL_TIMES:-0}" ] && { echo "gh: HTTP 404" >&2; exit 1; }
+          echo '{"ref":"refs/tags/v1.2.3"}'
+          STUB
+          chmod +x "$stub/gh"
+          export PATH="$stub:$PATH" WAIT_ATTEMPTS=5 WAIT_INTERVAL=0
+
+          fail=0
+          run() { COUNTER=$(mktemp) FAIL_TIMES=$1 bash "$S" octopusden/x v1.2.3 >/dev/null 2>&1; echo $?; }
+          check() {
+            if [ "$2" = "$3" ]; then echo "ok   $1"
+            else echo "::error::$1 — expected rc=$2, got rc=$3"; fail=1; fi
+          }
+
+          # Readable on the first lookup — the normal case.
+          check "visible immediately" 0 "$(run 0)"
+          # Readable only after two failures — the race this script exists for.
+          check "visible on 3rd attempt" 0 "$(run 2)"
+          # Never readable inside the budget — must fail, not hang and not pass.
+          check "never visible" 1 "$(run 99)"
+
+          exit "$fail"

--- a/.github/workflows/test-wait-for-tag-ref.yml
+++ b/.github/workflows/test-wait-for-tag-ref.yml
@@ -9,8 +9,7 @@ on:
 
 # Same shape as test-merge-gate-action.yml: synthetic cases with explicit assertions, no real
 # repository and no network. A stub `gh` on PATH decides how many lookups fail before one
-# succeeds, which is the only behaviour worth pinning here — the retry either survives early
-# failures or it does not.
+# succeeds, and rejects any lookup other than the GraphQL query `--verify-tag` itself uses.
 
 jobs:
   test:
@@ -26,9 +25,24 @@ jobs:
           stub=$(mktemp -d)
           cat > "$stub/gh" <<'STUB'
           #!/usr/bin/env bash
+          # Stands in for `gh`. Accepts ONLY the lookup that `gh release create --verify-tag` itself
+          # performs — the GraphQL repository.ref(qualifiedName:) query (cli/cli pkg/cmd/release/create/
+          # http.go, remoteTagExists). Any other lookup, the REST ref endpoint included, is rejected on
+          # every attempt: REST can answer while GraphQL is still stale, so polling it proves nothing.
+          if [ "${1:-}" != "api" ] || [ "${2:-}" != "graphql" ] || ! printf '%s\n' "$@" | grep -q 'ref(qualifiedName:'; then
+              echo "stub: refusing non-GraphQL lookup: $*" >&2; exit 1
+          fi
           n=$(( $(cat "$COUNTER" 2>/dev/null || echo 0) + 1 )); echo "$n" > "$COUNTER"
-          [ "$n" -le "${FAIL_TIMES:-0}" ] && { echo "gh: HTTP 404" >&2; exit 1; }
-          echo '{"ref":"refs/tags/v1.2.3"}'
+          if [ "$n" -le "${FAIL_TIMES:-0}" ]; then
+              case "${FAIL_MODE:-error}" in
+                  # GraphQL reports an absent tag as a SUCCESSFUL response carrying a null ref, so a
+                  # script that trusts the exit status alone declares victory while the tag is missing.
+                  null) echo "" ;;
+                  *)    echo "gh: HTTP 502" >&2; exit 1 ;;
+              esac
+              exit 0
+          fi
+          echo "REF_kwDOabcdef"
           STUB
           chmod +x "$stub/gh"
           export PATH="$stub:$PATH" WAIT_ATTEMPTS=5 WAIT_INTERVAL=0
@@ -42,9 +56,12 @@ jobs:
 
           # Readable on the first lookup — the normal case.
           check "visible immediately" 0 "$(run 0)"
-          # Readable only after two failures — the race this script exists for.
+          # Readable only after two failed lookups — the race this script exists for.
           check "visible on 3rd attempt" 0 "$(run 2)"
           # Never readable inside the budget — must fail, not hang and not pass.
           check "never visible" 1 "$(run 99)"
+          # Absent tag reported as a 200 with an empty ref: still not visible.
+          check "empty ref is not visible" 1 "$(FAIL_MODE=null run 99)"
+          check "empty ref then visible" 0 "$(FAIL_MODE=null run 2)"
 
           exit "$fail"

--- a/.github/workflows/test-wait-for-tag-ref.yml
+++ b/.github/workflows/test-wait-for-tag-ref.yml
@@ -41,6 +41,15 @@ jobs:
           printf '%s\n' "$@" | grep -qx "tagName=refs/tags/${EXPECT_TAG}" || {
               echo "stub: tagName is not refs/tags/${EXPECT_TAG}: $*" >&2; exit 1
           }
+          # ...and about the right repository. Querying the wrong owner/name returns repository:null, which
+          # `// empty` turns into "not visible" — so it fails closed rather than releasing wrongly, but it
+          # fails closed on EVERY release. Asserting the values is what makes swapping them detectable.
+          printf '%s\n' "$@" | grep -qx "owner=${EXPECT_OWNER}" || {
+              echo "stub: owner is not ${EXPECT_OWNER}: $*" >&2; exit 1
+          }
+          printf '%s\n' "$@" | grep -qx "name=${EXPECT_NAME}" || {
+              echo "stub: name is not ${EXPECT_NAME}: $*" >&2; exit 1
+          }
           # Emit a realistic response and apply the caller's own --jq filter to it, rather than emitting
           # what a correct filter would have produced. Otherwise the filter is never under test: an
           # absent tag yields the JSON below, and it is the filter's job to turn that into nothing.
@@ -60,7 +69,7 @@ jobs:
           if [ -n "$filter" ]; then printf '%s' "$body" | jq -r "$filter"; else printf '%s' "$body"; fi
           STUB
           chmod +x "$stub/gh"
-          export PATH="$stub:$PATH" WAIT_ATTEMPTS=5 WAIT_INTERVAL=0 EXPECT_TAG=v1.2.3
+          export PATH="$stub:$PATH" WAIT_ATTEMPTS=5 WAIT_INTERVAL=0 EXPECT_TAG=v1.2.3 EXPECT_OWNER=octopusden EXPECT_NAME=x
 
           fail=0
           run() { COUNTER=$(mktemp) FAIL_TIMES=$1 bash "$S" octopusden/x v1.2.3 >/dev/null 2>&1; echo $?; }
@@ -78,5 +87,15 @@ jobs:
           # Absent tag reported as a 200 with an empty ref: still not visible.
           check "empty ref is not visible" 1 "$(FAIL_MODE=null run 99)"
           check "empty ref then visible" 0 "$(FAIL_MODE=null run 2)"
+
+
+          # The wait must actually WAIT. With the sleep removed, ten attempts finish in
+          # milliseconds and the retry cannot outlast a real propagation gap — while every case
+          # above still passes, since they run with WAIT_INTERVAL=0 and carry no timing signal.
+          start=$SECONDS
+          COUNTER=$(mktemp) FAIL_TIMES=2 WAIT_INTERVAL=1 bash "$S" octopusden/x v1.2.3 >/dev/null 2>&1
+          elapsed=$((SECONDS - start))
+          if [ "$elapsed" -ge 2 ]; then echo "ok   honours the interval (waited ${elapsed}s)"
+          else echo "::error::honours the interval — waited only ${elapsed}s, expected >=2s"; fail=1; fi
 
           exit "$fail"


### PR DESCRIPTION
## Problem

`octopus-api-gateway` 2.0.19 published its artifacts, created tag `v2.0.19`, and then failed:

```
tag v2.0.19 doesn't exist
```

The tag existed afterwards, at the correct built commit. `gh release create --verify-tag`
performs its **own** lookup of the ref, and that read missed a ref created milliseconds
earlier. The result is a half-release: artifacts on the repository, tag in place, no GitHub
release — and it cannot be recovered by re-dispatching, because the version is already published.

Introduced in `dac2cf1` (#179), first shipped in **v2.6.2**: that commit split tag creation and
release creation into two API calls where they had been one, opening the window between them.

## Fix

A bounded retry (10 attempts, 2s apart) around the ref lookup, in
`.github/scripts/wait-for-tag-ref.sh`, before `gh release create` runs. Applied to both the
Gradle and the Maven release workflow.

It waits on the **same lookup `--verify-tag` itself performs** — GraphQL
`repository.ref(qualifiedName:)`, per `remoteTagExists` in cli/cli
`pkg/cmd/release/create/http.go:43`, used by both verify paths in `create.go` (:284, :312).
An earlier revision of this PR polled the REST ref endpoint; that was wrong. REST and GraphQL are
separate read paths, so REST can answer while GraphQL is still stale — precisely the staleness
that breaks the release. Caught in review.

Emptiness of the returned id decides, not the exit status: GraphQL reports an absent tag as a
**200 carrying a null ref**. A status check would have reported the tag visible on the first
attempt whether or not it existed, silently disarming the retry. `gh` makes the same distinction
internally (`Ref.ID != ""`).

`--verify-tag` is kept. Removing it as "redundant, we just created the tag" would let
`gh release create` create the tag *itself* at the default branch head whenever it cannot see
ours — publishing a release against unrelated code, the very outcome this guards.

If the ref never becomes readable, the error tells the operator what recovers it: **re-run the
failed job**, not re-dispatch the release. Re-running adopts the existing tag; re-dispatching
tries to publish a version that already exists.

## Getting the script to the runner

The `Tag and release` job has no checkout, and `GITHUB_WORKSPACE` there belongs to the *consumer*
repository, not to octopus-base — so the script is not present. It is fetched with a sparse
checkout of octopus-base pinned to `job.workflow_sha`, the same commit as the workflow calling it,
so helper and caller cannot drift. This is the mechanism this repository already uses for the
Portal publish helper; that existing fetch could not be reused, as it is gated on
`publish-to-nexus` and so is absent exactly where it is needed (api-gateway, dms-ui).

Two extra steps in a job that deliberately had none is a real cost. It buys the only thing that
makes a shell fix durable — the retry is exercised by CI, in the case that matters.

## Tests

`.github/workflows/test-wait-for-tag-ref.yml`, same shape as `test-merge-gate-action.yml`:
a stub `gh` on PATH, no network, five asserted cases.

| case | expected |
| --- | --- |
| visible on the first lookup | rc 0 |
| visible only on the 3rd attempt | rc 0 |
| never visible within the budget | rc 1 |
| absent tag reported as 200 + empty ref | rc 1 |
| empty ref, then visible | rc 0 |

The stub **rejects any lookup that is not that GraphQL query**, so a REST-based implementation
cannot pass by accident. Written before the implementation: RED 2/5 → GREEN 5/5, and the same
tests still score 2/5 against the REST revision. Also verified against the real API: existing tag
`v2.7.0` exits 0, absent `v99.99.99` exhausts its attempts and exits 1.
`.github/scripts/test-wait-for-tag-ref.local.sh` runs the identical cases locally.

## Scope: three confirmed occurrences, one still unrepaired

Corrected after review. An earlier revision of this section claimed one occurrence and wrote
dms-ui's failures off as "a different, still unexplained cause, predating this code". That was
wrong in both directions, and checking the actual run logs rather than reasoning from dates
settles it:

| when | repo / version | run | workflow ref | outcome |
| --- | --- | --- | --- | --- |
| 30 Jul | dms-ui `v3.0.11` | 30550213652 | `@v2.6.2` | `tag v3.0.11 doesn't exist` — **still a half-release today** |
| 3 Aug | api-gateway `v2.0.19` | 30815804876 | `@v2.7.0` | same signature; recovered by re-running the failed job |
| 3 Aug | dms-ui `v3.0.12` | 30815231812 | `@v2.7.0` | same signature; recovered by a re-run 4 minutes later |

`v2.6.2` does contain `dac2cf1` (`git merge-base --is-ancestor dac2cf1 v2.6.2` succeeds; v2.5.2,
v2.6.0 and v2.6.1 do not), so the 30 July run did not predate the code — it ran **on** it and
failed the same way. `dms-ui v3.0.11` remains a half-release right now: the tag is at the built
commit `7954070`, `releases/tags/v3.0.11` returns 404, and `Register release` was skipped, so that
version was never registered.

The 24 July dms-ui failure (run 30076518963) does **not** share the signature in the other
direction: `prepare-build-publish-release` failed on a plain Gradle `BUILD FAILED` and the
`Tag and release` job never ran. It is unrelated to this bug and was wrongly cited as evidence
for it.

So this is not a rare edge: two of the three occurrences are from today, in two different
repositories, on `@v2.7.0`. Every repository consuming these workflows at v2.6.2 or later is
exposed.

## Not verified

The retry budget — 10 attempts, 2s apart — is **chosen, not measured**. All three observed
failures lost the race almost immediately (api-gateway's step took 1.16s end to end; dms-ui
~1.5s from ref creation to the verify failure), and in each case a re-run minutes later saw the
tag at once. Nothing here establishes how long a genuine propagation gap can run, so 20s is a
guess informed only by the fact that the gap is evidently short. Raising it costs nothing but
runner seconds on a path that normally succeeds on the first attempt.

Release as **v2.7.1**.
